### PR TITLE
Ghcr release

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -1,38 +1,37 @@
 name: Build CLI
 on:
-    pull_request:
-    push:
-        branches:
-            - main
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v3.1.0
-            - name: Install Go
-              uses: actions/setup-go@v3.3.1
-              with:
-                go-version-file: go.mod
-            - name: Analysis
-              uses: golangci/golangci-lint-action@v3
-              with:
-                args: -v
-            - name: Build
-              run: make build-cli
-            - name: Deps
-              run: make test-deps
-            - name: Run tests
-              run: |
-                make test-cli
-                sudo env PATH="$PATH" make test-root
-            - name: Merge coverage
-              run: |
-                echo "mode: atomic" > coverage.out
-                grep -v "mode: atomic" coverage.txt >> coverage.out
-                grep -v "mode: atomic" coverage_root.txt >> coverage.out
-            - name: Codecov
-              uses: codecov/codecov-action@v3.1.1
-              with:
-                file: ./coverage.out
-
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.1.0
+      - name: Install Go
+        uses: actions/setup-go@v3.3.1
+        with:
+          go-version-file: go.mod
+      - name: Analysis
+        uses: golangci/golangci-lint-action@v3
+        with:
+          args: -v
+      - name: Build
+        run: make build-cli
+      - name: Deps
+        run: make test-deps
+      - name: Run tests
+        run: |
+          make test-cli
+          sudo env PATH="$PATH" make test-root
+      - name: Merge coverage
+        run: |
+          echo "mode: atomic" > coverage.out
+          grep -v "mode: atomic" coverage.txt >> coverage.out
+          grep -v "mode: atomic" coverage_root.txt >> coverage.out
+      - name: Codecov
+        uses: codecov/codecov-action@v3.1.1
+        with:
+          file: ./coverage.out

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,31 +1,32 @@
 name: goreleaser
+
 on:
-    push:
-        tags:
-            - 'v*'
+  push:
+    tags:
+      - 'v*'
 jobs:
-    goreleaser:
-        runs-on: ubuntu-latest
-        permissions:
-            id-token: write # undocumented OIDC support.
-            contents: write
+  goreleaser:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # undocumented OIDC support.
+      contents: write
+    env:
+      COSIGN_EXPERIMENTAL: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v3.3.1
+        with:
+          go-version-file: go.mod
+      - name: Set up cosign
+        uses: sigstore/cosign-installer@v2.8.0
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3.2.0
+        with:
+          version: latest
+          args: release --rm-dist
         env:
-            COSIGN_EXPERIMENTAL: 1
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3.1.0
-              with:
-                fetch-depth: 0
-            - name: Set up Go
-              uses: actions/setup-go@v3.3.1
-              with:
-                go-version-file: go.mod
-            - name: Set up cosign
-              uses: sigstore/cosign-installer@v2.8.0
-            - name: Run GoReleaser
-              uses: goreleaser/goreleaser-action@v3.2.0
-              with:
-                version: latest
-                args: release --rm-dist
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,11 @@
 name: goreleaser
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -30,3 +32,21 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-images:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ['x86_64']
+        flavor: ['green']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.ELEMENTAL_BOT_GITHUB_USERNAME }}
+          password: ${{ secrets.ELEMENTAL_BOT_GITHUB_TOKEN }}
+      - name: Build example image
+        run: |
+          make ARCH=${{ matrix.arch }} FLAVOR=${{ matrix.flavor }} REPO=ghcr.io/${{ github.workspace }}/${{ github.repository }}/elemental-${{ matrix.flavor}} build-os push-os

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ ARCH?=x86_64
 PLATFORM?=linux/$(ARCH)
 IMAGE_SIZE?=20G
 PACKER_TARGET?=qemu.elemental-${ARCH}
-VERSION?=latest
 REPO?=local/elemental-$(FLAVOR)
 DOCKER?=docker
 
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
 GIT_COMMIT_SHORT ?= $(shell git rev-parse --short HEAD)
-GIT_TAG ?= $(shell git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.1" )
+GIT_TAG ?= $(shell git describe --candidates=50 --abbrev=0 --tags 2>/dev/null || echo "v0.0.1" )
+VERSION ?= ${GIT_TAG}-g${GIT_COMMIT_SHORT}
 
 PKG        := ./cmd ./pkg/...
 LDFLAGS    := -w -s
@@ -42,6 +42,10 @@ build-cli:
 .PHONY: build-os
 build-os: build
 	$(DOCKER) build examples/$(FLAVOR) --build-arg VERSION=$(VERSION) --build-arg REPO=$(REPO) -t $(REPO):$(VERSION)
+
+.PHONY: push-os
+push-os:
+	$(DOCKER) push $(REPO):$(VERSION)
 
 .PHONY: build-iso
 build-iso: build-os
@@ -97,3 +101,7 @@ build-docs:
 
 .PHONY: lint
 lint: fmt vet
+
+.PHONY: _debug
+_debug:
+	@echo Debug version: ${VERSION}

--- a/tests/common/common.go
+++ b/tests/common/common.go
@@ -18,7 +18,7 @@ package common
 
 import "flag"
 
-const upImg = "ghcr.io/davidcassany/elemental-green:v0.10.6-66-g85c4bde8"
+const upImg = "ghcr.io/rancher/elemental-toolkit/elemental-green:v0.10.7-g3e4a3c56"
 
 var upgradeImg string
 


### PR DESCRIPTION
On tagged release build example images and push to ghcr.io/rancher/elemental-toolkit/elemental-<flavor>:<version>

Also update the image used in upgrade test to point to a static image from ghcr.io/rancher namespace.