### PR TITLE
Split sign into build and run

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -622,6 +622,7 @@
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-blue-arm64.yaml
+++ b/.github/workflows/build-main-blue-arm64.yaml
@@ -230,6 +230,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-blue-x86_64.yaml
+++ b/.github/workflows/build-main-blue-x86_64.yaml
@@ -248,6 +248,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-green-arm64.yaml
+++ b/.github/workflows/build-main-green-arm64.yaml
@@ -230,6 +230,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-green-x86_64.yaml
+++ b/.github/workflows/build-main-green-x86_64.yaml
@@ -248,6 +248,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-orange-arm64.yaml
+++ b/.github/workflows/build-main-orange-arm64.yaml
@@ -232,6 +232,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-orange-x86_64.yaml
+++ b/.github/workflows/build-main-orange-x86_64.yaml
@@ -248,6 +248,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-teal-arm64.yaml
+++ b/.github/workflows/build-main-teal-arm64.yaml
@@ -778,6 +778,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-main-teal-x86_64.yaml
+++ b/.github/workflows/build-main-teal-x86_64.yaml
@@ -931,6 +931,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -286,6 +286,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -304,6 +304,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -286,6 +286,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -304,6 +304,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -288,6 +288,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -304,6 +304,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-releases-teal-arm64.yaml
+++ b/.github/workflows/build-releases-teal-arm64.yaml
@@ -778,6 +778,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/.github/workflows/build-releases-teal-x86_64.yaml
+++ b/.github/workflows/build-releases-teal-x86_64.yaml
@@ -931,6 +931,7 @@ jobs:
           sudo -E make publish-repo
       - name: Sign artifacts
         run: |
+          make build_signer
           sudo -E make sign_artifacts
           # Also sign the default repository.yaml files pushed along with the snapshot id
           sudo -E REFERENCEID=repository.yaml make sign_artifacts

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -129,6 +129,15 @@ clean_build:
 	sudo rm -rf $(DESTINATION)
 
 
-sign_artifacts:
+build_signer:
 	cd ./.github && go build -o sign sign.go
+
+# sign artifacts requires root privs as we use luet installer to get the remote repository metadata and list of artifacts
+# that downloads stuff under /tmp and tries to chown it, which fails unless you are root, probably the original metadata has
+# the root owner so only root chan chown it.
+sign_artifacts:
+ifneq ($(shell id -u), 0)
+	@echo "Please run 'make $@' as root"
+	@exit 1
+endif
 	$(ROOT_DIR)/.github/sign


### PR DESCRIPTION
Build the signer without root privs so it works on any runner that installs go as the current user.

Also run the signer as root in a different target so we can build it once without privs and then run the binary with root as its needed due to luet chowning files

Signed-off-by: Itxaka <igarcia@suse.com>