### PR TITLE
grub: Delete loopback device on fallback

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.10.6
+    version: 0.10.7
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/grub2/collection.yaml
+++ b/packages/grub2/collection.yaml
@@ -7,7 +7,7 @@ packages:
         version: ">0.0.2"
   - name: "grub2-config"
     category: "system"
-    version: 0.1.3
+    version: 0.1.4
     provides:
       - name: "grub-config"
         version: ">0.0.12"

--- a/packages/grub2/config/grub.cfg
+++ b/packages/grub2/config/grub.cfg
@@ -43,24 +43,30 @@ insmod gfxterm
 insmod loopback
 insmod squash4
 
+set loopdev="loop0"
+
 menuentry "${display_name}" --id cos {
   # label is kept around for backward compatibility
   set label=${active_label}
   set img=/cOS/active.img
-  loopback loop0 /$img
-  source (loop0)/etc/cos/bootargs.cfg
-  linux (loop0)$kernel $kernelcmd ${extra_cmdline} ${extra_active_cmdline}
-  initrd (loop0)$initramfs
+  loopback $loopdev /$img
+  source ($loopdev)/etc/cos/bootargs.cfg
+  linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_active_cmdline}
+  initrd ($loopdev)$initramfs
 }
 
 menuentry "${display_name} (fallback)" --id fallback {
   # label is kept around for backward compatibility
   set label=${passive_label}
   set img=/cOS/passive.img
-  loopback loop0 /$img
-  source (loop0)/etc/cos/bootargs.cfg
-  linux (loop0)$kernel $kernelcmd ${extra_cmdline} ${extra_passive_cmdline}
-  initrd (loop0)$initramfs
+  # if loopdev already exists, we've probably already tried booting once, delete it and try again.
+  if [ -e ($loopdev) ]; then
+    loopback -d $loopdev
+  fi
+  loopback $loopdev /$img
+  source ($loopdev)/etc/cos/bootargs.cfg
+  linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_passive_cmdline}
+  initrd ($loopdev)$initramfs
 }
 
 menuentry "${display_name} recovery" --id recovery {
@@ -72,10 +78,14 @@ menuentry "${display_name} recovery" --id recovery {
   fi
   set img=/cOS/recovery.img
   search --no-floppy --label --set=root $recovery_label
-  loopback loop0 /$img
-  source (loop0)/etc/cos/bootargs.cfg
-  linux (loop0)$kernel $kernelcmd ${extra_cmdline} ${extra_recovery_cmdline}
-  initrd (loop0)$initramfs
+  # if loopdev already exists, we've probably already tried booting once, delete it and try again.
+  if [ -e ($loopdev) ]; then
+    loopback -d $loopdev
+  fi
+  loopback $loopdev /$img
+  source ($loopdev)/etc/cos/bootargs.cfg
+  linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_recovery_cmdline}
+  initrd ($loopdev)$initramfs
 }
 
 if [ -f "${custom_file}" ]; then


### PR DESCRIPTION
During boot if the active menu-entry fails the fallback will also fail with the error-message "device already exists".

This commit ensures we delete the loopback-device if it exists before booting to fallback or recovery.

Part of https://github.com/rancher/elemental/issues/708