### PR TITLE
Fixes cos-setup systemd unit paths

### DIFF
--- a/packages/cos-setup/02-cos-setup-initramfs.conf
+++ b/packages/cos-setup/02-cos-setup-initramfs.conf
@@ -1,4 +1,4 @@
-install_items+=" /lib/systemd/system/cos-setup-initramfs.service /etc/systemd/system/initrd.target.requires/cos-setup-initramfs.service "
-install_items+=" /lib/systemd/system/cos-setup-rootfs.service /etc/systemd/system/initrd-fs.target.requires/cos-setup-rootfs.service "
+install_items+=" /usr/lib/systemd/system/cos-setup-initramfs.service /etc/systemd/system/initrd.target.requires/cos-setup-initramfs.service "
+install_items+=" /usr/lib/systemd/system/cos-setup-rootfs.service /etc/systemd/system/initrd-fs.target.requires/cos-setup-rootfs.service "
 install_items+=" /etc/hosts "
 add_dracutmodules+=" network "

--- a/packages/cos-setup/build.yaml
+++ b/packages/cos-setup/build.yaml
@@ -3,11 +3,11 @@ requires:
   category: "distro"
   version: ">=0"
 steps:
-- mkdir -p /lib/systemd/system
+- mkdir -p /usr/lib/systemd/system
 - mkdir -p /etc/dracut.conf.d
 - cp 02-cos-setup-initramfs.conf /etc/dracut.conf.d
-- cp -rfv *.service /lib/systemd/system
-- cp -rfv *.timer /lib/systemd/system
+- cp -rfv *.service /usr/lib/systemd/system
+- cp -rfv *.timer /usr/lib/systemd/system
 - systemctl enable cos-setup-rootfs.service
 - systemctl enable cos-setup-initramfs.service
 - systemctl enable cos-setup-reconcile.timer

--- a/packages/cos-setup/definition.yaml
+++ b/packages/cos-setup/definition.yaml
@@ -1,3 +1,3 @@
 name: cos-setup
 category: system
-version: 0.6.3-7
+version: 0.6.4

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.9.4
+    version: 0.9.5
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
+++ b/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
@@ -22,7 +22,6 @@ install() {
     declare moddir=${moddir}
     declare systemdutildir=${systemdutildir}
     declare systemdsystemunitdir=${systemdsystemunitdir}
-    declare initdir="${initdir}"
 
     inst_multiple \
         mount mountpoint sort rmdir findmnt rsync cut

--- a/packages/immutable-rootfs/definition.yaml
+++ b/packages/immutable-rootfs/definition.yaml
@@ -1,6 +1,6 @@
 name: "immutable-rootfs"
 category: "system"
-version: "0.8"
+version: "0.8.1"
 requires:
   - name: "cos-setup"
     category: "system"

--- a/packages/initrd/definition.yaml
+++ b/packages/initrd/definition.yaml
@@ -1,4 +1,4 @@
 name: "dracut-initrd"
 category: "system"
-version: 0.4.1-2
+version: 0.4.1-3
 description: "Dracut-based generated initrd"


### PR DESCRIPTION
`/lib/systemd/system` is not the path used for most major distributions. In fact Fedora and Ubuntu ship their `/lib` as a symlink to `/usr/lib`, hence the real path is `/usr/lib/systemd/system`. In openSUSE Leap there is no such link and both exist `/usr/lib/` and `/lib`, being `/usr/lib` the default path for systemd. This also applies for Teal.

From systemd PoV `/lib/system/systemd` is a valid path, this why elemental-toolkit does not break. However I believe that if Ubuntu, Fedora and openSUSE they all use a different and equal path, we should use that.

Signed-off-by: David Cassany <dcassany@suse.com>