### PR TITLE
Fix bootargs.cfg

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.10.1-1
+    version: 0.10.1-2
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/grub2/collection.yaml
+++ b/packages/grub2/collection.yaml
@@ -7,7 +7,7 @@ packages:
         version: ">0.0.2"
   - name: "grub2-config"
     category: "system"
-    version: 0.1.0-4
+    version: 0.1.0-5
     provides:
       - name: "grub-config"
         version: ">0.0.12"

--- a/packages/grub2/config/bootargs.cfg
+++ b/packages/grub2/config/bootargs.cfg
@@ -1,6 +1,6 @@
 # TODO we could sanity check $partlabel is set here so we can error out before even attempting to boot
 set kernel=/boot/vmlinuz
-if [ ${label} == ${system_label} ]; then
+if [ "${label}" == "${system_label}" ]; then
   set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$recovery_label cos-img/filename=$img security=selinux selinux=0 rd.neednet=1 rd.cos.oemlabel=$oem_label"
 else
   set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$state_label cos-img/filename=$img panic=5 security=selinux selinux=1 rd.neednet=1 rd.cos.oemlabel=$oem_label fsck.mode=force fsck.repair=yes"


### PR DESCRIPTION
This commit ensures empty variables are evaluated as empty strings, as it was noted unquoted variables in conditional tests were not evaluated as empty strings leading to weird behavior on special corner cases.