### PR TITLE
autobump: Fix autobump missing arch for golang

### DIFF
--- a/packages/golang/collection.yaml
+++ b/packages/golang/collection.yaml
@@ -5,6 +5,7 @@ packages:
     base_url: https://golang.org/dl
     hidden: true # No need to make it installable for now
     labels:
+      autobump.arch: "amd64"
       autobump.revdeps: "true"
       autobump.string_replace: '{ "prefix": "" }'
       autobump.strategy: "custom"
@@ -14,7 +15,7 @@ packages:
       autobump.version_hook: |
         curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
       package.version: "1.16.6"
-      autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-{{.Values.golang_arch}}.tar.gz.sha256"
+      autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-{{.Values.labels.autobump.arch}}.tar.gz.sha256"
       package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
   - name: "golang-fips"
     category: "build"


### PR DESCRIPTION
Unfortunately the autobump does not and should not know about our values
files for each flavor. This means that we cannot get the arch from a
central place.

This patch fixes that by adding a autobump.arch value only for the
autobumper.

Signed-off-by: Itxaka <igarcia@suse.com>