### PR TITLE
Revert "Call deps_ci after adding the build repo"

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -267,6 +267,7 @@
       ARCH: {{{ $config.arch }}}
     steps:
       {{{ tmpl.Exec "prepare_worker" }}}
+      {{{ tmpl.Exec "make" "deps_ci" }}}
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -276,7 +277,6 @@
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      {{{ tmpl.Exec "make" "deps_ci" }}}
       - name: Install deps
         run: |
           sudo apt-get update
@@ -634,6 +634,7 @@
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
       {{{- end }}}
+      {{{ tmpl.Exec "make" "deps_ci" }}}
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -643,7 +644,6 @@
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      {{{ tmpl.Exec "make" "deps_ci" }}}
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -199,6 +199,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -208,10 +212,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -197,6 +197,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -206,10 +210,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -199,6 +199,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -208,10 +212,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -197,6 +197,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -206,10 +210,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -201,6 +201,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -210,10 +214,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -197,6 +197,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -206,10 +210,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master-teal-arm64.yaml
+++ b/.github/workflows/build-master-teal-arm64.yaml
@@ -168,6 +168,10 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -177,10 +181,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Install deps
         run: |
           sudo apt-get update
@@ -677,6 +677,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -686,10 +690,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master-teal-x86_64.yaml
+++ b/.github/workflows/build-master-teal-x86_64.yaml
@@ -166,6 +166,10 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -175,10 +179,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Install deps
         run: |
           sudo apt-get update
@@ -1071,6 +1071,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -1080,10 +1084,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-nightly-teal-x86_64.yaml
+++ b/.github/workflows/build-nightly-teal-x86_64.yaml
@@ -143,6 +143,10 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -152,10 +156,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Install deps
         run: |
           sudo apt-get update

--- a/.github/workflows/build-pr-teal-arm64.yaml
+++ b/.github/workflows/build-pr-teal-arm64.yaml
@@ -126,6 +126,10 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -135,10 +139,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Install deps
         run: |
           sudo apt-get update

--- a/.github/workflows/build-pr-teal-x86_64.yaml
+++ b/.github/workflows/build-pr-teal-x86_64.yaml
@@ -129,6 +129,10 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -138,10 +142,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Install deps
         run: |
           sudo apt-get update

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -255,6 +255,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -264,10 +268,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -253,6 +253,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -262,10 +266,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -255,6 +255,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -264,10 +268,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -253,6 +253,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -262,10 +266,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -257,6 +257,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -266,10 +270,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -253,6 +253,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -262,10 +266,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-releases-teal-arm64.yaml
+++ b/.github/workflows/build-releases-teal-arm64.yaml
@@ -168,6 +168,10 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -177,10 +181,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Install deps
         run: |
           sudo apt-get update
@@ -677,6 +677,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -686,10 +690,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-releases-teal-x86_64.yaml
+++ b/.github/workflows/build-releases-teal-x86_64.yaml
@@ -166,6 +166,10 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -175,10 +179,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Install deps
         run: |
           sudo apt-get update
@@ -1071,6 +1071,10 @@ jobs:
             registry: quay.io
             username: ${{ secrets.QUAY_USERNAME }}
             password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps_ci
+        run: |
+          export DOCKER_INSTALL=true
+          sudo -E make deps_ci
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -1080,10 +1084,6 @@ jobs:
         run: |
           export DOCKER_INSTALL=true
           sudo -E make add_local_repo
-      - name: Run make deps_ci
-        run: |
-          export DOCKER_INSTALL=true
-          sudo -E make deps_ci
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
Reverts rancher/elemental-toolkit#1500

This works as long as we are building on the same arch. Once we cross arches (arm64 build, running on x86) all hell breaks loose as it will install local deps for CI from the arm64 branch :(