### PR TITLE
Set fixed tool_images

### DIFF
--- a/values/blue-arm64.yaml
+++ b/values/blue-arm64.yaml
@@ -5,7 +5,7 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
-tool_image: registry.opensuse.org/opensuse/leap:15.3@sha256:fd491438873119e95cf24f11eb727c27a8d69957497c2700ffb5b98f5a447edc
+tool_image: registry.opensuse.org/opensuse/leap:15.3.2.535@sha256:eee7bde22c0b6ad71c50f301a34ad430d1af4aeb1bdbcbd40c340048da136a97
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-arm64-efi

--- a/values/green-arm64.yaml
+++ b/values/green-arm64.yaml
@@ -5,7 +5,7 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
-tool_image: registry.opensuse.org/opensuse/leap:15.3@sha256:fd491438873119e95cf24f11eb727c27a8d69957497c2700ffb5b98f5a447edc
+tool_image: registry.opensuse.org/opensuse/leap:15.3.2.535@sha256:eee7bde22c0b6ad71c50f301a34ad430d1af4aeb1bdbcbd40c340048da136a97
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-arm64-efi

--- a/values/orange-arm64.yaml
+++ b/values/orange-arm64.yaml
@@ -5,7 +5,7 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
-tool_image: registry.opensuse.org/opensuse/leap:15.3@sha256:fd491438873119e95cf24f11eb727c27a8d69957497c2700ffb5b98f5a447edc
+tool_image: registry.opensuse.org/opensuse/leap:15.3.2.535@sha256:eee7bde22c0b6ad71c50f301a34ad430d1af4aeb1bdbcbd40c340048da136a97
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-arm64-efi

--- a/values/teal-arm64.yaml
+++ b/values/teal-arm64.yaml
@@ -7,7 +7,7 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
-tool_image: registry.opensuse.org/opensuse/leap:15.3@sha256:fd491438873119e95cf24f11eb727c27a8d69957497c2700ffb5b98f5a447edc
+tool_image: registry.opensuse.org/opensuse/leap:15.3.2.535@sha256:eee7bde22c0b6ad71c50f301a34ad430d1af4aeb1bdbcbd40c340048da136a97
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-arm64-efi


### PR DESCRIPTION
Looks like the 15.3 image is a moving target, which gets updated from
time to time and older images dropped so we cannot count on it. Instead
use a point releases which should not be dropped and should not be
updated once its released

Signed-off-by: Itxaka <igarcia@suse.com>