### PR TITLE
Fail on errors while mounting for the immutable layout

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.10.5
+    version: 0.10.6
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/immutable-rootfs/30cos-immutable-rootfs/cos-generator.sh
+++ b/packages/immutable-rootfs/30cos-immutable-rootfs/cos-generator.sh
@@ -37,6 +37,8 @@ if [ -n "${oem_label}" ]; then
         echo "[Unit]"
         echo "DefaultDependencies=no"
         echo "Before=cos-setup-rootfs.service"
+        echo "After=dracut-initqueue.service"
+        echo "Wants=dracut-initqueue.service"
         echo "Conflicts=initrd-switch-root.target"
         echo "[Mount]"
         echo "Where=/oem"

--- a/packages/immutable-rootfs/definition.yaml
+++ b/packages/immutable-rootfs/definition.yaml
@@ -1,6 +1,6 @@
 name: "immutable-rootfs"
 category: "system"
-version: 0.8.7
+version: 0.8.8
 requires:
   - name: "cos-setup"
     category: "system"

--- a/packages/initrd/definition.yaml
+++ b/packages/initrd/definition.yaml
@@ -1,4 +1,4 @@
 name: "dracut-initrd"
 category: "system"
-version: 0.4.4
+version: 0.4.5
 description: "Dracut-based generated initrd"


### PR DESCRIPTION
This PR causes the cos-mout-layout.sh to explicitly exit with an error in case some mountpoint can't be properly prepared.

related with rancher/elemental#732