### PR TITLE
Remove deprecated cmdline options

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -80,17 +80,6 @@ func adaptDockerImageAndDirectoryFlagsToSystem(flags *pflag.FlagSet) {
 	}
 }
 
-func adaptEFIAndGPTFlags(flags *pflag.FlagSet) {
-	efi, _ := flags.GetBool("force-efi")
-	if efi {
-		_ = flags.Set("firmware", v1.EFI)
-	}
-	gpt, _ := flags.GetBool("force-gpt")
-	if gpt {
-		_ = flags.Set("part-table", v1.GPT)
-	}
-}
-
 func validateCosignFlags(log v1.Logger, flags *pflag.FlagSet) error {
 	cosignKey, _ := flags.GetString("cosign-key")
 	cosign, _ := flags.GetBool("cosign")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -65,9 +65,6 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			// Adapt 'docker-image' and 'directory'  deprecated flags to 'system' syntax
 			adaptDockerImageAndDirectoryFlagsToSystem(cmd.Flags())
 
-			//Adapt 'force-efi' and 'force-gpt' to 'firmware' and 'part-table'
-			adaptEFIAndGPTFlags(cmd.Flags())
-
 			cmd.SilenceUsage = true
 			spec, err := config.ReadInstallSpec(cfg, cmd.Flags())
 			if err != nil {
@@ -94,20 +91,12 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	root.AddCommand(c)
 	c.Flags().StringSliceP("cloud-init", "c", []string{}, "Cloud-init config files")
 	c.Flags().StringP("iso", "i", "", "Performs an installation from the ISO url")
-	c.Flags().StringP("partition-layout", "p", "", "Partitioning layout file")
-	_ = c.Flags().MarkDeprecated("partition-layout", "'partition-layout' is deprecated and ignored please use a config file instead")
 	c.Flags().Bool("no-format", false, "Don’t format disks. It is implied that COS_STATE, COS_RECOVERY, COS_PERSISTENT, COS_OEM are already existing")
 
-	c.Flags().Bool("force-efi", false, "Forces an EFI installation")
-	_ = c.Flags().MarkDeprecated("force-efi", "'force-efi' is deprecated please use 'firmware' instead")
 	c.Flags().Var(firmType, "firmware", "Firmware to install for: 'efi' or 'bios'. (defaults to 'efi')")
 
-	c.Flags().Bool("force-gpt", false, "Forces a GPT partition table")
-	_ = c.Flags().MarkDeprecated("force-gpt", "'force-gpt' is deprecated please use 'part-table' instead")
 	c.Flags().Var(pTableType, "part-table", "Partition table type to use")
 
-	c.Flags().String("tty", "", "Add named tty to grub")
-	_ = c.Flags().MarkDeprecated("tty", "'tty' is deprecated and ignored please set console as part of the extra kernel command line arguments as grub2 variables")
 	c.Flags().Bool("force", false, "Force install")
 	c.Flags().Bool("eject-cd", false, "Try to eject the cd on reboot, only valid if booting from iso")
 	c.Flags().Bool("disable-boot-entry", false, "Dont create an EFI entry for the system install.")

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -73,8 +73,6 @@ func NewResetCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	}
 	root.AddCommand(c)
 	c.Flags().StringSliceP("cloud-init", "c", []string{}, "Cloud-init config files")
-	c.Flags().BoolP("tty", "", false, "Add named tty to grub")
-	_ = c.Flags().MarkDeprecated("tty", "'tty' is deprecated and ignored please set console as part of the extra kernel command line arguments as grub2 variables")
 	c.Flags().BoolP("reset-persistent", "", false, "Clear persistent partitions")
 	c.Flags().BoolP("reset-oem", "", false, "Clear OEM partitions")
 	c.Flags().Bool("disable-boot-entry", false, "Dont create an EFI entry for the system install.")

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -84,9 +84,6 @@ install:
   # grub menu entry, this is the string that will be displayed
   grub-entry-name: Elemental
 
-  # tty console to add into the kernel parameters
-  tty: ttyS0
-
 # configuration for the 'reset' command
 reset:
   # if set to true it will format persistent partitions ('oem 'and 'persistent')
@@ -106,9 +103,6 @@ reset:
 
   # grub menu entry, this is the string that will be displayed
   grub-entry-name: Elemental
-
-  # tty console to add into the kernel parameters
-  tty: ttyS0
 
 # configuration used for the 'upgrade' command
 upgrade:

--- a/pkg/action/reset_test.go
+++ b/pkg/action/reset_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Reset action tests", func() {
 				"system_label":       "COS_SYSTEM",
 				"oem_label":          "COS_OEM",
 				"persistent_label":   "COS_PERSISTENT",
-				"default_menu_entry": "cOS",
+				"default_menu_entry": "Elemental",
 			}
 
 			lines := strings.Split(string(actualBytes), "\n")

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,8 +24,7 @@ import (
 const (
 	GrubConf           = "/etc/cos/grub.cfg"
 	GrubOEMEnv         = "grub_oem_env"
-	GrubDefEntry       = "cOS"
-	DefaultTty         = "tty1"
+	GrubDefEntry       = "Elemental"
 	BiosPartName       = "bios"
 	EfiLabel           = "COS_GRUB"
 	EfiPartName        = "efi"
@@ -186,7 +185,6 @@ func GetInstallKeyEnvMap() map[string]string {
 		"firmware":            "FIRMWARE",
 		"part-table":          "PART_TABLE",
 		"no-format":           "NO_FORMAT",
-		"tty":                 "TTY",
 		"grub-entry-name":     "GRUB_ENTRY_NAME",
 		"disable-boot-entry":  "DISABLE_BOOT_ENTRY",
 	}
@@ -196,7 +194,6 @@ func GetInstallKeyEnvMap() map[string]string {
 func GetResetKeyEnvMap() map[string]string {
 	return map[string]string{
 		"system.uri":       "SYSTEM",
-		"tty":              "TTY",
 		"grub-entry-name":  "GRUB_ENTRY_NAME",
 		"cloud-init":       "CLOUD_INIT",
 		"reset-persistent": "PERSISTENT",


### PR DESCRIPTION
Remove tty, force-efi, force-gpt and partition-layout deprecated flags and set the default grub entry to "Elemental".