### PR TITLE
Go 1.18 is sufficient for building

### DIFF
--- a/.obs/specfile/elemental-cli.spec
+++ b/.obs/specfile/elemental-cli.spec
@@ -38,7 +38,7 @@ Requires:       xfsprogs
 Recommends:     xorriso
 
 %if 0%{?suse_version}
-BuildRequires:  golang(API) >= 1.20
+BuildRequires:  golang(API) >= 1.18
 BuildRequires:  golang-packaging
 %{go_provides}
 %else


### PR DESCRIPTION
Surprisingly ALP only has go 1.19 as highest version