### PR TITLE
Remove sensitive flag on aws_ami_groups

### DIFF
--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -32,7 +32,6 @@ variable "aws_region" {
 variable "aws_ami_groups" {
   type = list(string)
   default = ["all"]
-  sensitive = true
   description = "A list of groups that have access to launch the resulting AMI(s). By default no groups have permission to launch the AMI. all will make the AMI publicly accessible."
 }
 


### PR DESCRIPTION
The default value of this field is "all" which causes the string "all" to be replaced with <sensitive> in all the log messages.

Is this field really sensitive?