### PR TITLE
ci: Build qemu boxes in ubuntu

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -240,8 +240,11 @@
   {{{ $flavor := index . "flavor" }}}
   {{{ $subset := index . "subset" }}}
   qemu-{{{$subset}}}-{{{ $flavor }}}:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-{{{$subset}}}-{{{ $flavor }}}
+    env:
+      FLAVOR: {{{ $flavor }}}
+      ARCH: {{{ $config.arch }}}
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -250,23 +253,22 @@
           name: cOS-{{{$subset}}}-{{{ $flavor }}}-{{{ $config.arch }}}.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch={{{ $config.arch }}}
           export PKR_VAR_flavor={{{ $flavor }}}
           export PKR_VAR_feature=vagrant
-          {{{if eq $config.arch "arm64" }}}
           export PKR_VAR_accelerator=none
+          {{{if eq $config.arch "arm64" }}}
           export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=$(find /usr/local/Cellar/qemu/ -name  edk2-aarch64-code.fd -print -quit)
+          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
           PACKER_ARGS="-only qemu.cos-arm64" make packer
           {{{else}}}
-          export PKR_VAR_accelerator=hvf
           PACKER_ARGS="-only qemu.cos" make packer
           {{{- end}}}
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -126,8 +126,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-squashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-squashfs-green
+    env:
+      FLAVOR: green
+      ARCH: arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -136,11 +139,11 @@ jobs:
           name: cOS-squashfs-green-arm64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=arm64
@@ -148,7 +151,7 @@ jobs:
           export PKR_VAR_feature=vagrant
           export PKR_VAR_accelerator=none
           export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=$(find /usr/local/Cellar/qemu/ -name  edk2-aarch64-code.fd -print -quit)
+          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
           PACKER_ARGS="-only qemu.cos-arm64" make packer
       - uses: actions/upload-artifact@v2
         with:
@@ -275,8 +278,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-nonsquashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-nonsquashfs-green
+    env:
+      FLAVOR: green
+      ARCH: arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -285,11 +291,11 @@ jobs:
           name: cOS-nonsquashfs-green-arm64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=arm64
@@ -297,7 +303,7 @@ jobs:
           export PKR_VAR_feature=vagrant
           export PKR_VAR_accelerator=none
           export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=$(find /usr/local/Cellar/qemu/ -name  edk2-aarch64-code.fd -print -quit)
+          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
           PACKER_ARGS="-only qemu.cos-arm64" make packer
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -138,8 +138,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-squashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-squashfs-green
+    env:
+      FLAVOR: green
+      ARCH: x86_64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -148,17 +151,17 @@ jobs:
           name: cOS-squashfs-green-x86_64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=x86_64
           export PKR_VAR_flavor=green
           export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=hvf
+          export PKR_VAR_accelerator=none
           PACKER_ARGS="-only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
@@ -304,8 +307,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-nonsquashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-nonsquashfs-green
+    env:
+      FLAVOR: green
+      ARCH: x86_64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -314,17 +320,17 @@ jobs:
           name: cOS-nonsquashfs-green-x86_64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=x86_64
           export PKR_VAR_flavor=green
           export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=hvf
+          export PKR_VAR_accelerator=none
           PACKER_ARGS="-only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-nightly-green-x86_64.yaml
+++ b/.github/workflows/build-nightly-green-x86_64.yaml
@@ -122,8 +122,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-squashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-squashfs-green
+    env:
+      FLAVOR: green
+      ARCH: x86_64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -132,17 +135,17 @@ jobs:
           name: cOS-squashfs-green-x86_64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=x86_64
           export PKR_VAR_flavor=green
           export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=hvf
+          export PKR_VAR_accelerator=none
           PACKER_ARGS="-only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
@@ -288,8 +291,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-nonsquashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-nonsquashfs-green
+    env:
+      FLAVOR: green
+      ARCH: x86_64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -298,17 +304,17 @@ jobs:
           name: cOS-nonsquashfs-green-x86_64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=x86_64
           export PKR_VAR_flavor=green
           export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=hvf
+          export PKR_VAR_accelerator=none
           PACKER_ARGS="-only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-pr-green-arm64.yaml
+++ b/.github/workflows/build-pr-green-arm64.yaml
@@ -112,8 +112,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-squashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-squashfs-green
+    env:
+      FLAVOR: green
+      ARCH: arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -122,11 +125,11 @@ jobs:
           name: cOS-squashfs-green-arm64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=arm64
