### PR TITLE
Bump yip and separate it into its own package

### DIFF
--- a/packages/toolchain/collection.yaml
+++ b/packages/toolchain/collection.yaml
@@ -45,21 +45,3 @@ packages:
     requires:
       - !!merge <<: *luet-fips
         version: "<1.0.0"
-  - category: "toolchain-fips"
-    name: "yip"
-    upx: false
-    fips: true
-    version: 0.11.0-1
-    labels:
-      github.repo: "yip"
-      github.owner: "mudler"
-      autobump.revdeps: "true"
-  - category: "toolchain"
-    name: "yip"
-    upx: false
-    fips: false
-    version: 0.11.0-1
-    labels:
-      github.repo: "yip"
-      github.owner: "mudler"
-      autobump.revdeps: "true"

--- a/packages/toolchain/yip/build.yaml
+++ b/packages/toolchain/yip/build.yaml
@@ -1,0 +1,32 @@
+requires:
+  - name: "golang{{- if .Values.fips -}}-fips{{- end -}}"
+    category: "build"
+    version: ">=0"
+env:
+{{ template "golang_env" }}
+{{if .Values.fips}}
+- CGO_ENABLED=1
+{{ else }}
+- CGO_ENABLED=0
+- LDFLAGS="-s -w"
+{{ end }}
+
+prelude:
+{{ template "golang_deps" .}}
+{{ $opts:= dict "version" (printf "v%s" .Values.version) "org" ( index .Values.labels "github.owner" ) "repo" ( index .Values.labels "github.repo" ) }}
+{{ template "golang_download_package" $opts}}
+steps:
+- |
+    PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && \
+    cd /luetbuild/go/src/github.com/{{ ( index .Values.labels "github.owner" ) }}/{{.Values.name}} && \
+    buildtime=$(date -u '+%Y-%m-%d %I:%M:%S %Z') && \
+    buildcommit=$(git rev-parse HEAD) && \
+    go build -ldflags "$LDFLAGS -X \"github.com/{{ ( index .Values.labels "github.owner" ) }}/{{.Values.name}}/cmd.BuildTime=$buildtime\" -X \"github.com/{{ ( index .Values.labels "github.owner" ) }}/{{.Values.name}}/cmd.BuildCommit=$buildcommit\"" && \
+    mv {{.Values.name}} /usr/bin/{{.Values.name}}
+{{ if .Values.fips }}
+# Check that we build with fips
+- go tool nm /usr/bin/{{.Values.name}} | grep '_Cfunc__goboringcrypto_' 1> /dev/null
+{{ end }}
+
+includes:
+  - /usr/bin/{{.Values.name}}

--- a/packages/toolchain/yip/collection.yaml
+++ b/packages/toolchain/yip/collection.yaml
@@ -1,0 +1,19 @@
+packages:
+  - category: "toolchain-fips"
+    name: "yip"
+    upx: false
+    fips: true
+    version: 0.11.3
+    labels:
+      github.repo: "yip"
+      github.owner: "mudler"
+      autobump.revdeps: "true"
+  - category: "toolchain"
+    name: "yip"
+    upx: false
+    fips: false
+    version: 0.11.3
+    labels:
+      github.repo: "yip"
+      github.owner: "mudler"
+      autobump.revdeps: "true"


### PR DESCRIPTION
Versioning has changed upstream to include a v in front of the version, so its no longer possible to have it on the same template as the others

Signed-off-by: Itxaka <igarcia@suse.com>