### PR TITLE
Add missing cpio in build image

### DIFF
--- a/packages/firmware/build.yaml
+++ b/packages/firmware/build.yaml
@@ -13,7 +13,7 @@ image: {{.Values.tool_image}}
 {{ end }}
 
 prelude:
-- zypper in -y wget
+- zypper in -y wget cpio
 
 steps:
 {{if eq .Values.name "odroid-c2"}}

--- a/packages/firmware/collection.yaml
+++ b/packages/firmware/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "odroid-c2"
     category: "firmware"
-    version: "20170419-5.191"
+    version: "20170419-5.197"
   - name: "u-boot-rpi64"
     category: "firmware"
     version: "2021.01-5.1"


### PR DESCRIPTION
Fixes:

```
  INFO   
       #11 [ 7/10] RUN rpm2cpio raspberrypi-firmware-dt-2021.03.15-2.1.noarch.rpm | cpio -idmv
       #11 sha256:c5506e0aba5bee6d2d9c2e23f438bf643b0c35f3c5dc934a15b4c5abb5e2204d
 INFO   #11 0.256 /bin/sh: line 1: cpio: command not found
 INFO   #11 ERROR: executor failed running [/bin/sh -c rpm2cpio raspberrypi-fi
```
Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>