### PR TITLE
ci: fix error on nightly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN zypper in -y docker curl squashfs xorriso make which mtools dosfstools jq gp
 COPY . /cOS
 WORKDIR /cOS
 
-RUN make deps
+RUN git config --global --add safe.directory /cOS && \ 
+    make deps
 
 ENTRYPOINT ["/usr/bin/make"]
 CMD ["build", "local-iso"]

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -55,7 +55,7 @@ _VALIDATE_OPTIONS?=-s
 # extract packages from yaml spec
 #
 # ignore the label field as its a string
-PACKAGES?=$(shell yq '.build[],.iso[]|select(. != "COS_LIVE")|join(" ")' | sort -u)
+PACKAGES?=$(shell yq '.build[],.iso[]|select(. != "COS_LIVE")|join(" ")' $(MANIFEST) | sed -e 's/channel://g' | sort -u)
 
 ifeq ("$(PACKAGES)","")
 	BUILD_ARGS+=--all

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -52,14 +52,9 @@ endif
 _VALIDATE_OPTIONS?=-s
 
 #
-# extract packages from yaml spec
+# Luet packages
 #
-# ignore the label field as its a string
-PACKAGES?=$(shell yq '.build[],.iso[]|select(. != "COS_LIVE")|join(" ")' $(MANIFEST) | sed -e 's/channel://g' | sort -u)
-
-ifeq ("$(PACKAGES)","")
-	BUILD_ARGS+=--all
-endif
+PACKAGES?=--all
 
 ifeq ("$(PUSH_CACHE)","true")
 	BUILD_ARGS+=--push
@@ -78,7 +73,6 @@ ifneq ($(shell id -u), 0)
 	@exit 1
 endif
 	# Buildkit is necessary due to https://github.com/moby/moby/issues/37965
-	@echo "PACKAGES >$(PACKAGES)<"
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) $(LUET) build $(BUILD_ARGS) \
 	--values $(ROOT_DIR)/values/$(FLAVOR)-$(ARCH).yaml \
 	--tree=$(TREE) \


### PR DESCRIPTION
Seems like PACKAGES is not set correctly, also /cOS in Dockerfile will
be owned by another user, which logs warnings in CI.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>