### PR TITLE
bump luet-cosing version

### DIFF
--- a/packages/toolchain/luet-cosign/definition.yaml
+++ b/packages/toolchain/luet-cosign/definition.yaml
@@ -1,6 +1,6 @@
 name: "luet-cosign"
 category: "toolchain"
-version: 0.0.5
+version: 0.0.6
 labels:
   github.repo: "luet-cosign"
   github.owner: "rancher-sandbox"


### PR DESCRIPTION
0.0.6 supports keyless signing

Signed-off-by: Itxaka <igarcia@suse.com>