### PR TITLE
Refactor grub.cfg

### DIFF
--- a/packages/cloud-config/collection.yaml
+++ b/packages/cloud-config/collection.yaml
@@ -4,7 +4,7 @@ packages:
     oem_file: "00_rootfs.yaml"
     oem_dir: "/system/oem"
     category: cloud-config
-    version: 0.4.2-9
+    version: 0.4.2-10
     requires:
       - name: "cos-setup"
         category: "system"

--- a/packages/cloud-config/oem/08_boot_assessment.yaml
+++ b/packages/cloud-config/oem/08_boot_assessment.yaml
@@ -78,10 +78,9 @@ stages:
          permsisions: 0600
          content: |
             set extra_active_cmdline="rd.emergency=reboot rd.shell=0 panic=5 systemd.crash_reboot systemd.crash_shell=0"
-            set boot_assessment="/boot_assessment"
-            search --no-floppy --file --set=boot_assessment_blk "${boot_assessment}"
-            if [ "${boot_assessment_blk}" ]; then
-              load_env -f "(${boot_assessment_blk})${boot_assessment}"
+            set boot_assessment_file="/boot_assessment"
+            if [ -f "${boot_assessment_file}" ]; then
+              load_env -f "${boot_assessment_file}"
             fi
             if [ "${enable_boot_assessment}" = "yes" -o "${enable_boot_assessment_always}" = "yes" ]; then
               if [ -z "${selected_entry}" ]; then
@@ -90,7 +89,7 @@ stages:
                   set extra_passive_cmdline="upgrade_failure"
                 else
                   set boot_assessment_tentative="yes"
-                  save_env -f "(${boot_assessment_blk})${boot_assessment}" boot_assessment_tentative
+                  save_env -f "${boot_assessment_file}" boot_assessment_tentative
                 fi
               fi
             fi

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.10.3
+    version: 0.10.4
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/grub2/collection.yaml
+++ b/packages/grub2/collection.yaml
@@ -7,7 +7,7 @@ packages:
         version: ">0.0.2"
   - name: "grub2-config"
     category: "system"
-    version: 0.1.2
+    version: 0.1.3
     provides:
       - name: "grub-config"
         version: ">0.0.12"

--- a/packages/grub2/config/grub.cfg
+++ b/packages/grub2/config/grub.cfg
@@ -19,7 +19,7 @@ if [ "${next_entry}" ]; then
   set default="${next_entry}"
   set selected_entry="${next_entry}"
   set next_entry=
-  save_env -f "${env_file}" next_entry
+  save_env -f "(${oem_blk})${env_file}" next_entry
 else
   set default="${saved_entry}"
 fi

--- a/packages/grub2/config/grub.cfg
+++ b/packages/grub2/config/grub.cfg
@@ -1,35 +1,18 @@
 set timeout=10
 
-# Load custom env file
 set env_file="/grubenv"
-search --no-floppy --file --set=env_blk "${env_file}"
-
-# Load custom env file
 set oem_env_file="/grub_oem_env"
-search --no-floppy --file --set=oem_blk "${oem_env_file}"
+set custom_file="/grubcustom"
 
-# Load custom config file
-set custom_menu="/grubmenu"
-search --no-floppy --file --set=menu_blk "${custom_menu}"
-
-# Load custom config file
-set custom="/grubcustom"
-search --no-floppy --file --set=custom_blk "${custom}"
-
-if [ "${oem_blk}" ] ; then
-  load_env -f "(${oem_blk})${oem_env_file}"
-fi
-
-if [ "${env_blk}" ] ; then
-  load_env -f "(${env_blk})${env_file}"
-fi
+load_env -f "${oem_env_file}"
+load_env -f "${env_file}"
 
 # Save default
 if [ "${next_entry}" ]; then
   set default="${next_entry}"
   set selected_entry="${next_entry}"
   set next_entry=
-  save_env -f "(${env_blk})${env_file}" next_entry
+  save_env -f "${env_file}" next_entry
 else
   set default="${saved_entry}"
 fi
@@ -88,10 +71,6 @@ menuentry "${display_name} recovery" --id recovery {
   initrd (loop0)$initramfs
 }
 
-if [ "${menu_blk}" ]; then
-  source "(${menu_blk})${custom_menu}"
-fi
-
-if [ "${custom_blk}" ]; then
-  source "(${custom_blk})${custom}"
+if [ -f "${custom_file}" ]; then
+  source "${custom_file}"
 fi

--- a/packages/grub2/config/grub.cfg
+++ b/packages/grub2/config/grub.cfg
@@ -4,8 +4,13 @@ set env_file="/grubenv"
 set oem_env_file="/grub_oem_env"
 set custom_file="/grubcustom"
 
-load_env -f "${oem_env_file}"
-load_env -f "${env_file}"
+if [ -f "${env_file}" ]; then
+  load_env -f "${env_file}"
+fi
+
+if [ -f "${oem_env_file}" ]; then
+  load_env -f "${oem_env_file}"
+fi
 
 # Save default
 if [ "${next_entry}" ]; then

--- a/packages/grub2/config/grub.cfg
+++ b/packages/grub2/config/grub.cfg
@@ -4,12 +4,14 @@ set env_file="/grubenv"
 set oem_env_file="/grub_oem_env"
 set custom_file="/grubcustom"
 
-if [ -f "${env_file}" ]; then
-  load_env -f "${env_file}"
-fi
-
 if [ -f "${oem_env_file}" ]; then
   load_env -f "${oem_env_file}"
+fi
+
+search --no-floppy --set oem_blk --label "${oem_label}"
+
+if [ -f "(${oem_blk})${env_file}" ]; then
+  load_env -f "(${oem_blk})${env_file}"
 fi
 
 # Save default

--- a/tests/fallback/fallback_test.go
+++ b/tests/fallback/fallback_test.go
@@ -32,7 +32,7 @@ var _ = Describe("cOS booting fallback tests", func() {
 		Expect(out).To(ContainSubstring("bootfile_loc"))
 
 		out, _ = s.Command("sudo cat /run/initramfs/cos-state/grub_boot_assessment")
-		Expect(out).To(ContainSubstring("boot_assessment_blk"))
+		Expect(out).To(ContainSubstring("boot_assessment_file"))
 
 		cmdline, _ := s.Command("sudo cat /proc/cmdline")
 		Expect(cmdline).To(ContainSubstring("rd.emergency=reboot rd.shell=0 panic=5"))


### PR DESCRIPTION
Remove search commands in order to speed up boot. Search can in some cases be very slow and should be used sparingly.

This means we will only have grub-config files on state partition (instead of searching on any device).

Also removes the grubmenu file from loading since it's used in the same way as grubcustom.