### PR TITLE
Drop SLE Micro version refrences from the code

### DIFF
--- a/.obs/dockerfile/Dockerfile
+++ b/.obs/dockerfile/Dockerfile
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the names/tags of the container
-#!BuildTag: rancher/elemental-builder-image:latest
 #!BuildTag: rancher/elemental-builder-image:%VERSION%
 #!BuildTag: rancher/elemental-builder-image:%VERSION%-%RELEASE%
 #

--- a/.obs/dockerfile/Dockerfile
+++ b/.obs/dockerfile/Dockerfile
@@ -1,23 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the names/tags of the container
-#!BuildTag: rancher/elemental-builder-image/5.3:latest
-#!BuildTag: rancher/elemental-builder-image/5.3:%VERSION%
-#!BuildTag: rancher/elemental-builder-image/5.3:%VERSION%-%RELEASE%
+#!BuildTag: rancher/elemental-builder-image:latest
+#!BuildTag: rancher/elemental-builder-image:%VERSION%
+#!BuildTag: rancher/elemental-builder-image:%VERSION%-%RELEASE%
 #
 
-FROM suse/sle15:15.4
+ARG SLE_VERSION
+
+FROM suse/sle15:$SLE_VERSION
 
 RUN zypper in -y elemental-cli xfsprogs parted e2fsprogs udev rsync grub2 dosfstools squashfs mtools xorriso lvm2
+
+ARG BUILD_REPO=registry.suse.com
+ARG IMAGE_REPO=$BUILD_REPO/rancher/elemental-builder-image
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.rancher.elemental
 LABEL org.opencontainers.image.title="Rancher Elemental Builder"
 LABEL org.opencontainers.image.description="Provides Elemental Client and required dependencies for installation media building"
 LABEL org.opencontainers.image.version="%VERSION%"
-LABEL org.opencontainers.image.url="https://github.com/rancher/elemental-cli"
+LABEL org.opencontainers.image.url="https://github.com/rancher/elemental-toolkit"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="SUSE LLC"
-LABEL org.opensuse.reference="%%IMG_REPO%%/rancher/elemental-builder-image/5.3"
+LABEL org.opensuse.reference=$IMAGE_REPO
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL com.suse.supportlevel="techpreview"
 # endlabelprefix

--- a/.obs/dockerfile/Dockerfile
+++ b/.obs/dockerfile/Dockerfile
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Define the names/tags of the container
-#!BuildTag: rancher/elemental-builder-image:%VERSION%
-#!BuildTag: rancher/elemental-builder-image:%VERSION%-%RELEASE%
+#!BuildTag: rancher/elemental-builder-image/%%SLEMICRO_VERSION%%:latest
+#!BuildTag: rancher/elemental-builder-image/%%SLEMICRO_VERSION%%:%VERSION%
+#!BuildTag: rancher/elemental-builder-image/%%SLEMICRO_VERSION%%:%VERSION%-%RELEASE%
 #
 
 ARG SLE_VERSION
@@ -10,8 +11,9 @@ FROM suse/sle15:$SLE_VERSION
 
 RUN zypper in -y elemental-cli xfsprogs parted e2fsprogs udev rsync grub2 dosfstools squashfs mtools xorriso lvm2
 
-ARG BUILD_REPO=registry.suse.com
-ARG IMAGE_REPO=$BUILD_REPO/rancher/elemental-builder-image
+ARG SLEMICRO_VERSION
+ARG BUILD_REPO=%%IMG_REPO%%
+ARG IMAGE_REPO=$BUILD_REPO/rancher/elemental-builder-image/$SLEMICRO_VERSION
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.rancher.elemental


### PR DESCRIPTION
These are the changes required in this repository for the builds I prepared in [here](https://build.opensuse.org/project/show/home:dcassany:ElementalNewDev). 

Note this changes image and charts URLs, so this is likely to be a breaking change from CI perspective.

Part of rancher/elemental#815