### PR TITLE
Fix immutable rootfs setup

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.10.0-12
+    version: 0.10.0-14
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/immutable-rootfs/30cos-immutable-rootfs/cos-mount-layout.sh
+++ b/packages/immutable-rootfs/30cos-immutable-rootfs/cos-mount-layout.sh
@@ -7,6 +7,7 @@
 
 function getOverlayMountpoints {
     local mountpoints
+    local path
 
     for path in "${rw_paths[@]}"; do
         if ! hasMountpoint "${path}" "${cos_mounts[@]}"; then
@@ -19,6 +20,7 @@ function getOverlayMountpoints {
 function getStateMountpoints {
     local mountpoints=$1
     local state_mounts
+    local path
 
     for path in "${state_paths[@]}"; do
         if ! hasMountpoint "${path}" "${mountpoints}"; then
@@ -32,6 +34,7 @@ function hasMountpoint {
     local path=$1
     shift
     local mounts=("$@")
+    local mount
     
     for mount in "${mounts[@]}"; do
         if [ "${path}" = "${mount#*:}" ]; then
@@ -70,6 +73,7 @@ function parseCOSMount {
 }
 
 function readCOSLayoutConfig {
+    local mount
     local mounts=()
     : "${MERGE:=true}"
 
@@ -117,6 +121,7 @@ function readCOSLayoutConfig {
 }
 
 function getCOSMounts {
+    local mount
     local mounts
 
     for mount in "${cos_mounts[@]}"; do
@@ -232,6 +237,7 @@ declare fstab
 declare state_paths
 declare state_bind
 declare state_target
+declare mount
 
 readCOSLayoutConfig
 

--- a/packages/immutable-rootfs/definition.yaml
+++ b/packages/immutable-rootfs/definition.yaml
@@ -1,6 +1,6 @@
 name: "immutable-rootfs"
 category: "system"
-version: 0.8.4-1
+version: 0.8.5
 requires:
   - name: "cos-setup"
     category: "system"

--- a/packages/initrd/definition.yaml
+++ b/packages/initrd/definition.yaml
@@ -1,4 +1,4 @@
 name: "dracut-initrd"
 category: "system"
-version: 0.4.3-2
+version: 0.4.3-3
 description: "Dracut-based generated initrd"


### PR DESCRIPTION
This commit ensures variables defined in loops are also declared as local in each function. Otherwise some variables are crossing from one method to another.

The issue poped up adding multiple device mountpoints within the kernel command line.

Signed-off-by: David Cassany <dcassany@suse.com>