@@ -134,7 +137,7 @@ jobs:
           export PKR_VAR_feature=vagrant
           export PKR_VAR_accelerator=none
           export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=$(find /usr/local/Cellar/qemu/ -name  edk2-aarch64-code.fd -print -quit)
+          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
           PACKER_ARGS="-only qemu.cos-arm64" make packer
       - uses: actions/upload-artifact@v2
         with:
@@ -261,8 +264,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-nonsquashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-nonsquashfs-green
+    env:
+      FLAVOR: green
+      ARCH: arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -271,11 +277,11 @@ jobs:
           name: cOS-nonsquashfs-green-arm64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=arm64
@@ -283,7 +289,7 @@ jobs:
           export PKR_VAR_feature=vagrant
           export PKR_VAR_accelerator=none
           export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=$(find /usr/local/Cellar/qemu/ -name  edk2-aarch64-code.fd -print -quit)
+          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
           PACKER_ARGS="-only qemu.cos-arm64" make packer
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-pr-green-x86_64.yaml
+++ b/.github/workflows/build-pr-green-x86_64.yaml
@@ -110,8 +110,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-squashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-squashfs-green
+    env:
+      FLAVOR: green
+      ARCH: x86_64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -120,17 +123,17 @@ jobs:
           name: cOS-squashfs-green-x86_64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=x86_64
           export PKR_VAR_flavor=green
           export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=hvf
+          export PKR_VAR_accelerator=none
           PACKER_ARGS="-only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
@@ -276,8 +279,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-nonsquashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-nonsquashfs-green
+    env:
+      FLAVOR: green
+      ARCH: x86_64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -286,17 +292,17 @@ jobs:
           name: cOS-nonsquashfs-green-x86_64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=x86_64
           export PKR_VAR_flavor=green
           export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=hvf
+          export PKR_VAR_accelerator=none
           PACKER_ARGS="-only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -126,8 +126,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-squashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-squashfs-green
+    env:
+      FLAVOR: green
+      ARCH: arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -136,11 +139,11 @@ jobs:
           name: cOS-squashfs-green-arm64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=arm64
@@ -148,7 +151,7 @@ jobs:
           export PKR_VAR_feature=vagrant
           export PKR_VAR_accelerator=none
           export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=$(find /usr/local/Cellar/qemu/ -name  edk2-aarch64-code.fd -print -quit)
+          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
           PACKER_ARGS="-only qemu.cos-arm64" make packer
       - uses: actions/upload-artifact@v2
         with:
@@ -275,8 +278,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-nonsquashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-nonsquashfs-green
+    env:
+      FLAVOR: green
+      ARCH: arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -285,11 +291,11 @@ jobs:
           name: cOS-nonsquashfs-green-arm64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=arm64
@@ -297,7 +303,7 @@ jobs:
           export PKR_VAR_feature=vagrant
           export PKR_VAR_accelerator=none
           export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=$(find /usr/local/Cellar/qemu/ -name  edk2-aarch64-code.fd -print -quit)
+          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
           PACKER_ARGS="-only qemu.cos-arm64" make packer
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -138,8 +138,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-squashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-squashfs-green
+    env:
+      FLAVOR: green
+      ARCH: x86_64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -148,17 +151,17 @@ jobs:
           name: cOS-squashfs-green-x86_64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=x86_64
           export PKR_VAR_flavor=green
           export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=hvf
+          export PKR_VAR_accelerator=none
           PACKER_ARGS="-only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
@@ -304,8 +307,11 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu-nonsquashfs-green:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     needs: iso-nonsquashfs-green
+    env:
+      FLAVOR: green
+      ARCH: x86_64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -314,17 +320,17 @@ jobs:
           name: cOS-nonsquashfs-green-x86_64.iso.zip
       - name: Install deps
         run: |
-          brew install qemu
-          brew install yq
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 qemu-system qemu-efi
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
           export PKR_VAR_arch=x86_64
           export PKR_VAR_flavor=green
           export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=hvf
+          export PKR_VAR_accelerator=none
           PACKER_ARGS="-only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This allows us to free more macos instances on the CI (Max 5 at a time) for the tests, so if there is more than one job in parallel they are not blocked by this

Signed-off-by: Itxaka <igarcia@suse.com>