### PR TITLE
Fix signing referenceId

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -706,24 +706,10 @@
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          {{{ if eq $config.pipeline "release"}}}
-          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
-          {{{else}}}
-          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
-          {{{end}}}
-
-
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
-
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
-
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       {{{- if $config.slack_on_failure }}}{{{tmpl.Exec "post_failed_status_slack"}}}{{{- end }}}
 {{{ end }}}
 

--- a/.github/workflows/build-main-blue-arm64.yaml
+++ b/.github/workflows/build-main-blue-arm64.yaml
@@ -254,13 +254,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-blue-x86_64.yaml
+++ b/.github/workflows/build-main-blue-x86_64.yaml
@@ -197,13 +197,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-green-arm64.yaml
+++ b/.github/workflows/build-main-green-arm64.yaml
@@ -254,13 +254,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-green-x86_64.yaml
+++ b/.github/workflows/build-main-green-x86_64.yaml
@@ -197,13 +197,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-orange-arm64.yaml
+++ b/.github/workflows/build-main-orange-arm64.yaml
@@ -256,13 +256,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-orange-x86_64.yaml
+++ b/.github/workflows/build-main-orange-x86_64.yaml
@@ -197,13 +197,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-teal-arm64.yaml
+++ b/.github/workflows/build-main-teal-arm64.yaml
@@ -758,16 +758,10 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-main-teal-x86_64.yaml
+++ b/.github/workflows/build-main-teal-x86_64.yaml
@@ -1081,16 +1081,10 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git rev-parse HEAD)-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -310,16 +310,10 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -253,16 +253,10 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -310,16 +310,10 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -253,16 +253,10 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -312,16 +312,10 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -253,16 +253,10 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-teal-arm64.yaml
+++ b/.github/workflows/build-releases-teal-arm64.yaml
@@ -758,16 +758,10 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/.github/workflows/build-releases-teal-x86_64.yaml
+++ b/.github/workflows/build-releases-teal-x86_64.yaml
@@ -1081,16 +1081,10 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
-          # This exports the proper snapshot id to sign. On master its the commit and on tags is the tag
-          export REFERENCEID=$(git describe --abbrev=0 --tags )-repository.yaml
           export PATH=$PATH:/usr/local/go/bin
-          pushd ./.github
-          go build -o sign sign.go
-          popd
-          sudo -E ./.github/sign
+          sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
-          export REFERENCEID=repository.yaml
-          sudo -E ./.github/sign
+          sudo -E REFERENCEID=repository.yaml make sign_artifacts
       - name: Send failed status to slack
         if: failure()
         uses: slackapi/slack-github-action@v1.18.0

--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,13 @@ CURRENT_COMMIT ?= $(shell git rev-parse HEAD)
 # get the tag
 GIT_TAG ?= $(shell git describe --abbrev=0 --tags )
 # if both match, we are on a tag, so use that for snapshot id, otherwise use the current commit
+# also set the REFERENCEID for the signer
 ifeq ($(strip $(LAST_TAGGED_COMMIT)), $(strip $(CURRENT_COMMIT)))
 	export SNAPSHOT_ID?=$(GIT_TAG)
+	export REFERENCEID?=$(GIT_TAG)
 else
 	export SNAPSHOT_ID?=$(CURRENT_COMMIT)
+	export REFERENCEID?=$(CURRENT_COMMIT)
 endif
 
 #----------------------- end global variables -----------------------

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -127,3 +127,8 @@ validate: $(LUET)
 
 clean_build:
 	sudo rm -rf $(DESTINATION)
+
+
+sign_artifacts:
+	cd ./.github && go build -o sign sign.go
+	$(ROOT_DIR)/.github/sign


### PR DESCRIPTION
When pushing the artifacts and signing them we use 2 different apporaches to getting the current referenceID/tag/commit.

This could result in pushing one reference and using a different one for signing.

This patch fixes that by moving the signing to the makefile, as it should have been from the start, and reusing the same reference for both pushing the artifacts and signing them, so there is no possibility of mixing them up

Signed-off-by: itxaka <igarcia@suse.com>