### PR TITLE
grub2: try to fix blue iso

### DIFF
--- a/packages/grub2/build.yaml
+++ b/packages/grub2/build.yaml
@@ -33,8 +33,10 @@ steps:
     {{if eq .Values.arch "x86_64"}}
 - grub2-mkimage -O x86_64-efi -o /EFI/BOOT/bootx64.efi -c /EFI/BOOT/grub.cfg -p /grub2 -d /usr/lib/grub/x86_64-efi {{.Values.efi_modules}}
     {{else if eq .Values.arch "aarch64"}}
-- grub2-mkimage -O arm64-efi -o /EFI/BOOT/bootaa64.efi -c /EFI/BOOT/grub.cfg -p /grub2 -d /usr/lib/grub/arm64-efi {{.Values.efi_modules_arm64}}
-    {{end}}
+- mkdir -p /EFI/fedora
+- cp -r /boot/efi/EFI/fedora/* /EFI/fedora/
+- cp -r /boot/efi/EFI/BOOT/* /EFI/BOOT/
+  {{end}}
   {{else if eq .Values.distribution "ubuntu"}}
     {{if eq .Values.arch "x86_64"}}
 - grub-mkimage -O x86_64-efi -o /EFI/BOOT/bootx64.efi -c /EFI/BOOT/grub.cfg -p /grub2 -d /usr/lib/grub/x86_64-efi {{.Values.efi_modules}} linuxefi

--- a/packages/grub2/collection.yaml
+++ b/packages/grub2/collection.yaml
@@ -13,7 +13,7 @@ packages:
         version: ">0.0.12"
   - name: "grub2-efi-image"
     category: "system"
-    version: 0.0.1-7
+    version: 0.0.1-8
     # TODO: Modules list could be refined
     efi_modules: ext2 iso9660 linux echo configfile search_label search_fs_file search search_fs_uuid ls normal gzio png fat gettext font minicmd gfxterm gfxmenu all_video xfs gcry_rijndael gcry_sha256 gcry_sha512 test true loadenv part_gpt part_msdos efi_gop efi_uga
     efi_modules_arm64: ext2 iso9660 linux echo configfile search_label search_fs_file search search_fs_uuid ls normal gzio png fat gettext font minicmd gfxterm gfxmenu all_video xfs gcry_rijndael gcry_sha256 gcry_sha512 test true loadenv part_gpt part_msdos efi_gop

--- a/values/blue-arm64.yaml
+++ b/values/blue-arm64.yaml
@@ -9,6 +9,7 @@ skip_checksum: ["golang", "golang-fips"]
 packages: >-
     grub2-efi-aa64
     grub2-efi-aa64-modules
+    shim-aa64
     NetworkManager
     squashfs-tools
     dracut-live

--- a/values/blue-x86_64.yaml
+++ b/values/blue-x86_64.yaml
@@ -8,6 +8,7 @@ packages: >-
     grub2-pc
     grub2-efi-x64
     grub2-efi-x64-modules
+    shim-x64
     NetworkManager
     squashfs-tools
     dracut-live


### PR DESCRIPTION
Seems like we have missing packages as blue doesnt need to generate the
efi file nor it needs a grub2-install but only to install the efi
packages and copy the artifacts over

Signed-off-by: Itxaka <igarcia@suse.com>