### PR TITLE
Update documentation

### DIFF
--- a/docs/content/en/docs/Customizing/configuration_persistency.md
+++ b/docs/content/en/docs/Customizing/configuration_persistency.md
@@ -36,9 +36,6 @@ stages:
             permissions: 0644
             owner: 0
             group: 0
-          systemctl:
-            disable:
-            - wicked
         - name: "After install (second step)"
           files:
           - path: /etc/motd

--- a/docs/content/en/docs/Examples/cloud_config.md
+++ b/docs/content/en/docs/Examples/cloud_config.md
@@ -11,9 +11,9 @@ You can find here examples on how to tweak a system via cloud-config various asp
 
 The examples are meant to be placed as yaml files under `/oem` ore either `/usr/local/cloud-config`. They can be also given as input cloud-config while calling `elemental install`.
 
-## Networking with wicked
+## Networking with NetworkManager
 
-By default all interfaces will get automatically an IP address, however, there are situations where a static IP is desired, or custom configuration to be specified, here you can find some network settings with wicked.
+By default all interfaces will get automatically an IP address, however, there are situations where a static IP is desired, or custom configuration to be specified, here you can find some network settings with NetworkManager.
 
 ### Additional NIC
 
@@ -24,7 +24,7 @@ name: "Default network configuration"
 stages:
    boot:
      - commands:
-       - wicked ifup eth1
+       - nmcli dev up eth1
      - name: "Setup network"
        files:
        - path: /etc/sysconfig/network/ifcfg-eth1
@@ -45,7 +45,7 @@ name: "Default network configuration"
 stages:
    boot:
      - commands:
-       - wicked ifup eth0
+       - nmcli dev up eth0
    initramfs:
      - name: "Setup network"
        files:
@@ -65,7 +65,7 @@ name: "Default network configuration"
 stages:
    boot:
      - commands:
-       - wicked ifup eth1
+       - nmcli dev up eth1
    initramfs:
      - name: "Setup network"
        files:

--- a/docs/content/en/docs/Examples/embedded_images.md
+++ b/docs/content/en/docs/Examples/embedded_images.md
@@ -180,7 +180,7 @@ stages:
           /var/log
           /var/lib/rancher
           /var/lib/kubelet
-          /var/lib/wicked
+          /var/lib/NetworkManager
           /var/lib/longhorn
           /var/lib/cni
         PERSISTENT_STATE_BIND: "true"

--- a/docs/content/en/docs/Getting started/download.md
+++ b/docs/content/en/docs/Getting started/download.md
@@ -38,24 +38,12 @@ _Note_: `elemental install` supports other options as well. Run `elemental insta
 
 Elemental has 4 variants:
 
-- [teal](https://quay.io/repository/costoolkit/releases-teal): sle-micro-rancher based one, shipping packages from Sle Micro 5.2.
-- [green](https://quay.io/repository/costoolkit/releases-green): openSUSE based one, shipping packages from OpenSUSE Leap 15.3 repositories.
+- [teal](https://quay.io/repository/costoolkit/releases-teal): SLE Micro for Rancher based one, shipping packages from Sle Micro 5.3.
+- [green](https://quay.io/repository/costoolkit/releases-green): openSUSE based one, shipping packages from OpenSUSE Leap 15.4 repositories.
 - [blue](https://quay.io/repository/costoolkit/releases-blue): Fedora based one, shipping packages from Fedora 33 repositories
 - [orange](https://quay.io/repository/costoolkit/releases-orange): Ubuntu based one, shipping packages form Ubuntu 20.10 repositories
 
 We currently support and test only the **teal** variant.
-
-## Published AMI images
-
-We publish AMI images for each release, you can find them into ec2 for example with:
-
-```bash
-aws ec2 describe-images --filters 'Name=description,Values=cOS*'
-```
-
-The list of all the published AMI is released as part of the [releases](https://github.com/rancher/elemental-toolkit/releases) assets with the `ami_id.txt.tar.xz` file, e.g. [v0.6.7](https://github.com/rancher/elemental-toolkit/releases/download/v0.6.7/ami_id.txt.tar.xz)
-
-The AMI Owner ID is `053594193760`.
 
 ## What to do next?
 

--- a/docs/content/en/docs/Reference/selinux.md
+++ b/docs/content/en/docs/Reference/selinux.md
@@ -38,7 +38,7 @@ version: 0.0.1
 ```
 
 
-Example mypolicy.te (generated with `audit2alllow`)
+Example mypolicy.te (generated with `audit2allow`)
 ```
 #==== Elemental SELinux targeted policy module ========
 #
@@ -58,7 +58,7 @@ require {
 	type initrc_t;
 	type bin_t;
 	type tmpfs_t;
-	type wicked_t;
+	type NetworkManager_t;
 	type systemd_logind_t;
 	type sshd_t;
 	type lib_t;
@@ -116,8 +116,8 @@ allow unconfined_service_t bin_t:file execmod;
 #!!!! This avc can be allowed using the boolean 'selinuxuser_execmod'
 allow unconfined_t bin_t:file execmod;
 
-#============= wicked_t ==============
-allow wicked_t tmpfs_t:dir read;
-allow wicked_t tmpfs_t:file { getattr open read };
-allow wicked_t tmpfs_t:lnk_file read;
+#============= NetworkManager_t ==============
+allow NetworkManager_t tmpfs_t:dir read;
+allow NetworkManager_t tmpfs_t:file { getattr open read };
+allow NetworkManager_t tmpfs_t:lnk_file read;
 ```

--- a/packages/cloud-config/README.md
+++ b/packages/cloud-config/README.md
@@ -1,4 +1,4 @@
 
 Several default cloud config are present in the cOS repositories. They can be all pulled with the `system/cloud-config` package or individually ( `cloud-config/<package>` ).
 
-Each one of them bring a separate functionality or extend the system. For example, the `networking` cloud-config provides a basic networking setting for `wicked`, or `cloud-config/rootfs` provides a basic cOS default rootfs layout configuration.
+Each one of them bring a separate functionality or extend the system. For example, the `networking` cloud-config provides a basic networking setting, or `cloud-config/rootfs` provides a basic cOS default rootfs layout configuration.


### PR DESCRIPTION
Update docs to use NetworkManager and `nmcli` instead of `wicked`

Also remove mentions of AMI:s in releases since those are dropped in #1619 

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>