### PR TITLE
Set a point release image

### DIFF
--- a/values/teal-arm64.yaml
+++ b/values/teal-arm64.yaml
@@ -1,5 +1,6 @@
 
 # skopeo inspect docker://registry.suse.com/suse/sle-micro-rancher/5.2:latest --override-arch arm64 | jq '.Digest'
+
 image: registry.suse.com/suse/sle-micro-rancher/5.3@sha256:fb4b77662cd848be843a5ed76699e6117ec6d108e5eef22eea6f96c33c451671
 distribution: "opensuse"
 codename: "teal"
@@ -7,7 +8,10 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
-tool_image: registry.opensuse.org/opensuse/leap:15.4@sha256:1ae4d4d0eb2caa62224c44067bfdfb59c7635c5c0bb3281b2c779abbf4520699
+# skopeo inspect docker://registry.opensuse.org/opensuse/leap:15.4.3.471
+# make sure to point to a point release instead of 15.4 because that tag gets overwritten so our sha is no longer valid
+# the rest are untouched, so we can rely on those
+tool_image: registry.opensuse.org/opensuse/leap:15.4@sha256:7632d4d7f04a79340118db056e4db548b9ed52b7a9f9a0b2192225340b08a603
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-arm64-efi


### PR DESCRIPTION
simple version images gets replaced over time, which means that our sha
is not valid anymore for those tags.

Use a point release image instead which dont get replaced so we can use
them over time

Signed-off-by: Itxaka <igarcia@suse.com>