### PR TITLE
Add mount command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.20
+ARG GO_VERSION=1.21
 ARG LEAP_VERSION=15.5
 
 FROM golang:${GO_VERSION}-alpine as elemental-bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN go build \
     -X github.com/rancher/elemental-toolkit/internal/version.gitCommit=$ELEMENTAL_COMMIT" \
     -o /usr/bin/elemental
 
-FROM opensuse/leap:$LEAP_VERSION AS elemental
+FROM registry.opensuse.org/opensuse/leap:$LEAP_VERSION AS elemental
 # This helps invalidate the cache on each build so the following steps are really run again getting the latest packages
 # versions, as long as the elemental commit has changed
 ARG ELEMENTAL_COMMIT=""

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -241,9 +242,9 @@ func ReadInitSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.InitSpec, error) {
 	if vp == nil {
 		vp = viper.New()
 	}
-	// Bind install cmd flags
+	// Bind init cmd flags
 	bindGivenFlags(vp, flags)
-	// Bind install env vars
+	// Bind init env vars
 	viperReadEnv(vp, "INIT", constants.GetInitKeyEnvMap())
 
 	err := vp.Unmarshal(init, setDecoder, decodeHook)
@@ -259,16 +260,70 @@ func ReadMountSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.MountSpec, error)
 	if vp == nil {
 		vp = viper.New()
 	}
-	// Bind install cmd flags
+	// Bind mount cmd flags
 	bindGivenFlags(vp, flags)
-	// Bind install env vars
-	viperReadEnv(vp, "MOUNT", constants.GetInitKeyEnvMap())
+	// Bind mount env vars
+	viperReadEnv(vp, "MOUNT", constants.GetMountKeyEnvMap())
 
 	err := vp.Unmarshal(mount, setDecoder, decodeHook)
 	if err != nil {
 		r.Logger.Warnf("error unmarshalling MountSpec: %s", err)
+		return mount, err
 	}
+
+	if err := applyKernelCmdline(r, mount); err != nil {
+		r.Logger.Errorf("Error reading kernel cmdline: %s", err.Error())
+		return mount, err
+	}
+
+	err = mount.Sanitize()
+	r.Logger.Debugf("Loaded mount spec: %s", litter.Sdump(mount))
 	return mount, err
+}
+
+func applyKernelCmdline(r *v1.RunConfig, mount *v1.MountSpec) error {
+	if !mount.ReadKernelCmdline {
+		r.Logger.Debug("Skipping reading kernel cmdline")
+		return nil
+	}
+
+	cmdline, err := r.Config.Fs.ReadFile("/proc/cmdline")
+	if err != nil {
+		r.Logger.Errorf("Error reading /proc/cmdline: %s", err.Error())
+		return err
+	}
+
+	for _, cmd := range strings.Fields(string(cmdline)) {
+		split := strings.SplitN(cmd, "=", 2)
+
+		val := ""
+		if len(split) == 2 {
+			val = split[1]
+		}
+
+		switch split[0] {
+		case "elemental.image":
+			mount.Mode = val
+		case "elemental.disable", "rd.cos.disable":
+			mount.Disable = true
+		case "cos-img/filename":
+			switch val {
+			case constants.ActiveImgPath:
+				mount.Mode = "active"
+			case constants.PassiveImgPath:
+				mount.Mode = "passive"
+			case constants.RecoveryImgPath:
+				mount.Mode = "recovery"
+			default:
+				r.Logger.Errorf("Error parsing cmdline %s", cmd)
+				return errors.New("Unknown image path")
+			}
+		case "elemental.oemlabel", "rd.cos.oemlabel":
+			mount.Partitions.OEM.FilesystemLabel = val
+		}
+	}
+
+	return nil
 }
 
 func ReadResetSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.ResetSpec, error) {

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -276,11 +276,6 @@ func ReadMountSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.MountSpec, error)
 		return mount, err
 	}
 
-	if err := applyMountEnvVars(mount); err != nil {
-		r.Logger.Errorf("Error reading env vars: %s", err.Error())
-		return mount, err
-	}
-
 	err = mount.Sanitize()
 	r.Logger.Debugf("Loaded mount spec: %s", litter.Sdump(mount))
 	return mount, err
@@ -326,38 +321,6 @@ func applyKernelCmdline(r *v1.RunConfig, mount *v1.MountSpec) error {
 		case "elemental.oemlabel", "rd.cos.oemlabel":
 			mount.Partitions.OEM.FilesystemLabel = val
 		}
-	}
-
-	return nil
-}
-
-func applyMountEnvVars(mount *v1.MountSpec) error {
-	// Read the OVERLAY, RW_PATHS, PERSISTENT_STATE_PATHS and PERSISTENT_STATE_BIND and overwrite the MountSpec
-
-	overlay, exists := os.LookupEnv("OVERLAY")
-	if exists {
-		split := strings.SplitN(overlay, ":", 2)
-
-		if split[0] == "tmpfs" && len(split) == 2 {
-			mount.Overlay.Size = split[1]
-		} else {
-			return fmt.Errorf("unknown OVERLAY value: '%s'", overlay)
-		}
-	}
-
-	rwPaths, exists := os.LookupEnv("RW_PATHS")
-	if exists {
-		mount.Overlay.Paths = strings.Fields(rwPaths)
-	}
-
-	persistentPaths, exists := os.LookupEnv("PERSISTENT_STATE_PATHS")
-	if exists {
-		mount.Persistent.Paths = strings.Fields(persistentPaths)
-	}
-
-	persistentBind, exists := os.LookupEnv("PERSISTENT_STATE_BIND")
-	if exists && persistentBind == "true" {
-		mount.Persistent.Mode = constants.BindMode
 	}
 
 	return nil

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -253,6 +253,24 @@ func ReadInitSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.InitSpec, error) {
 	return init, err
 }
 
+func ReadMountSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.MountSpec, error) {
+	mount := config.NewMountSpec()
+	vp := viper.Sub("mount")
+	if vp == nil {
+		vp = viper.New()
+	}
+	// Bind install cmd flags
+	bindGivenFlags(vp, flags)
+	// Bind install env vars
+	viperReadEnv(vp, "MOUNT", constants.GetInitKeyEnvMap())
+
+	err := vp.Unmarshal(mount, setDecoder, decodeHook)
+	if err != nil {
+		r.Logger.Warnf("error unmarshalling MountSpec: %s", err)
+	}
+	return mount, err
+}
+
 func ReadResetSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.ResetSpec, error) {
 	reset, err := config.NewResetSpec(r.Config)
 	if err != nil {

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -1,0 +1,59 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"k8s.io/mount-utils"
+
+	"github.com/rancher/elemental-toolkit/cmd/config"
+	"github.com/rancher/elemental-toolkit/pkg/action"
+	"github.com/rancher/elemental-toolkit/pkg/constants"
+	elementalError "github.com/rancher/elemental-toolkit/pkg/error"
+)
+
+func MountCmd(root *cobra.Command) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "mount DEVICE SYSROOT",
+		Short: "Mount an elemental system from a device into the specified sysroot",
+		Args:  cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mounter := mount.New(constants.MountBinary)
+
+			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), mounter)
+			if err != nil {
+				cfg.Logger.Errorf("Error reading config: %s\n", err)
+				return elementalError.NewFromError(err, elementalError.ReadingRunConfig)
+			}
+
+			cmd.SilenceUsage = true
+			spec, err := config.ReadMountSpec(cfg, cmd.Flags())
+			if err != nil {
+				cfg.Logger.Errorf("Error reading spec: %s\n", err)
+				return elementalError.NewFromError(err, elementalError.ReadingSpecConfig)
+			}
+
+			cfg.Logger.Infof("Mounting system...")
+			return action.RunMount(cfg, spec)
+		},
+	}
+	root.AddCommand(c)
+	return c
+}
+
+var _ = MountCmd(rootCmd)

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -27,11 +27,10 @@ import (
 	elementalError "github.com/rancher/elemental-toolkit/pkg/error"
 )
 
