### PR TITLE
Remove after-install from upgrade-grub-hooks

### DIFF
--- a/.obs/specfile/elemental-toolkit.spec
+++ b/.obs/specfile/elemental-toolkit.spec
@@ -65,7 +65,6 @@ Requires:       elemental-init-recovery = %{version}-%{release}
 Requires:       elemental-init-live = %{version}-%{release}
 Requires:       elemental-init-boot-assessment = %{version}-%{release}
 Requires:       elemental-init-services = %{version}-%{release}
-Requires:       elemental-upgrade-hooks = %{version}-%{release}
 
 %description -n elemental-init-config
 Provides Elemental default initialization configuration files

--- a/packages/cloud-config/oem/01_upgrade_grub_hook.yaml
+++ b/packages/cloud-config/oem/01_upgrade_grub_hook.yaml
@@ -7,9 +7,19 @@
 # copy the file with a prefix starting by 90, e.g. /oem/91_custom.yaml
 name: "Adapt grub2 configuration on updates"
 stages:
-  after-install:
+  after-upgrade-chroot:
+    - &installhook
+      name: "Install grub updater in OEM"
+      commands:
+      - |
+        hook="/system/oem/01_upgrade_grub_hook.yaml"
+
+        if mountpoint -q /oem; then
+          [ -f "${hook}" ] || exit 0
+          cp "${hook}" /oem
+        fi
+  after-upgrade:
     - &grubenv
-      # TODO this should be part of the elemental install command
       name: "Set grub env variables"
       commands:
       - |
@@ -24,20 +34,6 @@ stages:
         grub2-editenv ${statemnt}/grub_oem_env set recovery_label=COS_RECOVERY
         grub2-editenv ${statemnt}/grub_oem_env set system_label=COS_SYSTEM
         grub2-editenv ${statemnt}/grub_oem_env set oem_label=COS_OEM
-  after-upgrade-chroot:
-    - &installhook
-      name: "Install grub updater in OEM"
-      commands:
-      - |
-        hook="/system/oem/01_upgrade_grub_hook.yaml"
-
-        if mountpoint -q /oem; then
-          [ -f "${hook}" ] || exit 0
-          cp "${hook}" /oem
-        fi
-  after-upgrade:
-    # TODO labels should be parsed from state.yaml
-    - <<: *grubenv
   after-upgrade.after:
     - &uninstallhook
       if: '[ -f "/oem/01_upgrade_grub_hook.yaml" ]'
@@ -48,7 +44,6 @@ stages:
   after-reset-chroot:
     - <<: *installhook
   after-reset:
-    # TODO labels should be parsed from state.yaml
     - <<: *grubenv
   after-reset.after:
     - <<: *uninstallhook

--- a/packages/toolchain/elemental-cli/collection.yaml
+++ b/packages/toolchain/elemental-cli/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &elemental
     name: "elemental-cli"
     category: "toolchain"
-    version: "0.20230117"
+    version: "0.20230127"
     bin_name: "elemental"
     fips: false
     labels:
@@ -11,7 +11,7 @@ packages:
       autobump.revdeps: "true"
       autobump.strategy: "git_hash"
       autobump.git.branch: "main"
-      git.hash: "7b348b51342c9041741145d1426951336836c757"
+      git.hash: "19a9832efe6cc5411f76f97204543700a7d45ea6"
 # - !!merge <<: *elemental
 #   category: "toolchain-fips"
 #   fips: true


### PR DESCRIPTION
The labels are now set during install/upgrade/reset by elemental-cli in rancher/elemental-cli#414.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>