### PR TITLE
split pushing artifacts from signing

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -650,6 +650,7 @@
       FLAVOR: {{{ $flavor }}}
       ARCH: {{{ $config.arch }}}
       FINAL_REPO: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}
+      COSIGN_REPOSITORY: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
@@ -657,12 +658,18 @@
       LUET_INSTALL_FROM_COS_REPO: {{{ $config.luet_install_from_cos_repo }}}
       {{{- end }}}
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       {{{ tmpl.Exec "prepare_build" }}}
       {{{ tmpl.Exec "prepare_worker" }}}
       {{{- if or $config.publishing_pipeline $config.push_cache }}}
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -697,13 +704,26 @@
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          {{{ if eq $config.pipeline "release"}}}
+          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
+          {{{else}}}
+          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
+          {{{end}}}
+
+
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
+
       {{{- if $config.slack_on_failure }}}{{{tmpl.Exec "post_failed_status_slack"}}}{{{- end }}}
 {{{ end }}}
 

--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -716,13 +716,13 @@
 
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
 
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
 
       {{{- if $config.slack_on_failure }}}{{{tmpl.Exec "post_failed_status_slack"}}}{{{- end }}}
 {{{ end }}}

--- a/.github/sign.go
+++ b/.github/sign.go
@@ -98,6 +98,11 @@ func checkAndSign(tag string, ctx *types.Context) {
 	var args []string
 	tag = strings.TrimSpace(tag)
 
+	referenceID := os.Getenv("REFERENCEID")
+	if referenceID == "" {
+		referenceID = "repository.yaml"
+	}
+
 	ctx.Info("Checking artifact", tag)
 	tmpDir, _ := os.MkdirTemp("", "sign-*")
 	defer os.RemoveAll(tmpDir)
@@ -116,10 +121,18 @@ func checkAndSign(tag string, ctx *types.Context) {
 	ctx.Debug("Verify output:", string(out))
 	if err != nil {
 		ctx.Warning("Artifact", tag, "has no signature, signing it")
+
+		args = []string{
+			"sign",
+			"-y",
+			"-a", "team=elemental",
+			"-a", fmt.Sprintf("referenceID=%s", referenceID),
+		}
+
 		if fulcioFlag != "" {
-			args = []string{"sign", "-y", fulcioFlag, tag}
+			args = append(args, fulcioFlag, tag)
 		} else {
-			args = []string{"sign", "-y", tag}
+			args = append(args, tag)
 		}
 		ctx.Debug("Calling cosing with the following args:", args)
 		out, err := exec.Command("cosign", args...).CombinedOutput()

--- a/.github/workflows/build-main-blue-arm64.yaml
+++ b/.github/workflows/build-main-blue-arm64.yaml
@@ -153,12 +153,11 @@ jobs:
       FLAVOR: blue
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-blue-arm64
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-blue-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -204,6 +203,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -245,10 +252,15 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign

--- a/.github/workflows/build-main-blue-arm64.yaml
+++ b/.github/workflows/build-main-blue-arm64.yaml
@@ -258,9 +258,9 @@ jobs:
           export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign

--- a/.github/workflows/build-main-blue-x86_64.yaml
+++ b/.github/workflows/build-main-blue-x86_64.yaml
@@ -120,12 +120,11 @@ jobs:
       FLAVOR: blue
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-blue
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -147,6 +146,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -188,10 +195,15 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign

--- a/.github/workflows/build-main-blue-x86_64.yaml
+++ b/.github/workflows/build-main-blue-x86_64.yaml
@@ -201,9 +201,9 @@ jobs:
           export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign

--- a/.github/workflows/build-main-green-arm64.yaml
+++ b/.github/workflows/build-main-green-arm64.yaml
@@ -153,12 +153,11 @@ jobs:
       FLAVOR: green
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -204,6 +203,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -245,10 +252,15 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign

--- a/.github/workflows/build-main-green-arm64.yaml
+++ b/.github/workflows/build-main-green-arm64.yaml
@@ -258,9 +258,9 @@ jobs:
           export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign

--- a/.github/workflows/build-main-green-x86_64.yaml
+++ b/.github/workflows/build-main-green-x86_64.yaml
@@ -120,12 +120,11 @@ jobs:
       FLAVOR: green
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-green
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -147,6 +146,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -188,10 +195,15 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign

--- a/.github/workflows/build-main-green-x86_64.yaml
+++ b/.github/workflows/build-main-green-x86_64.yaml
@@ -201,9 +201,9 @@ jobs:
           export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign

--- a/.github/workflows/build-main-orange-arm64.yaml
+++ b/.github/workflows/build-main-orange-arm64.yaml
@@ -260,9 +260,9 @@ jobs:
           export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign

--- a/.github/workflows/build-main-orange-arm64.yaml
+++ b/.github/workflows/build-main-orange-arm64.yaml
@@ -155,12 +155,11 @@ jobs:
       FLAVOR: orange
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-orange-arm64
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-orange-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -206,6 +205,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -247,10 +254,15 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign

--- a/.github/workflows/build-main-orange-x86_64.yaml
+++ b/.github/workflows/build-main-orange-x86_64.yaml
@@ -120,12 +120,11 @@ jobs:
       FLAVOR: orange
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-orange
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -147,6 +146,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -188,10 +195,15 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign

--- a/.github/workflows/build-main-orange-x86_64.yaml
+++ b/.github/workflows/build-main-orange-x86_64.yaml
@@ -201,9 +201,9 @@ jobs:
           export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign

--- a/.github/workflows/build-main-teal-arm64.yaml
+++ b/.github/workflows/build-main-teal-arm64.yaml
@@ -657,12 +657,11 @@ jobs:
       FLAVOR: teal
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-teal-arm64
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-teal-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -708,6 +707,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -749,13 +756,18 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-main-teal-arm64.yaml
+++ b/.github/workflows/build-main-teal-arm64.yaml
@@ -762,12 +762,12 @@ jobs:
           export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-main-teal-x86_64.yaml
+++ b/.github/workflows/build-main-teal-x86_64.yaml
@@ -1004,12 +1004,11 @@ jobs:
       FLAVOR: teal
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-teal
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-teal
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -1031,6 +1030,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -1072,13 +1079,18 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-main-teal-x86_64.yaml
+++ b/.github/workflows/build-main-teal-x86_64.yaml
@@ -1085,12 +1085,12 @@ jobs:
           export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -314,12 +314,12 @@ jobs:
           export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -209,12 +209,11 @@ jobs:
       FLAVOR: blue
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-blue-arm64
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-blue-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -260,6 +259,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -301,13 +308,18 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -257,12 +257,12 @@ jobs:
           export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -176,12 +176,11 @@ jobs:
       FLAVOR: blue
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-blue
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -203,6 +202,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -244,13 +251,18 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -209,12 +209,11 @@ jobs:
       FLAVOR: green
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -260,6 +259,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -301,13 +308,18 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -314,12 +314,12 @@ jobs:
           export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -176,12 +176,11 @@ jobs:
       FLAVOR: green
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-green
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -203,6 +202,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -244,13 +251,18 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -257,12 +257,12 @@ jobs:
           export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -316,12 +316,12 @@ jobs:
           export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -211,12 +211,11 @@ jobs:
       FLAVOR: orange
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-orange-arm64
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-orange-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -262,6 +261,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -303,13 +310,18 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -176,12 +176,11 @@ jobs:
       FLAVOR: orange
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-orange
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -203,6 +202,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -244,13 +251,18 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -257,12 +257,12 @@ jobs:
           export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-teal-arm64.yaml
+++ b/.github/workflows/build-releases-teal-arm64.yaml
@@ -762,12 +762,12 @@ jobs:
           export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-teal-arm64.yaml
+++ b/.github/workflows/build-releases-teal-arm64.yaml
@@ -657,12 +657,11 @@ jobs:
       FLAVOR: teal
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-teal-arm64
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-teal-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -708,6 +707,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -749,13 +756,18 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-teal-x86_64.yaml
+++ b/.github/workflows/build-releases-teal-x86_64.yaml
@@ -1085,12 +1085,12 @@ jobs:
           export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
           # Also sign the default repository.yaml files pushed along with the snapshot id
           export REFERENCEID=repository.yaml
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-teal-x86_64.yaml
+++ b/.github/workflows/build-releases-teal-x86_64.yaml
@@ -1004,12 +1004,11 @@ jobs:
       FLAVOR: teal
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-teal
+      COSIGN_REPOSITORY: quay.io/costoolkit/releases-teal
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
       DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
-      PUBLISH_ARGS: "--plugin luet-cosign"
-      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Release space from worker ♻
         if: always()
@@ -1031,6 +1030,14 @@ jobs:
       - name: Install CI plugins
         run: |
             sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Fix cosign binary for root
+        run: |
+          cosign_bin="$HOME/.cosign/cosign"
+          sudo ln -s $cosign_bin /usr/bin/cosign
+      - name: Verify cosign for sudo
+        run: sudo -E cosign version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -1072,13 +1079,18 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - name: upload cosign logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: luetcosign.log.zip
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
+      - name: Sign artifacts
+        run: |
+          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
+          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o resign resign.go
+          popd
+          sudo -E ./.github/resign
+          # Also sign the default repository.yaml files pushed along with the snapshot id
+          export REFERENCEID=repository.yaml
+          sudo -E ./.github/resign
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/resigner.yaml
+++ b/.github/workflows/resigner.yaml
@@ -79,6 +79,6 @@ jobs:
         run: |
           export PATH=$PATH:/usr/local/go/bin
           pushd ./.github
-          go build -o resign resign.go
+          go build -o sign sign.go
           popd
-          sudo -E ./.github/resign
+          sudo -E ./.github/sign


### PR DESCRIPTION
if signing fails, we end up with no artifacts properly pushed so first
publish artifacts and then sign them

This reuses the resigner binary to sign the full tree of artifacts

Signed-off-by: Itxaka <igarcia@suse.com>