### PR TITLE
Set serial baudrate to 115200

### DIFF
--- a/packages/livecd/grub2/config/grub_live.cfg
+++ b/packages/livecd/grub2/config/grub_live.cfg
@@ -21,7 +21,7 @@ if [ -f ${font} ];then
 fi
 menuentry "cOS" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0,115200 rd.cos.disable
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }


### PR DESCRIPTION
This is the standard rate on Raspberry Pi.

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>