### PR TITLE
Disable service triggers on staging

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -18,20 +18,11 @@ push_workflow:
 tag_workflow:
   steps:
     - trigger_services:
-        project: isv:Rancher:Elemental:Staging
-        package: elemental-toolkit
-    - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: elemental-toolkit
     - trigger_services:
-        project: isv:Rancher:Elemental:Staging
-        package: elemental-cli
-    - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: elemental-cli
-    - trigger_services:
-        project: isv:Rancher:Elemental:Staging
-        package: builder-image
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: builder-image


### PR DESCRIPTION
Since all services are set to `manual` or `buildtime` in staging, triggering services has no effect. Staging has to be updated manually.

Related to rancher/elemental#971 and rancher/elemental-operator#498