### PR TITLE
Fix permissions on some unit files

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -20,6 +20,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -91,6 +92,12 @@ func (f *Feature) Install(log v1.Logger, destFs v1.FS, runner v1.Runner) error {
 			return err
 		}
 
+		filePerm, err := os.Stat(path)
+		if err != nil {
+			log.Errorf("Error getting permissions on embedded file '%s': %s", path, err.Error())
+			return err
+		}
+
 		content, err := files.ReadFile(path)
 		if err != nil {
 			log.Errorf("Error reading embedded file '%s': %s", path, err.Error())
@@ -98,7 +105,7 @@ func (f *Feature) Install(log v1.Logger, destFs v1.FS, runner v1.Runner) error {
 		}
 
 		log.Debugf("Writing file '%s' to '%s'", path, targetPath)
-		return destFs.WriteFile(targetPath, content, 0755)
+		return destFs.WriteFile(targetPath, content, filePerm.Mode().Perm())
 	})
 	if err != nil {
 		log.Errorf("Error walking files for feature %s: %s", f.Name, err.Error())


### PR DESCRIPTION
Some systemd unit files are set with permissions `0755` which is not really needed:
```sh
841ad18b3e5c:/ # ls -l /usr/lib/systemd/system/elemental-*
-rw-r--r-- 1 root root 302 Feb  1  2023 /usr/lib/systemd/system/elemental-populate-node-labels.service
-rw-r--r-- 1 root root 342 Sep  5 13:13 /usr/lib/systemd/system/elemental-register-install.service
-rw-r--r-- 1 root root 381 Sep  5 13:13 /usr/lib/systemd/system/elemental-register-reset.service
-rw-r--r-- 1 root root 560 Sep  5 13:13 /usr/lib/systemd/system/elemental-register.service
-rw-r--r-- 1 root root 370 Sep  5 13:13 /usr/lib/systemd/system/elemental-register.timer
-rwxr-xr-x 1 root root 196 Sep  5 21:50 /usr/lib/systemd/system/elemental-setup-boot.service
-rwxr-xr-x 1 root root 261 Sep  5 21:50 /usr/lib/systemd/system/elemental-setup-fs.service
-rwxr-xr-x 1 root root 352 Sep  5 21:50 /usr/lib/systemd/system/elemental-setup-initramfs.service
-rwxr-xr-x 1 root root 319 Sep  5 21:50 /usr/lib/systemd/system/elemental-setup-network.service
-rwxr-xr-x 1 root root 293 Sep  5 21:50 /usr/lib/systemd/system/elemental-setup-reconcile.service
-rwxr-xr-x 1 root root 169 Sep  5 21:50 /usr/lib/systemd/system/elemental-setup-reconcile.timer
-rwxr-xr-x 1 root root 352 Sep  5 21:50 /usr/lib/systemd/system/elemental-setup-rootfs.service
-rw-r--r-- 1 root root 568 Sep  5 13:13 /usr/lib/systemd/system/elemental-system-agent.service
```

I think that value `0755` has been set to be sure that scripts are copied as executable, but maybe we can "simply" copy the value of the source file on the target?