### PR TITLE
fix network stage execution constraints

### DIFF
--- a/packages/cos-setup/cos-setup-network.service
+++ b/packages/cos-setup/cos-setup-network.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=cOS setup after network
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Nice=19

--- a/packages/cos-setup/definition.yaml
+++ b/packages/cos-setup/definition.yaml
@@ -1,3 +1,3 @@
 name: cos-setup
 category: system
-version: 0.6.4-6
+version: 0.6.5

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.10.1
+    version: 0.10.1-1
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:


### PR DESCRIPTION
This makes sure the network stage is actually executed when `network-online.target` is either in failed or succeeded status, but not before.