### PR TITLE
Split recovery tests in individual tests

### DIFF
--- a/.github/config/master.yaml
+++ b/.github/config/master.yaml
@@ -69,7 +69,10 @@ flavors:
         skip_tests: false
         run_tests:
           squashfs:
-            - "test-recovery"
+            - "test-recovery1"
+            - "test-recovery2"
+            - "test-recovery3"
+            - "test-recovery4"
           nonsquashfs:
             - "test-smoke"
             - "test-upgrades-images-unsigned"

--- a/.github/config/pr.yaml
+++ b/.github/config/pr.yaml
@@ -72,7 +72,10 @@ flavors:
         skip_tests: false
         run_tests:
           squashfs:
-            - "test-recovery"
+            - "test-recovery1"
+            - "test-recovery2"
+            - "test-recovery3"
+            - "test-recovery4"
           nonsquashfs:
             - "test-smoke"
             - "test-upgrades-images-unsigned"

--- a/.github/config/releases.yaml
+++ b/.github/config/releases.yaml
@@ -71,7 +71,10 @@ flavors:
         skip_tests: false
         run_tests:
           squashfs:
-            - "test-recovery"
+            - "test-recovery1"
+            - "test-recovery2"
+            - "test-recovery3"
+            - "test-recovery4"
           nonsquashfs:
             - "test-smoke"
             - "test-upgrades-images-unsigned"

--- a/.github/workflows/build-master-teal-arm64.yaml
+++ b/.github/workflows/build-master-teal-arm64.yaml
@@ -319,7 +319,7 @@ jobs:
     needs: qemu-squashfs-teal
     strategy:
       matrix:
-        test: [ test-recovery ]
+        test: [ test-recovery1, test-recovery2, test-recovery3, test-recovery4 ]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-pr-teal-arm64.yaml
+++ b/.github/workflows/build-pr-teal-arm64.yaml
@@ -221,7 +221,7 @@ jobs:
     needs: qemu-squashfs-teal
     strategy:
       matrix:
-        test: [ test-recovery ]
+        test: [ test-recovery1, test-recovery2, test-recovery3, test-recovery4 ]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-teal-arm64.yaml
+++ b/.github/workflows/build-releases-teal-arm64.yaml
@@ -319,7 +319,7 @@ jobs:
     needs: qemu-squashfs-teal
     strategy:
       matrix:
-        test: [ test-recovery ]
+        test: [ test-recovery1, test-recovery2, test-recovery3, test-recovery4 ]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -96,6 +96,20 @@ test-smoke: $(GINKGO)
 test-recovery: $(GINKGO)
 	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) ./recovery
 
+# Individual test recovery for arm64 in order to run them in parallel on the CI, otherwise the full test is too long
+
+test-recovery1: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) --label-filter "first-test" ./recovery
+
+test-recovery2: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) --label-filter "second-test" ./recovery
+
+test-recovery3: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) --label-filter "third-test" ./recovery
+
+test-recovery4: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) --label-filter "fourth-test" ./recovery
+
 test-deploys-images-recovery: $(GINKGO)
 	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) --focus "From recovery" ./deploys-images
 

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -53,8 +53,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220606081226-e2271aedf37d h1:TS1yU5Fukk0GlR1CZ5Lq5YEQ5ANDoYg3oxKFhOhM3CY=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220606081226-e2271aedf37d/go.mod h1:rZj2a+V44LvtFVH/vsFXtHYIWMP1Q9aSrl6RGLbk49A=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220606083541-53f6740b36f3 h1:KUThwq0ywLLb0wPfqmpxdNFkz3ZP37vhPH/Cgzao100=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220606083541-53f6740b36f3/go.mod h1:rZj2a+V44LvtFVH/vsFXtHYIWMP1Q9aSrl6RGLbk49A=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/tests/recovery/recovery_test.go
+++ b/tests/recovery/recovery_test.go
@@ -91,9 +91,9 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 	})
 
 	// After this test, the VM is no longer in its initial state!!
-	Context("upgrading recovery", Label("third-test"), func() {
+	Context("upgrading recovery", func() {
 		When("using specific images", func() {
-			It("upgrades to a specific image and reset back to the installed version", func() {
+			It("upgrades to a specific image and reset back to the installed version", Label("third-test"), func() {
 
 				version := s.GetOSRelease("VERSION")
 				By(fmt.Sprintf("upgrading to %s:cos-recovery-%s", s.GetArtifactsRepo(), s.TestVersion))
@@ -120,8 +120,8 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 			})
 		})
 
-		When("using upgrade channel", Label("fourth-test"), func() {
-			It("upgrades to latest image", func() {
+		When("using upgrade channel", func() {
+			It("upgrades to latest image", Label("fourth-test"), func() {
 				By("upgrading recovery")
 				out, err := s.Command(s.ElementalCmd("upgrade", "--recovery"))
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/recovery/recovery_test.go
+++ b/tests/recovery/recovery_test.go
@@ -26,10 +26,16 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 	Context("upgrading COS_ACTIVE from the recovery partition", func() {
 		AfterEach(func() {
 			if !CurrentSpecReport().Failed() {
-				s.Reset()
+				// Get the label filter
+				a, _ := GinkgoConfiguration()
+				// if no label was set, we are running the whole suite, so do the reset
+				// Otherwise we are only running one test, no need to reset the vm afterwards, saves time
+				if a.LabelFilter == "" {
+					s.Reset()
+				}
 			}
 		})
-		It("upgrades to the latest", func() {
+		It("upgrades to the latest", Label("first-test"), func() {
 			currentName := s.GetOSRelease("NAME")
 
 			By("booting into recovery to check the OS version")
@@ -53,7 +59,7 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
 		})
 
-		It("upgrades to a specific image", func() {
+		It("upgrades to a specific image", Label("second-test"), func() {
 			err := s.ChangeBoot(sut.Active)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -84,8 +90,8 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 		})
 	})
 
-	// After this tests the VM is no longer in its initial state!!
-	Context("upgrading recovery", func() {
+	// After this test, the VM is no longer in its initial state!!
+	Context("upgrading recovery", Label("third-test"), func() {
 		When("using specific images", func() {
 			It("upgrades to a specific image and reset back to the installed version", func() {
 
@@ -114,7 +120,7 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 			})
 		})
 
-		When("using upgrade channel", func() {
+		When("using upgrade channel", Label("fourth-test"), func() {
 			It("upgrades to latest image", func() {
 				By("upgrading recovery")
 				out, err := s.Command(s.ElementalCmd("upgrade", "--recovery"))


### PR DESCRIPTION
Using labels so we can run them individually for arm64, as they take too
long

It also uses a bit of trickery to determine if we are running the tests
with labels, which would indicate that we are running them individually
and skips the reset part to speed them up even further.

Currently only done for arm64, x86 tests are still run on the whole
suite

Signed-off-by: Itxaka <igarcia@suse.com>