### PR TITLE
Remove block: prefix in immutable-rootfs

### DIFF
--- a/pkg/features/embedded/immutable-rootfs/usr/lib/dracut/modules.d/30elemental-immutable-rootfs/parse-elemental-cmdline.sh
+++ b/pkg/features/embedded/immutable-rootfs/usr/lib/dracut/modules.d/30elemental-immutable-rootfs/parse-elemental-cmdline.sh
@@ -43,7 +43,7 @@ esac
 
 info "root device set to root=${root}"
 
-wait_for_dev -n "${root}"
+wait_for_dev -n "${root#block:}"
 
 # Only run filesystem checks on force mode
 fsck_mode=$(getarg fsck.mode=)


### PR DESCRIPTION
The wait_for_dev dracut function will wait for the device with that exact name. In later versions 'block:' is added in parse-rootfs in dracut which means we will wait for a device that will never exist.