### PR TITLE
ci: reduce number of retry

### DIFF
--- a/.github/build.go
+++ b/.github/build.go
@@ -19,7 +19,7 @@ import (
 	"github.com/mudler/luet/pkg/tree"
 )
 
-const DefaultRetries = 120
+const DefaultRetries = 10
 
 type opData struct {
 	FinalRepo string


### PR DESCRIPTION
Now we don't list images so we don't get rate limited anymore. This also
makes the CI busy for long time in case we are dropping packages from
repositories

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>