-func MountCmd(root *cobra.Command) *cobra.Command {
+func NewMountCmd(root *cobra.Command) *cobra.Command {
 	c := &cobra.Command{
-		Use:   "mount DEVICE SYSROOT",
-		Short: "Mount an elemental system from a device into the specified sysroot",
-		Args:  cobra.MaximumNArgs(2),
+		Use:   "mount",
+		Short: "Mount an elemental system into the specified sysroot",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			mounter := mount.New(constants.MountBinary)
 
@@ -48,7 +47,12 @@ func MountCmd(root *cobra.Command) *cobra.Command {
 				return elementalError.NewFromError(err, elementalError.ReadingSpecConfig)
 			}
 
-			cfg.Logger.Infof("Mounting system...")
+			if spec.Disable {
+				cfg.Logger.Info("Mounting disabled, exiting")
+				return nil
+			}
+
+			cfg.Logger.Info("Mounting system...")
 			return action.RunMount(cfg, spec)
 		},
 	}
@@ -56,4 +60,4 @@ func MountCmd(root *cobra.Command) *cobra.Command {
 	return c
 }
 
-var _ = MountCmd(rootCmd)
+var _ = NewMountCmd(rootCmd)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -130,10 +130,12 @@ mount:
   sysroot: /sysroot
   write-fstab: true
   write-sentinel: true
-  rw-paths:
-    - /var
-    - /etc
-    - /srv
+  overlay:
+    size: 25%
+    paths:
+      - /var
+      - /etc
+      - /srv
   persistent:
     mode: overlay # overlay|bind
     paths:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -124,6 +124,27 @@ upgrade:
   # grub menu entry, this is the string that will be displayed
   grub-entry-name: Elemental
 
+# configuration used for the 'mount' command
+mount:
+  read-kernel-cmdline: true # read and parse /proc/cmdline for arguments
+  sysroot: /sysroot
+  write-fstab: true
+  write-sentinel: true
+  rw-paths:
+    - /var
+    - /etc
+    - /srv
+  persistent:
+    mode: overlay # overlay|bind
+    paths:
+      - /etc/systemd
+      - /etc/ssh
+      - /home
+      - /opt
+      - /root
+      - /usr/libexec
+      - /var/log
+
 # use cosign to validate images from container registries
 cosign: true
 # cosign key to used for validation

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -129,7 +129,7 @@ mount:
   read-kernel-cmdline: true # read and parse /proc/cmdline for arguments
   sysroot: /sysroot # Path to mount system to
   write-fstab: true # Write fstab into sysroot/etc/fstab
-  run-cloud-init: true # Run rootfs stage
+  run-rootfs-service: true # Run rootfs stage
   run-fsck: true # Run fsck on all partitions before mounting
   overlay:
     type: tmpfs # tmpfs|block

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -129,9 +129,11 @@ mount:
   read-kernel-cmdline: true # read and parse /proc/cmdline for arguments
   sysroot: /sysroot
   write-fstab: true
-  write-sentinel: true
+  run-cloud-init: true
   overlay:
-    size: 25%
+    type: tmpfs # tmpfs|block
+    device: /dev/sda6 # used when type is set to block
+    size: 25% # used when type is set to tmpfs
     paths:
       - /var
       - /etc

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -127,13 +127,14 @@ upgrade:
 # configuration used for the 'mount' command
 mount:
   read-kernel-cmdline: true # read and parse /proc/cmdline for arguments
-  sysroot: /sysroot
-  write-fstab: true
-  run-cloud-init: true
+  sysroot: /sysroot # Path to mount system to
+  write-fstab: true # Write fstab into sysroot/etc/fstab
+  run-cloud-init: true # Run rootfs stage
+  run-fsck: true # Run fsck on all partitions before mounting
   overlay:
     type: tmpfs # tmpfs|block
-    device: /dev/sda6 # used when type is set to block
-    size: 25% # used when type is set to tmpfs
+    device: /dev/sda6 # Block device used to store overlay. Used when type is set to block
+    size: 25% # Size of tmpfs as percentag of system memory. Used when type is set to tmpfs
     paths:
       - /var
       - /etc

--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -54,7 +54,7 @@ RUN systemctl enable NetworkManager.service
 RUN cp /usr/share/systemd/tmp.mount /etc/systemd/system
 
 # Generate initrd with required elemental services
-RUN elemental init -f elemental-rootfs,grub-config,grub-default-bootargs,elemental-setup,dracut-config,cloud-config-defaults,cloud-config-essentials && \
+RUN elemental init -f elemental-rootfs,grub-config,grub-default-bootargs,dracut-config,cloud-config-defaults,cloud-config-essentials && \
     kernel=$(ls /boot/Image-* | head -n1) && \
     if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi && \
     rm -rf /var/log/update* && \

--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -54,7 +54,7 @@ RUN systemctl enable NetworkManager.service
 RUN cp /usr/share/systemd/tmp.mount /etc/systemd/system
 
 # Generate initrd with required elemental services
-RUN elemental init -f elemental-rootfs,grub-config,elemental-setup,dracut-config,cloud-config-defaults,cloud-config-essentials && \
+RUN elemental init -f elemental-rootfs,grub-config,grub-default-bootargs,elemental-setup,dracut-config,cloud-config-defaults,cloud-config-essentials && \
     kernel=$(ls /boot/Image-* | head -n1) && \
     if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi && \
     rm -rf /var/log/update* && \

--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -54,7 +54,7 @@ RUN systemctl enable NetworkManager.service
 RUN cp /usr/share/systemd/tmp.mount /etc/systemd/system
 
 # Generate initrd with required elemental services
-RUN elemental init -f && \
+RUN elemental init -f elemental-rootfs,grub-config,elemental-setup,dracut-config,cloud-config-defaults,cloud-config-essentials && \
     kernel=$(ls /boot/Image-* | head -n1) && \
     if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi && \
     rm -rf /var/log/update* && \

--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION
 FROM ${TOOLKIT_REPO}:${VERSION} as TOOLKIT
 
 # OS base image of our choice
-FROM opensuse/leap:15.5 as OS
+FROM registry.opensuse.org/opensuse/leap:15.5 as OS
 ARG REPO
 ARG VERSION
 ENV VERSION=${VERSION}

--- a/examples/tumbleweed/Dockerfile
+++ b/examples/tumbleweed/Dockerfile
@@ -54,7 +54,7 @@ RUN systemctl enable NetworkManager.service
 RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
 
 # Generate initrd with required elemental services
-RUN elemental init -f && \
+RUN elemental init -f elemental-rootfs,grub-config,elemental-setup,dracut-config,cloud-config-defaults,cloud-config-essentials && \
     kernel=$(ls /boot/Image-* | head -n1) && \
     if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi && \
     rm -rf /var/log/update* && \

--- a/examples/tumbleweed/Dockerfile
+++ b/examples/tumbleweed/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION
 FROM ${TOOLKIT_REPO}:${VERSION} as TOOLKIT
 
 # OS base image of our choice
-FROM opensuse/tumbleweed:latest as OS
+FROM registry.opensuse.org/opensuse/tumbleweed:latest as OS
 ARG REPO
 ARG VERSION
 ENV VERSION=${VERSION}

--- a/examples/tumbleweed/Dockerfile
+++ b/examples/tumbleweed/Dockerfile
@@ -54,7 +54,7 @@ RUN systemctl enable NetworkManager.service
 RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
 
 # Generate initrd with required elemental services
-RUN elemental init -f elemental-rootfs,grub-config,grub-default-bootargs,elemental-setup,dracut-config,cloud-config-defaults,cloud-config-essentials && \
+RUN elemental init -f elemental-rootfs,grub-config,grub-default-bootargs,dracut-config,cloud-config-defaults,cloud-config-essentials && \
     kernel=$(ls /boot/Image-* | head -n1) && \
     if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi && \
     rm -rf /var/log/update* && \

--- a/examples/tumbleweed/Dockerfile
+++ b/examples/tumbleweed/Dockerfile
@@ -54,7 +54,7 @@ RUN systemctl enable NetworkManager.service
 RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
 
 # Generate initrd with required elemental services
-RUN elemental init -f elemental-rootfs,grub-config,elemental-setup,dracut-config,cloud-config-defaults,cloud-config-essentials && \
+RUN elemental init -f elemental-rootfs,grub-config,grub-default-bootargs,elemental-setup,dracut-config,cloud-config-defaults,cloud-config-essentials && \
     kernel=$(ls /boot/Image-* | head -n1) && \
     if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi && \
     rm -rf /var/log/update* && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/elemental-toolkit
 
-go 1.20
+go 1.21
 
 require (
 	github.com/canonical/go-efilib v0.3.1-0.20220324150059-04e254148b45

--- a/pkg/action/mount.go
+++ b/pkg/action/mount.go
@@ -34,14 +34,8 @@ func RunMount(cfg *v1.RunConfig, spec *v1.MountSpec) error {
 
 	e := elemental.NewElemental(&cfg.Config)
 
-	allParts, err := utils.GetAllPartitions()
-	if err != nil {
-		cfg.Logger.Errorf("Error getting all partitions: %s", err.Error())
-		return err
-	}
-
 	cfg.Logger.Debug("Fscking partitions")
-	if err := e.FsckPartitions(allParts); err != nil {
+	if err := RunFsck(cfg, spec, e); err != nil {
 		cfg.Logger.Errorf("Error fscking partitions: %s", err.Error())
 		return err
 	}
@@ -135,6 +129,21 @@ func applyLayoutConfig(cfg *v1.RunConfig, spec *v1.MountSpec) error {
 	}
 
 	return nil
+}
+
+func RunFsck(cfg *v1.RunConfig, spec *v1.MountSpec, e *elemental.Elemental) error {
+	if !spec.RunFsck {
+		cfg.Logger.Debug("Skipping fsck")
+		return nil
+	}
+
+	allParts, err := utils.GetAllPartitions()
+	if err != nil {
+		cfg.Logger.Errorf("Error getting all partitions: %s", err.Error())
+		return err
+	}
+
+	return e.FsckPartitions(allParts)
 }
 
 func MountOverlay(cfg *v1.RunConfig, sysroot string, overlay v1.OverlayMounts) error {

--- a/pkg/action/mount.go
+++ b/pkg/action/mount.go
@@ -30,6 +30,8 @@ import (
 	"github.com/rancher/elemental-toolkit/pkg/utils"
 )
 
+const overlaySuffix = ".overlay"
+
 func RunMount(cfg *v1.RunConfig, spec *v1.MountSpec) error {
 	cfg.Logger.Info("Running mount command")
 
@@ -248,7 +250,7 @@ func MountOverlayPath(cfg *v1.RunConfig, sysroot, overlayDir, path string) error
 	}
 
 	trimmed := strings.TrimPrefix(path, "/")
-	pathName := strings.ReplaceAll(trimmed, "/", "-") + ".overlay"
+	pathName := strings.ReplaceAll(trimmed, "/", "-") + overlaySuffix
 	upper := fmt.Sprintf("%s/%s/upper", overlayDir, pathName)
 	if err := utils.MkdirAll(cfg.Config.Fs, upper, constants.DirPerm); err != nil {
 		cfg.Logger.Errorf("Error creating upperdir %s: %s", upper, err.Error())
@@ -290,7 +292,7 @@ func WriteFstab(cfg *v1.RunConfig, spec *v1.MountSpec) error {
 
 	for _, rw := range spec.Overlay.Paths {
 		trimmed := strings.TrimPrefix(rw, "/")
-		pathName := strings.ReplaceAll(trimmed, "/", "-") + ".overlay"
+		pathName := strings.ReplaceAll(trimmed, "/", "-") + overlaySuffix
 		upper := fmt.Sprintf("%s/%s/upper", constants.OverlayDir, pathName)
 		work := fmt.Sprintf("%s/%s/work", constants.OverlayDir, pathName)
 
@@ -306,7 +308,7 @@ func WriteFstab(cfg *v1.RunConfig, spec *v1.MountSpec) error {
 	for _, path := range spec.Persistent.Paths {
 		if spec.Persistent.Mode == constants.OverlayMode {
 			trimmed := strings.TrimPrefix(path, "/")
-			pathName := strings.ReplaceAll(trimmed, "/", "-") + ".overlay"
+			pathName := strings.ReplaceAll(trimmed, "/", "-") + overlaySuffix
 			upper := fmt.Sprintf("%s/%s/upper", constants.PersistentStateDir, pathName)
 			work := fmt.Sprintf("%s/%s/work", constants.PersistentStateDir, pathName)
 

--- a/pkg/action/mount.go
+++ b/pkg/action/mount.go
@@ -1,0 +1,126 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/rancher/elemental-toolkit/pkg/constants"
+	"github.com/rancher/elemental-toolkit/pkg/elemental"
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
+	"github.com/rancher/elemental-toolkit/pkg/utils"
+)
+
+func RunMount(cfg *v1.RunConfig, spec *v1.MountSpec) error {
+	cfg.Logger.Info("Running mount command")
+
+	e := elemental.NewElemental(&cfg.Config)
+
+	err := e.MountPartitions(spec.Partitions.PartitionsByMountPoint(false))
+	if err != nil {
+		return err
+	}
+
+	if err := e.MountImage(spec.Image); err != nil {
+		cfg.Logger.Errorf("Error mounting image %s: %s", spec.Image.File, err.Error())
+		return err
+	}
+
+	for _, path := range spec.RwPaths {
+		cfg.Logger.Debugf("Mounting path %s into %s", path, spec.Sysroot)
+		if err := MountRwPath(cfg, spec.Sysroot, path); err != nil {
+			cfg.Logger.Errorf("Error mounting path %s: %s", path, err.Error())
+			return err
+		}
+	}
+
+	if err := WriteFstab(cfg, spec); err != nil {
+		cfg.Logger.Errorf("Error writing new fstab: %s", err.Error())
+		return err
+	}
+
+	cfg.Logger.Info("Mount command finished successfully")
+	return nil
+}
+
+func MountRwPath(cfg *v1.RunConfig, sysroot, path string) error {
+	cfg.Logger.Debugf("Mounting Path")
+
+	lower := filepath.Join(sysroot, path)
+	if err := utils.MkdirAll(cfg.Config.Fs, lower, constants.DirPerm); err != nil {
+		cfg.Logger.Errorf("Error creating directory %s: %s", path, err.Error())
+		return err
+	}
+
+	trimmed := strings.TrimPrefix(path, "/")
+	pathName := strings.ReplaceAll(trimmed, "/", "-")
+	upper := fmt.Sprintf("%s/%s/upper", constants.OverlayDir, pathName)
+	if err := utils.MkdirAll(cfg.Config.Fs, upper, constants.DirPerm); err != nil {
+		cfg.Logger.Errorf("Error creating upperdir %s: %s", upper, err.Error())
+		return err
+	}
+
+	work := fmt.Sprintf("%s/%s/work", constants.OverlayDir, pathName)
+	if err := utils.MkdirAll(cfg.Config.Fs, work, constants.DirPerm); err != nil {
+		cfg.Logger.Errorf("Error creating workdir %s: %s", work, err.Error())
+		return err
+	}
+
+	cfg.Logger.Debugf("Mounting overlay %s", lower)
+	options := []string{"defaults"}
+	options = append(options, fmt.Sprintf("lowerdir=%s", lower))
+	options = append(options, fmt.Sprintf("upperdir=%s", upper))
+	options = append(options, fmt.Sprintf("workdir=%s", work))
+
+	if err := cfg.Mounter.Mount("overlay", lower, "overlay", options); err != nil {
+		cfg.Logger.Errorf("Error mounting overlay: %s", err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func WriteFstab(cfg *v1.RunConfig, spec *v1.MountSpec) error {
+	if !spec.WriteFstab {
+		cfg.Logger.Debug("Skipping writing fstab")
+		return nil
+	}
+
+	data := fmt.Sprintf("%s\t/\tauto\tro\t0 0\n", spec.Image.LoopDevice)
+
+	for _, part := range spec.Partitions.PartitionsByMountPoint(false) {
+		data = data + fmt.Sprintf("%s\t%s\t%s\t%s\n", part.Path, part.MountPoint, part.FS, "")
+	}
+
+	for _, rw := range spec.RwPaths {
+		trimmed := strings.TrimPrefix(rw, "/")
+		pathName := strings.ReplaceAll(trimmed, "/", "-")
+		upper := fmt.Sprintf("%s/%s/upper", constants.OverlayDir, pathName)
+		work := fmt.Sprintf("%s/%s/work", constants.OverlayDir, pathName)
+
+		options := []string{"defaults"}
+		options = append(options, fmt.Sprintf("lowerdir=%s", rw))
+		options = append(options, fmt.Sprintf("upperdir=%s", upper))
+		options = append(options, fmt.Sprintf("workdir=%s", work))
+		options = append(options, fmt.Sprintf("x-systemd.requires-mounts-for=%s", constants.OverlayDir))
+		data = data + fmt.Sprintf("%s\t%s\t%s\t%s\n", "overlay", rw, "overlay", strings.Join(options, ","))
+	}
+
+	return cfg.Config.Fs.WriteFile(filepath.Join(spec.Sysroot, "/etc/fstab"), []byte(data), 0644)
+}

--- a/pkg/action/mount.go
+++ b/pkg/action/mount.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/rancher/elemental-toolkit/pkg/constants"
 	"github.com/rancher/elemental-toolkit/pkg/elemental"
+	"github.com/rancher/elemental-toolkit/pkg/systemd"
 	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
 	"github.com/rancher/elemental-toolkit/pkg/utils"
 )
@@ -52,15 +53,15 @@ func RunMount(cfg *v1.RunConfig, spec *v1.MountSpec) error {
 		return err
 	}
 
-	if spec.RunCloudInit {
-		cfg.Logger.Debug("Running rootfs cloud-init stage")
-		err := utils.RunStage(&cfg.Config, "rootfs", cfg.Strict, cfg.CloudInitPaths...)
+	if spec.RunRootfsService {
+		cfg.Logger.Debug("Running elemental-setup-rootfs service")
+		err := systemd.Start(cfg.Config.Runner, systemd.NewUnit("elemental-setup-rootfs"))
 		if err != nil {
 			cfg.Logger.Errorf("Error running rootfs stage: %s", err.Error())
 			return err
 		}
 	} else {
-		cfg.Logger.Debug("Skipping cloud-init rootfs stage")
+		cfg.Logger.Debug("Skipping elemental-setup-rootfs")
 	}
 
 	if err := applyLayoutConfig(cfg, spec); err != nil {

--- a/pkg/action/mount.go
+++ b/pkg/action/mount.go
@@ -34,16 +34,20 @@ func RunMount(cfg *v1.RunConfig, spec *v1.MountSpec) error {
 
 	e := elemental.NewElemental(&cfg.Config)
 
-	partitions := spec.Partitions.PartitionsByMountPoint(false)
+	allParts, err := utils.GetAllPartitions()
+	if err != nil {
+		cfg.Logger.Errorf("Error getting all partitions: %s", err.Error())
+		return err
+	}
 
 	cfg.Logger.Debug("Fscking partitions")
-	if err := e.FsckPartitions(partitions); err != nil {
+	if err := e.FsckPartitions(allParts); err != nil {
 		cfg.Logger.Errorf("Error fscking partitions: %s", err.Error())
 		return err
 	}
 
 	cfg.Logger.Debug("Mounting partitions")
-	if err := e.MountPartitions(partitions); err != nil {
+	if err := e.MountPartitions(spec.Partitions.PartitionsByMountPoint(false)); err != nil {
 		cfg.Logger.Errorf("Error mounting partitions: %s", err.Error())
 		return err
 	}
@@ -322,5 +326,5 @@ func WriteFstab(cfg *v1.RunConfig, spec *v1.MountSpec) error {
 }
 
 func fstab(device, path, fstype string, flags []string) string {
-	return fmt.Sprintf("%s\t%s\t%s\t%s\n", device, path, fstype, strings.Join(flags, ","))
+	return fmt.Sprintf("%s\t%s\t%s\t%s\t0\t0\n", device, path, fstype, strings.Join(flags, ","))
 }

--- a/pkg/action/mount.go
+++ b/pkg/action/mount.go
@@ -44,13 +44,13 @@ func RunMount(cfg *v1.RunConfig, spec *v1.MountSpec) error {
 		return err
 	}
 
-	cfg.Logger.Debugf("Mounting overlay")
+	cfg.Logger.Debugf("Mounting overlays")
 	if err := MountOverlay(cfg, spec.Sysroot, spec.Overlay); err != nil {
 		cfg.Logger.Errorf("Error mounting image %s: %s", spec.Image.File, err.Error())
 		return err
 	}
 
-	cfg.Logger.Debugf("Mounting persistent")
+	cfg.Logger.Debugf("Mounting persistent directories")
 	if err := MountPersistent(cfg, spec.Sysroot, spec.Persistent); err != nil {
 		cfg.Logger.Errorf("Error mounting image %s: %s", spec.Image.File, err.Error())
 		return err

--- a/pkg/action/mount_test.go
+++ b/pkg/action/mount_test.go
@@ -48,6 +48,9 @@ var _ = Describe("Mount Action", func() {
 				Image: &v1.Image{
 					LoopDevice: "/dev/loop0",
 				},
+				Overlay: v1.OverlayMounts{
+					Size: "30%",
+				},
 			}
 			utils.MkdirAll(fs, filepath.Join(spec.Sysroot, "/etc"), constants.DirPerm)
 			err := action.WriteFstab(cfg, spec)
@@ -55,7 +58,7 @@ var _ = Describe("Mount Action", func() {
 
 			fstab, err := cfg.Config.Fs.ReadFile(filepath.Join(spec.Sysroot, "/etc/fstab"))
 			Expect(err).To(BeNil())
-			Expect(string(fstab)).To(Equal("/dev/loop0\t/\tauto\tro\t0 0\n"))
+			Expect(string(fstab)).To(Equal("/dev/loop0\t/\tauto\tro\ntmpfs\t/run/elemental/overlay\ttmpfs\tdefaults,size=30%\n"))
 		})
 	})
 	// Describe("Mount image", Label("mount", "image"), func() {

--- a/pkg/action/mount_test.go
+++ b/pkg/action/mount_test.go
@@ -1,0 +1,71 @@
+package action_test
+
+import (
+	"bytes"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"github.com/twpayne/go-vfs"
+	"github.com/twpayne/go-vfs/vfst"
+	"k8s.io/mount-utils"
+
+	"github.com/rancher/elemental-toolkit/pkg/action"
+	"github.com/rancher/elemental-toolkit/pkg/config"
+	"github.com/rancher/elemental-toolkit/pkg/constants"
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
+	"github.com/rancher/elemental-toolkit/pkg/utils"
+)
+
+var _ = Describe("Mount Action", func() {
+	var cfg *v1.RunConfig
+	var mounter *mount.FakeMounter
+	var fs vfs.FS
+	var logger v1.Logger
+	var cleanup func()
+	var memLog *bytes.Buffer
+
+	BeforeEach(func() {
+		mounter = &mount.FakeMounter{}
+		memLog = &bytes.Buffer{}
+		logger = v1.NewBufferLogger(memLog)
+		logger.SetLevel(logrus.DebugLevel)
+		fs, cleanup, _ = vfst.NewTestFS(map[string]interface{}{})
+		cfg = config.NewRunConfig(
+			config.WithFs(fs),
+			config.WithMounter(mounter),
+			config.WithLogger(logger),
+		)
+	})
+	AfterEach(func() {
+		cleanup()
+	})
+	Describe("Write fstab", Label("mount", "fstab"), func() {
+		It("Writes a simple fstab", func() {
+			spec := &v1.MountSpec{
+				WriteFstab: true,
+				Image: &v1.Image{
+					LoopDevice: "/dev/loop0",
+				},
+			}
+			utils.MkdirAll(fs, filepath.Join(spec.Sysroot, "/etc"), constants.DirPerm)
+			err := action.WriteFstab(cfg, spec)
+			Expect(err).To(BeNil())
+
+			fstab, err := cfg.Config.Fs.ReadFile(filepath.Join(spec.Sysroot, "/etc/fstab"))
+			Expect(err).To(BeNil())
+			Expect(string(fstab)).To(Equal("/dev/loop0\t/\tauto\tro\t0 0\n"))
+		})
+	})
+	// Describe("Mount image", Label("mount", "image"), func() {
+	// 	It("Mounts an image", func() {
+	// 		spec := &v1.MountSpec{
+	// 			Image: &v1.Image{},
+	// 		}
+
+	// 		err := action.RunMount(cfg, spec)
+	// 		Expect(err).To(BeNil())
+	// 	})
+	// })
+})

--- a/pkg/action/mount_test.go
+++ b/pkg/action/mount_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Mount Action", func() {
 
 			fstab, err := cfg.Config.Fs.ReadFile(filepath.Join(spec.Sysroot, "/etc/fstab"))
 			Expect(err).To(BeNil())
-			Expect(string(fstab)).To(Equal("/dev/loop0\t/\tauto\tro\ntmpfs\t/run/elemental/overlay\ttmpfs\tdefaults,size=30%\n"))
+			Expect(string(fstab)).To(Equal("/dev/loop0\t/\tauto\tro\t0\t0\ntmpfs\t/run/elemental/overlay\ttmpfs\tdefaults,size=30%\t0\t0\n"))
 		})
 	})
 	// Describe("Mount image", Label("mount", "image"), func() {

--- a/pkg/action/mount_test.go
+++ b/pkg/action/mount_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package action_test
 
 import (

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -143,10 +143,10 @@ func (u *UpgradeAction) Run() (err error) {
 
 	if u.spec.RecoveryUpgrade {
 		upgradeImg = u.spec.Recovery
-		finalImageFile = filepath.Join(u.spec.Partitions.Recovery.MountPoint, "cOS", constants.RecoveryImgFile)
+		finalImageFile = filepath.Join(u.spec.Partitions.Recovery.MountPoint, constants.RecoveryImgPath)
 	} else {
 		upgradeImg = u.spec.Active
-		finalImageFile = filepath.Join(u.spec.Partitions.State.MountPoint, "cOS", constants.ActiveImgFile)
+		finalImageFile = filepath.Join(u.spec.Partitions.State.MountPoint, constants.ActiveImgPath)
 	}
 
 	umount, err := e.MountRWPartition(u.spec.Partitions.State)
@@ -260,7 +260,7 @@ func (u *UpgradeAction) Run() (err error) {
 		//TODO this step could be part of elemental package
 		// backup current active.img to passive.img before overwriting the active.img
 		u.Info("Backing up current active image")
-		source := filepath.Join(u.spec.Partitions.State.MountPoint, "cOS", constants.ActiveImgFile)
+		source := filepath.Join(u.spec.Partitions.State.MountPoint, constants.ActiveImgPath)
 		u.Info("Moving %s to %s", source, u.spec.Passive.File)
 		_, err := u.config.Runner.Run("mv", "-f", source, u.spec.Passive.File)
 		if err != nil {

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -84,10 +84,10 @@ var _ = Describe("Runtime Actions", func() {
 		var spec *v1.UpgradeSpec
 		var upgrade *action.UpgradeAction
 		var memLog *bytes.Buffer
-		activeImg := fmt.Sprintf("%s/cOS/%s", constants.RunningStateDir, constants.ActiveImgFile)
-		passiveImg := fmt.Sprintf("%s/cOS/%s", constants.RunningStateDir, constants.PassiveImgFile)
+		activeImg := fmt.Sprintf("%s%s", constants.RunningStateDir, constants.ActiveImgPath)
+		passiveImg := fmt.Sprintf("%s%s", constants.RunningStateDir, constants.PassiveImgPath)
 
-		recoveryImg := fmt.Sprintf("%s/cOS/%s", constants.LiveDir, constants.RecoveryImgFile)
+		recoveryImg := fmt.Sprintf("%s%s", constants.LiveDir, constants.RecoveryImgPath)
 
 		BeforeEach(func() {
 			memLog = &bytes.Buffer{}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -233,7 +233,7 @@ func NewMountSpec() *v1.MountSpec {
 		ReadKernelCmdline: true,
 		Sysroot:           "/sysroot",
 		WriteFstab:        true,
-		RunCloudInit:      true,
+		RunRootfsService:  true,
 		RunFsck:           true,
 		Image: &v1.Image{
 			FS:         constants.LinuxImgFs,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -233,7 +233,7 @@ func NewMountSpec() *v1.MountSpec {
 		ReadKernelCmdline: true,
 		Sysroot:           "/sysroot",
 		WriteFstab:        true,
-		WriteSentinel:     true,
+		RunCloudInit:      true,
 		Image: &v1.Image{
 			FS:         constants.LinuxImgFs,
 			MountPoint: "/sysroot",
@@ -272,6 +272,7 @@ func NewMountSpec() *v1.MountSpec {
 			},
 		},
 		Overlay: v1.OverlayMounts{
+			Type:  constants.Tmpfs,
 			Size:  "25%",
 			Paths: []string{"/var", "/etc", "/srv"},
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -278,7 +278,7 @@ func NewMountSpec() *v1.MountSpec {
 		},
 		Persistent: v1.PersistentMounts{
 			Mode:  constants.OverlayMode,
-			Paths: []string{"/etc/systemd", "/etc/ssh", "/home", "/opt", "/root", "/usr/libexec", "/var/log"},
+			Paths: []string{"/etc/systemd", "/etc/ssh", "/home", "/opt", "/root", "/var/log"},
 		},
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -235,7 +235,6 @@ func NewMountSpec() *v1.MountSpec {
 		WriteFstab:        true,
 		WriteSentinel:     true,
 		Image: &v1.Image{
-
 			FS:         constants.LinuxImgFs,
 			MountPoint: "/sysroot",
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -228,6 +228,48 @@ func NewInitSpec() *v1.InitSpec {
 	}
 }
 
+func NewMountSpec() *v1.MountSpec {
+	return &v1.MountSpec{
+		Sysroot:       "/sysroot",
+		WriteFstab:    true,
+		WriteSentinel: true,
+		Image: &v1.Image{
+			Label:      constants.ActiveLabel,
+			FS:         constants.LinuxImgFs,
+			File:       filepath.Join(constants.RunningStateDir, "cOS", constants.ActiveImgFile),
+			Source:     v1.NewFileSrc(filepath.Join(constants.RunningStateDir, "cOS", constants.ActiveImgFile)),
+			MountPoint: "/sysroot",
+		},
+		Partitions: v1.ElementalPartitions{
+			State: &v1.Partition{
+				FilesystemLabel: constants.StateLabel,
+				Size:            constants.StateSize,
+				Name:            constants.StatePartName,
+				FS:              constants.LinuxFs,
+				MountPoint:      constants.RunningStateDir,
+				Flags:           []string{},
+			},
+			Persistent: &v1.Partition{
+				FilesystemLabel: constants.PersistentLabel,
+				Size:            constants.PersistentSize,
+				Name:            constants.PersistentPartName,
+				FS:              constants.LinuxFs,
+				MountPoint:      constants.PersistentDir,
+				Flags:           []string{},
+			},
+			OEM: &v1.Partition{
+				FilesystemLabel: constants.OEMLabel,
+				Size:            constants.OEMSize,
+				Name:            constants.OEMPartName,
+				FS:              constants.LinuxFs,
+				MountPoint:      constants.OEMPath,
+				Flags:           []string{},
+			},
+		},
+		RwPaths: []string{"/var", "/etc", "/srv"},
+	}
+}
+
 func NewInstallElementalPartitions() v1.ElementalPartitions {
 	partitions := v1.ElementalPartitions{}
 	partitions.OEM = &v1.Partition{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -264,6 +264,13 @@ func NewMountSpec() *v1.MountSpec {
 				MountPoint:      constants.OEMPath,
 				Flags:           []string{},
 			},
+			Recovery: &v1.Partition{
+				FilesystemLabel: constants.RecoveryLabel,
+				Size:            constants.RecoverySize,
+				Name:            constants.RecoveryPartName,
+				FS:              constants.LinuxFs,
+				Flags:           []string{},
+			},
 		},
 		Overlay: v1.OverlayMounts{
 			Size:  "25%",
@@ -431,7 +438,7 @@ func NewResetSpec(cfg v1.Config) (*v1.ResetSpec, error) {
 	var imgSource *v1.ImageSource
 	var aState, pState *v1.ImageState
 
-	if !utils.BootedFrom(cfg.Runner, constants.RecoveryImgFile) {
+	if !utils.BootedFrom(cfg.Runner, constants.RecoveryImgName) {
 		return nil, fmt.Errorf("reset can only be called from the recovery system")
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -187,7 +187,7 @@ func NewInstallSpec(cfg v1.Config) *v1.InstallSpec {
 
 	activeImg.Label = constants.ActiveLabel
 	activeImg.Size = constants.ImgSize
-	activeImg.File = filepath.Join(constants.StateDir, "cOS", constants.ActiveImgFile)
+	activeImg.File = filepath.Join(constants.StateDir, constants.ActiveImgPath)
 	activeImg.FS = constants.LinuxImgFs
 	activeImg.MountPoint = constants.ActiveDir
 	if isoRootExists {
@@ -199,10 +199,10 @@ func NewInstallSpec(cfg v1.Config) *v1.InstallSpec {
 	recoveryImg.Source = v1.NewFileSrc(activeImg.File)
 	recoveryImg.FS = constants.LinuxImgFs
 	recoveryImg.Label = constants.SystemLabel
-	recoveryImg.File = filepath.Join(constants.RecoveryDir, "cOS", constants.RecoveryImgFile)
+	recoveryImg.File = filepath.Join(constants.RecoveryDir, constants.RecoveryImgPath)
 
 	passiveImg = v1.Image{
-		File:   filepath.Join(constants.StateDir, "cOS", constants.PassiveImgFile),
+		File:   filepath.Join(constants.StateDir, constants.PassiveImgPath),
 		Label:  constants.PassiveLabel,
 		Source: v1.NewFileSrc(activeImg.File),
 		FS:     constants.LinuxImgFs,
@@ -230,14 +230,13 @@ func NewInitSpec() *v1.InitSpec {
 
 func NewMountSpec() *v1.MountSpec {
 	return &v1.MountSpec{
-		Sysroot:       "/sysroot",
-		WriteFstab:    true,
-		WriteSentinel: true,
+		ReadKernelCmdline: true,
+		Sysroot:           "/sysroot",
+		WriteFstab:        true,
+		WriteSentinel:     true,
 		Image: &v1.Image{
-			Label:      constants.ActiveLabel,
+
 			FS:         constants.LinuxImgFs,
-			File:       filepath.Join(constants.RunningStateDir, "cOS", constants.ActiveImgFile),
-			Source:     v1.NewFileSrc(filepath.Join(constants.RunningStateDir, "cOS", constants.ActiveImgFile)),
 			MountPoint: "/sysroot",
 		},
 		Partitions: v1.ElementalPartitions{
@@ -497,7 +496,7 @@ func NewResetSpec(cfg v1.Config) (*v1.ResetSpec, error) {
 		cfg.Logger.Warnf("no Persistent partition found")
 	}
 
-	recoveryImg := filepath.Join(constants.RunningStateDir, "cOS", constants.RecoveryImgFile)
+	recoveryImg := filepath.Join(constants.RunningStateDir, constants.RecoveryImgPath)
 
 	if exists, _ := utils.Exists(cfg.Fs, recoveryImg); exists {
 		imgSource = v1.NewFileSrc(recoveryImg)
@@ -505,7 +504,7 @@ func NewResetSpec(cfg v1.Config) (*v1.ResetSpec, error) {
 		imgSource = v1.NewEmptySrc()
 	}
 
-	activeFile := filepath.Join(ep.State.MountPoint, "cOS", constants.ActiveImgFile)
+	activeFile := filepath.Join(ep.State.MountPoint, constants.ActiveImgPath)
 	return &v1.ResetSpec{
 		Target:       target,
 		Partitions:   ep,
@@ -521,7 +520,7 @@ func NewResetSpec(cfg v1.Config) (*v1.ResetSpec, error) {
 			MountPoint: constants.ActiveDir,
 		},
 		Passive: v1.Image{
-			File:   filepath.Join(ep.State.MountPoint, "cOS", constants.PassiveImgFile),
+			File:   filepath.Join(ep.State.MountPoint, constants.PassiveImgPath),
 			Label:  pState.Label,
 			Source: v1.NewFileSrc(activeFile),
 			FS:     aState.FS,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -266,7 +266,10 @@ func NewMountSpec() *v1.MountSpec {
 				Flags:           []string{},
 			},
 		},
-		RwPaths: []string{"/var", "/etc", "/srv"},
+		Overlay: v1.OverlayMounts{
+			Size:  "25%",
+			Paths: []string{"/var", "/etc", "/srv"},
+		},
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -270,6 +270,10 @@ func NewMountSpec() *v1.MountSpec {
 			Size:  "25%",
 			Paths: []string{"/var", "/etc", "/srv"},
 		},
+		Persistent: v1.PersistentMounts{
+			Mode:  constants.OverlayMode,
+			Paths: []string{"/etc/systemd", "/etc/ssh", "/home", "/opt", "/root", "/usr/libexec", "/var/log"},
+		},
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -234,6 +234,7 @@ func NewMountSpec() *v1.MountSpec {
 		Sysroot:           "/sysroot",
 		WriteFstab:        true,
 		RunCloudInit:      true,
+		RunFsck:           true,
 		Image: &v1.Image{
 			FS:         constants.LinuxImgFs,
 			MountPoint: "/sysroot",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -65,6 +65,9 @@ const (
 	ConfigDir          = "/etc/elemental"
 	OverlayMode        = "overlay"
 	BindMode           = "bind"
+	Tmpfs              = "tmpfs"
+	Autofs             = "auto"
+	Block              = "block"
 
 	// Mountpoints of images and partitions
 	RecoveryDir        = "/run/elemental/recovery"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -61,7 +61,6 @@ const (
 	ImgSize            = uint(0)
 	ImgOverhead        = uint(256)
 	HTTPTimeout        = 60
-	CosSetup           = "/usr/bin/cos-setup"
 	GPT                = "gpt"
 	BuildImgName       = "elemental"
 	UsrLocalPath       = "/usr/local"
@@ -69,15 +68,16 @@ const (
 	ConfigDir          = "/etc/elemental"
 
 	// Mountpoints of images and partitions
-	RecoveryDir     = "/run/cos/recovery"
-	StateDir        = "/run/cos/state"
-	OEMDir          = "/run/cos/oem"
-	PersistentDir   = "/run/cos/persistent"
-	ActiveDir       = "/run/cos/active"
-	TransitionDir   = "/run/cos/transition"
-	EfiDir          = "/run/cos/efi"
-	ImgSrcDir       = "/run/cos/imgsrc"
-	WorkingImgDir   = "/run/cos/workingtree"
+	RecoveryDir     = "/run/elemental/recovery"
+	StateDir        = "/run/elemental/state"
+	OEMDir          = "/run/elemental/oem"
+	PersistentDir   = "/run/elemental/persistent"
+	ActiveDir       = "/run/elemental/active"
+	TransitionDir   = "/run/elemental/transition"
+	EfiDir          = "/run/elemental/efi"
+	ImgSrcDir       = "/run/elemental/imgsrc"
+	WorkingImgDir   = "/run/elemental/workingtree"
+	OverlayDir      = "/run/elemental/overlay"
 	RunningStateDir = "/run/initramfs/cos-state" // TODO: converge this constant with StateDir/RecoveryDir in dracut module from cos-toolkit
 
 	// Live image mountpoints

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -66,19 +66,22 @@ const (
 	UsrLocalPath       = "/usr/local"
 	OEMPath            = "/oem"
 	ConfigDir          = "/etc/elemental"
+	OverlayMode        = "overlay"
+	BindMode           = "bind"
 
 	// Mountpoints of images and partitions
-	RecoveryDir     = "/run/elemental/recovery"
-	StateDir        = "/run/elemental/state"
-	OEMDir          = "/run/elemental/oem"
-	PersistentDir   = "/run/elemental/persistent"
-	ActiveDir       = "/run/elemental/active"
-	TransitionDir   = "/run/elemental/transition"
-	EfiDir          = "/run/elemental/efi"
-	ImgSrcDir       = "/run/elemental/imgsrc"
-	WorkingImgDir   = "/run/elemental/workingtree"
-	OverlayDir      = "/run/elemental/overlay"
-	RunningStateDir = "/run/initramfs/cos-state" // TODO: converge this constant with StateDir/RecoveryDir in dracut module from cos-toolkit
+	RecoveryDir        = "/run/elemental/recovery"
+	StateDir           = "/run/elemental/state"
+	OEMDir             = "/run/elemental/oem"
+	PersistentDir      = "/run/elemental/persistent"
+	PersistentStateDir = "/run/elemental/persistent/.state"
+	ActiveDir          = "/run/elemental/active"
+	TransitionDir      = "/run/elemental/transition"
+	EfiDir             = "/run/elemental/efi"
+	ImgSrcDir          = "/run/elemental/imgsrc"
+	WorkingImgDir      = "/run/elemental/workingtree"
+	OverlayDir         = "/run/elemental/overlay"
+	RunningStateDir    = "/run/initramfs/cos-state" // TODO: converge this constant with StateDir/RecoveryDir in dracut module from cos-toolkit
 
 	// Live image mountpoints
 	ISOBaseTree = "/run/rootfsbase"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -41,9 +41,6 @@ const (
 	PersistentPartName = "persistent"
 	OEMLabel           = "COS_OEM"
 	OEMPartName        = "oem"
-	ActiveImgName      = "active"
-	PassiveImgName     = "passive"
-	RecoveryImgName    = "recovery"
 	MountBinary        = "/usr/bin/mount"
 	EfiDevice          = "/sys/firmware/efi"
 	LinuxFs            = "ext4"
@@ -81,17 +78,23 @@ const (
 	ImgSrcDir          = "/run/elemental/imgsrc"
 	WorkingImgDir      = "/run/elemental/workingtree"
 	OverlayDir         = "/run/elemental/overlay"
-	RunningStateDir    = "/run/initramfs/cos-state" // TODO: converge this constant with StateDir/RecoveryDir in dracut module from cos-toolkit
+	RunningStateDir    = "/run/initramfs/cos-state" // TODO: converge this constant with StateDir/RecoveryDir when moving to elemental-rootfs as default rootfs feature.
 
 	// Live image mountpoints
 	ISOBaseTree = "/run/rootfsbase"
 	LiveDir     = "/run/initramfs/live"
 
-	// Image file names
+	// Image constants
+	ActiveImgName     = "active"
+	PassiveImgName    = "passive"
+	RecoveryImgName   = "recovery"
 	ActiveImgFile     = "active.img"
 	PassiveImgFile    = "passive.img"
 	RecoveryImgFile   = "recovery.img"
 	TransitionImgFile = "transition.img"
+	ActiveImgPath     = "/cOS/active.img"
+	PassiveImgPath    = "/cOS/passive.img"
+	RecoveryImgPath   = "/cOS/recovery.img"
 
 	// Yip stages evaluated on reset/upgrade/install/build-disk actions
 	AfterInstallChrootHook = "after-install-chroot"
@@ -186,6 +189,16 @@ func GetInitKeyEnvMap() map[string]string {
 	return map[string]string{
 		"mkinitrd": "MKINITRD",
 		"force":    "FORCE",
+	}
+}
+
+// GetMountKeyEnvMap returns environment variable bindings to MountSpec data
+func GetMountKeyEnvMap() map[string]string {
+	return map[string]string{
+		"write-fstab":         "WRITE_FSTAB",
+		"write-sentinel":      "WRITE_SENTINEL",
+		"sysroot":             "SYSROOT",
+		"read-kernel-cmdline": "READ_KERNEL_CMDLINE",
 	}
 }
 

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -222,7 +222,9 @@ func (e Elemental) FsckPartitions(partitions v1.PartitionList) error {
 		}
 
 		e.config.Logger.Debugf("Fscking device '%s'", part.Path)
-		if _, err := e.config.Runner.Run("systemd-fsck", part.Path); err != nil {
+		stdout, err := e.config.Runner.Run("systemd-fsck", part.Path)
+		e.config.Logger.Debugf("Fsck output: %s", stdout)
+		if err != nil {
 			e.config.Logger.Errorf("Fsck error for device '%s': %s", part.Path, err.Error())
 			return err
 		}

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -287,7 +287,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			img = &v1.Image{
 				Label:      constants.ActiveLabel,
 				Size:       32,
-				File:       filepath.Join(constants.StateDir, "cOS", constants.ActiveImgFile),
+				File:       filepath.Join(constants.StateDir, constants.ActiveImgPath),
 				FS:         constants.LinuxImgFs,
 				MountPoint: constants.ActiveDir,
 				Source:     v1.NewDirSrc(constants.ISOBaseTree),

--- a/pkg/features/embedded/elemental-rootfs/etc/dracut.conf.d/02-elemental-rootfs.conf
+++ b/pkg/features/embedded/elemental-rootfs/etc/dracut.conf.d/02-elemental-rootfs.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" elemental-rootfs "

--- a/pkg/features/embedded/elemental-rootfs/etc/dracut.conf.d/02-elemental-setup-initramfs.conf
+++ b/pkg/features/embedded/elemental-rootfs/etc/dracut.conf.d/02-elemental-setup-initramfs.conf
@@ -1,0 +1,4 @@
+install_items+=" /usr/lib/systemd/system/elemental-setup-initramfs.service /etc/systemd/system/initrd.target.requires/elemental-setup-initramfs.service "
+install_items+=" /usr/lib/systemd/system/elemental-setup-rootfs.service /etc/systemd/system/initrd-fs.target.requires/elemental-setup-rootfs.service "
+install_items+=" /etc/hosts "
+add_dracutmodules+=" network "

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/elemental-cmdline.sh
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/elemental-cmdline.sh
@@ -1,0 +1,38 @@
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.cos.disable; then
+    return 0
+fi
+
+if getargbool 0 elemental.disable; then
+    return 0
+fi
+
+elemental_img=$(getarg elemental.image=)
+mkdir -p /run/elemental
+case "${elemental_img}" in
+    *recovery*)
+        echo -n 1 > /run/elemental/recovery_mode ;;
+    *active*)
+        echo -n 1 > /run/elemental/active_mode ;;
+    *passive*)
+        echo -n 1 > /run/elemental/passive_mode ;;
+esac
+
+cos_img=$(getarg cos-img/filename=)
+[ -z "${cos_img}" ] && return 0
+
+# set sentinel file for boot mode
+mkdir -p /run/cos
+case "${cos_img}" in
+    *recovery*)
+        echo -n 1 > /run/cos/recovery_mode ;;
+    *active*)
+        echo -n 1 > /run/cos/active_mode ;;
+    *passive*)
+        echo -n 1 > /run/cos/passive_mode ;;
+esac
+
+
+return 0
+

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/elemental-generator.sh
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/elemental-generator.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if [ ! -e "$GENERATOR_DIR/initrd-root-fs.target.requires/sysroot.mount" ]; then
+    mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires
+    ln -s "$GENERATOR_DIR"/sysroot.mount \
+        "$GENERATOR_DIR"/initrd-root-fs.target.requires/sysroot.mount
+fi

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/elemental-rootfs.service
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/elemental-rootfs.service
@@ -9,6 +9,4 @@ Conflicts=initrd-switch-root.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-EnvironmentFile=-/run/cos/cos-layout.env
-EnvironmentFile=-/run/elemental/layout.env
 ExecStart=/usr/bin/elemental mount --debug

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/elemental-rootfs.service
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/elemental-rootfs.service
@@ -9,4 +9,6 @@ Conflicts=initrd-switch-root.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+EnvironmentFile=-/run/cos/cos-layout.env
+EnvironmentFile=-/run/elemental/layout.env
 ExecStart=/usr/bin/elemental mount --debug

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/elemental-rootfs.service
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/elemental-rootfs.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Elemental system rootfs mounts
+DefaultDependencies=no
+After=initrd-root-fs.target elemental-setup-rootfs.service
+Requires=initrd-root-fs.target
+Before=initrd-fs.target
+Conflicts=initrd-switch-root.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/elemental mount --debug

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/module-setup.sh
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/module-setup.sh
@@ -32,6 +32,7 @@ install() {
     # probably a devoted dracut module makes sense
     inst_multiple -o \
         "$systemdutildir"/systemd-fsck partprobe sync udevadm parted mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat mkfs.xfs blkid e2fsck resize2fs mount xfs_growfs umount sgdisk elemental
+    inst_hook cmdline 30 "${moddir}/elemental-cmdline.sh"
     inst_script "${moddir}/elemental-generator.sh" \
         "${systemdutildir}/system-generators/dracut-elemental-generator"
     inst_simple "${moddir}/elemental-rootfs.service" \

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/module-setup.sh
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/module-setup.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    require_binaries "$systemdutildir"/systemd || return 1
+    return 255
+}
+
+# called by dracut 
+depends() {
+    echo systemd rootfs-block dm fs-lib
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    instmods overlay
+}
+
+# called by dracut
+install() {
+    declare moddir=${moddir}
+    declare systemdutildir=${systemdutildir}
+    declare systemdsystemunitdir=${systemdsystemunitdir}
+
+    inst_multiple \
+        mount mountpoint sort rmdir findmnt rsync cut realpath basename lsblk
+
+    inst_simple "/etc/elemental/config.yaml"
+
+    # Include utilities required for elemental-setup services,
+    # probably a devoted dracut module makes sense
+    inst_multiple -o \
+        "$systemdutildir"/systemd-fsck partprobe sync udevadm parted mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat mkfs.xfs blkid e2fsck resize2fs mount xfs_growfs umount sgdisk elemental
+    inst_script "${moddir}/elemental-generator.sh" \
+        "${systemdutildir}/system-generators/dracut-elemental-generator"
+    inst_simple "${moddir}/elemental-rootfs.service" \
+        "${systemdsystemunitdir}/elemental-rootfs.service"
+    mkdir -p "${initdir}/${systemdsystemunitdir}/initrd-fs.target.requires"
+    ln_r "../elemental-rootfs.service" \
+        "${systemdsystemunitdir}/initrd-fs.target.requires/elemental-rootfs.service"
+    ln_r "$systemdutildir"/systemd-fsck \
+        "/sbin/systemd-fsck"
+    dracut_need_initqueue
+}

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-boot.service
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-boot.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Elemental system configuration
+Before=getty.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/elemental run-stage boot
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-fs.service
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-fs.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Elemental system after FS setup
+DefaultDependencies=no
+After=local-fs.target
+Wants=local-fs.target
+Before=sysinit.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/elemental run-stage fs
+
+[Install]
+WantedBy=sysinit.target

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-initramfs.service
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-initramfs.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Elemental system initramfs setup before switch root
+DefaultDependencies=no
+After=initrd-fs.target
+Requires=initrd-fs.target
+Before=initrd.target
+
+[Service]
+RootDirectory=/sysroot
+BindPaths=/proc /sys /dev /run /tmp
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/elemental run-stage initramfs
+
+[Install]
+RequiredBy=initrd.target

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-network.service
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-network.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Elemental setup after network
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Nice=19
+IOSchedulingClass=2
+IOSchedulingPriority=7
+Type=oneshot
+ExecStart=/usr/bin/elemental run-stage network
+TimeoutStopSec=180
+KillMode=process
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-reconcile.service
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-reconcile.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Elemental setup reconciler
+
+[Service]
+Nice=19
+IOSchedulingClass=2
+IOSchedulingPriority=7
+Type=oneshot
+ExecStart=/bin/bash -c "systemd-inhibit /usr/bin/elemental run-stage reconcile"
+TimeoutStopSec=180
+KillMode=process
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-reconcile.timer
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-reconcile.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Elemental setup reconciler
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=60min
+Unit=elemental-setup-reconcile.service
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-rootfs.service
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-setup-rootfs.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Elemental system early rootfs setup
+DefaultDependencies=no
+After=initrd-root-fs.target
+Requires=initrd-root-fs.target
+Conflicts=initrd-switch-root.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/usr/bin/ln -sf -t / /sysroot/system
+ExecStart=/usr/bin/elemental run-stage rootfs
+
+[Install]
+RequiredBy=initrd-fs.target

--- a/pkg/features/embedded/grub-config/etc/cos/grub.cfg
+++ b/pkg/features/embedded/grub-config/etc/cos/grub.cfg
@@ -49,6 +49,7 @@ menuentry "${display_name}" --id cos {
   # label is kept around for backward compatibility
   set label=${active_label}
   set img=/cOS/active.img
+  set mode=active
   loopback $loopdev /$img
   source ($loopdev)/etc/cos/bootargs.cfg
   linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_active_cmdline}
@@ -60,6 +61,7 @@ menuentry "${display_name} (fallback)" --id fallback {
   # label is kept around for backward compatibility
   set label=${passive_label}
   set img=/cOS/passive.img
+  set mode=passive
   loopback $loopdev /$img
   source ($loopdev)/etc/cos/bootargs.cfg
   linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_passive_cmdline}
@@ -75,6 +77,7 @@ menuentry "${display_name} recovery" --id recovery {
     set recoverylabel=${recovery_label}
   fi
   set img=/cOS/recovery.img
+  set mode=recovery
   search --no-floppy --label --set=root $recovery_label
   loopback $loopdev /$img
   source ($loopdev)/etc/cos/bootargs.cfg

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -36,6 +36,7 @@ const (
 	embeddedRoot = "embedded"
 
 	FeatureImmutableRootfs       = "immutable-rootfs"
+	FeatureElementalRootfs       = "elemental-rootfs"
 	FeatureGrubConfig            = "grub-config"
 	FeatureGrubDefaultBootargs   = "grub-default-bootargs"
 	FeatureElementalSetup        = "elemental-setup"
@@ -133,6 +134,8 @@ func Get(names []string) ([]*Feature, error) {
 		case FeatureCloudConfigEssentials:
 			features = append(features, New(name, nil))
 		case FeatureImmutableRootfs:
+			features = append(features, New(name, nil))
+		case FeatureElementalRootfs:
 			features = append(features, New(name, nil))
 		case FeatureDracutConfig:
 			features = append(features, New(name, nil))

--- a/pkg/systemd/unit.go
+++ b/pkg/systemd/unit.go
@@ -34,3 +34,8 @@ func Enable(runner v1.Runner, unit *Unit) error {
 	_, err := runner.Run("systemctl", "enable", unit.Name)
 	return err
 }
+
+func Start(runner v1.Runner, unit *Unit) error {
+	_, err := runner.Run("systemctl", "start", unit.Name)
+	return err
+}

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -242,6 +242,7 @@ type MountSpec struct {
 	ReadKernelCmdline bool   `yaml:"read-kernel-cmdline,omitempty" mapstructure:"read-kernel-cmdline"`
 	WriteFstab        bool   `yaml:"write-fstab,omitempty" mapstructure:"write-fstab"`
 	RunCloudInit      bool   `yaml:"run-cloud-init,omitempty" mapstructure:"run-cloud-init"`
+	RunFsck           bool   `yaml:"run-fsck,omitempty" mapstructure:"run-fsck"`
 	Disable           bool   `yaml:"disable,omitempty" mapstructure:"disable"`
 	Sysroot           string `yaml:"sysroot,omitempty" mapstructure:"sysroot"`
 	Mode              string `yaml:"mode,omitempty" mapstructure:"mode"`

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -245,7 +245,7 @@ type MountSpec struct {
 	Sysroot           string `yaml:"sysroot,omitempty" mapstructure:"sysroot"`
 	Image             *Image `yaml:"image,omitempty" mapstructure:"image"`
 	Partitions        ElementalPartitions
-	RwPaths           []string         `yaml:"rw-paths,omitempty" mapstructure:"rw-paths"`
+	Overlay           OverlayMounts    `yaml:"overlay,omitempty" mapstructure:"overlay"`
 	Persistent        PersistentMounts `yaml:"persistent,omitempty" mapstructure:"persistent"`
 }
 
@@ -253,6 +253,11 @@ type MountSpec struct {
 // persistent
 type PersistentMounts struct {
 	Mode  string   `yaml:"mode,omitempty" mapstructure:"mode"`
+	Paths []string `yaml:"paths,omitempty" mapstructure:"paths"`
+}
+
+type OverlayMounts struct {
+	Size  string   `yaml:"mode,omitempty" mapstructure:"mode"`
 	Paths []string `yaml:"paths,omitempty" mapstructure:"paths"`
 }
 

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -258,6 +258,8 @@ type PersistentMounts struct {
 	Paths []string `yaml:"paths,omitempty" mapstructure:"paths"`
 }
 
+// OverlayMounts contains information about the RW overlay mounted over the
+// immutable system.
 type OverlayMounts struct {
 	Type   string   `yaml:"type,omitempty" mapstructure:"type"`
 	Device string   `yaml:"device,omitempty" mapstructure:"device"`

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -288,6 +288,9 @@ func (spec *MountSpec) Sanitize() error {
 	case constants.RecoveryImgName:
 		spec.Image.Label = constants.ActiveLabel
 		spec.Image.File = filepath.Join(constants.RunningStateDir, constants.RecoveryImgPath)
+
+		spec.Partitions.State.MountPoint = ""
+		spec.Partitions.Recovery.MountPoint = constants.RunningStateDir
 	default:
 		return fmt.Errorf("Unknown mode '%s'", spec.Mode)
 	}

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -229,11 +229,31 @@ func (i *InstallSpec) Sanitize() error {
 	return i.Partitions.SetFirmwarePartitions(i.Firmware, i.PartTable)
 }
 
+// InitSpec struct represents all the init action details
 type InitSpec struct {
 	Mkinitrd bool `yaml:"mkinitrd,omitempty" mapstructure:"mkinitrd"`
 	Force    bool `yaml:"force,omitempty" mapstructure:"force"`
 
 	Features []string `yaml:"features,omitempty" mapstructure:"features"`
+}
+
+// MountSpec struct represents all the mount action details
+type MountSpec struct {
+	ReadKernelCmdline bool   `yaml:"read-kernel-cmdline,omitempty" mapstructure:"read-kernel-cmdline"`
+	WriteFstab        bool   `yaml:"write-fstab,omitempty" mapstructure:"write-fstab"`
+	WriteSentinel     bool   `yaml:"write-sentinel,omitempty" mapstructure:"write-sentinel"`
+	Sysroot           string `yaml:"sysroot,omitempty" mapstructure:"sysroot"`
+	Image             *Image `yaml:"image,omitempty" mapstructure:"image"`
+	Partitions        ElementalPartitions
+	RwPaths           []string         `yaml:"rw-paths,omitempty" mapstructure:"rw-paths"`
+	Persistent        PersistentMounts `yaml:"persistent,omitempty" mapstructure:"persistent"`
+}
+
+// PersistentMounts struct contains settings for which paths to mount as
+// persistent
+type PersistentMounts struct {
+	Mode  string   `yaml:"mode,omitempty" mapstructure:"mode"`
+	Paths []string `yaml:"paths,omitempty" mapstructure:"paths"`
 }
 
 // ResetSpec struct represents all the reset action details

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -241,7 +241,7 @@ type InitSpec struct {
 type MountSpec struct {
 	ReadKernelCmdline bool   `yaml:"read-kernel-cmdline,omitempty" mapstructure:"read-kernel-cmdline"`
 	WriteFstab        bool   `yaml:"write-fstab,omitempty" mapstructure:"write-fstab"`
-	RunCloudInit      bool   `yaml:"run-cloud-init,omitempty" mapstructure:"run-cloud-init"`
+	RunRootfsService  bool   `yaml:"run-rootfs-service,omitempty" mapstructure:"run-rootfs-service"`
 	RunFsck           bool   `yaml:"run-fsck,omitempty" mapstructure:"run-fsck"`
 	Disable           bool   `yaml:"disable,omitempty" mapstructure:"disable"`
 	Sysroot           string `yaml:"sysroot,omitempty" mapstructure:"sysroot"`

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -259,7 +259,7 @@ type PersistentMounts struct {
 }
 
 type OverlayMounts struct {
-	Size  string   `yaml:"mode,omitempty" mapstructure:"mode"`
+	Size  string   `yaml:"size,omitempty" mapstructure:"size"`
 	Paths []string `yaml:"paths,omitempty" mapstructure:"paths"`
 }
 

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -132,7 +132,7 @@ func ConcatFiles(fs v1.FS, sources []string, target string) (err error) {
 // CreateDirStructure creates essentials directories under the root tree that might not be present
 // within a container image (/dev, /run, etc.)
 func CreateDirStructure(fs v1.FS, target string) error {
-	for _, dir := range []string{"/run", "/dev", "/boot", "/usr/local", "/oem", "/system", "/etc/elemental/config.d"} {
+	for _, dir := range []string{"/run", "/dev", "/boot", "/oem", "/system", "/etc/elemental/config.d"} {
 		err := MkdirAll(fs, filepath.Join(target, dir), constants.DirPerm)
 		if err != nil {
 			return err

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -431,7 +431,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 	})
 	Describe("CreateDirStructure", Label("CreateDirStructure"), func() {
 		It("Creates essential directories", func() {
-			dirList := []string{"sys", "proc", "dev", "tmp", "boot", "usr/local", "oem"}
+			dirList := []string{"sys", "proc", "dev", "tmp", "boot", "oem"}
 			for _, dir := range dirList {
 				_, err := fs.Stat(fmt.Sprintf("/my/root/%s", dir))
 				Expect(err).NotTo(BeNil())


### PR DESCRIPTION
The mount command mounts the system and is meant to run in an initrd to actually mount the root filesystem and use systemd to switch-root into it.

It also optionally writes an /etc/fstab file to the newly mounted system so that systemd will mount the system after switching root.

The command is used in the new dracut module elemental-rootfs, which will coexist with immutable-rootfs (they are functionally the same) until immutable-rootfs can be deprecated.

Fixes #1781, #1830