### PR TITLE
feat(partitioner): call partprobe after udevadm

### DIFF
--- a/pkg/partitioner/disk.go
+++ b/pkg/partitioner/disk.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -318,14 +317,6 @@ func (dev Disk) FindPartitionDevice(partNum int) (string, error) {
 	for tries := 0; tries <= partitionTries; tries++ {
 		dev.logger.Debugf("Trying to find the partition device %d of device %s (try number %d)", partNum, dev, tries+1)
 		_, _ = dev.runner.Run("udevadm", "settle")
-
-		if id := dev.getMajorID(); string(id) != "" {
-			out, err := dev.runner.Run("mknod", device, "b", string(id), fmt.Sprint(partNum))
-			if err != nil {
-				dev.logger.Debugf("mknod failed: %s: %s", err.Error(), string(out))
-			}
-		}
-
 		if exists, _ := utils.Exists(dev.fs, device); exists {
 			return device, nil
 		}
@@ -436,17 +427,4 @@ func (dev Disk) expandFilesystem(device string) (string, error) {
 	}
 
 	return "", nil
-}
-
-func (d *Disk) getMajorID() []byte {
-	re := regexp.MustCompile(`\d+$`)
-
-	match := re.Find([]byte(d.device))
-
-	_, err := strconv.Atoi(string(match))
-	if err != nil {
-		return []byte{}
-	}
-
-	return match
 }

--- a/pkg/partitioner/disk.go
+++ b/pkg/partitioner/disk.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -317,7 +318,14 @@ func (dev Disk) FindPartitionDevice(partNum int) (string, error) {
 	for tries := 0; tries <= partitionTries; tries++ {
 		dev.logger.Debugf("Trying to find the partition device %d of device %s (try number %d)", partNum, dev, tries+1)
 		_, _ = dev.runner.Run("udevadm", "settle")
-		_, _ = dev.runner.Run("partprobe")
+
+		if id := dev.getMajorID(); string(id) != "" {
+			out, err := dev.runner.Run("mknod", device, "b", string(id), fmt.Sprint(partNum))
+			if err != nil {
+				dev.logger.Debugf("mknod failed: %s: %s", err.Error(), string(out))
+			}
+		}
+
 		if exists, _ := utils.Exists(dev.fs, device); exists {
 			return device, nil
 		}
@@ -428,4 +436,17 @@ func (dev Disk) expandFilesystem(device string) (string, error) {
 	}
 
 	return "", nil
+}
+
+func (d *Disk) getMajorID() []byte {
+	re := regexp.MustCompile(`\d+$`)
+
+	match := re.Find([]byte(d.device))
+
+	_, err := strconv.Atoi(string(match))
+	if err != nil {
+		return []byte{}
+	}
+
+	return match
 }

--- a/pkg/partitioner/disk.go
+++ b/pkg/partitioner/disk.go
@@ -317,6 +317,7 @@ func (dev Disk) FindPartitionDevice(partNum int) (string, error) {
 	for tries := 0; tries <= partitionTries; tries++ {
 		dev.logger.Debugf("Trying to find the partition device %d of device %s (try number %d)", partNum, dev, tries+1)
 		_, _ = dev.runner.Run("udevadm", "settle")
+		_, _ = dev.runner.Run("partprobe")
 		if exists, _ := utils.Exists(dev.fs, device); exists {
 			return device, nil
 		}

--- a/pkg/partitioner/parted.go
+++ b/pkg/partitioner/parted.go
@@ -128,6 +128,10 @@ func (pc *PartedCall) WriteChanges() (string, error) {
 	pc.wipe = false
 	pc.parts = []*Partition{}
 	pc.deletions = []int{}
+
+	// Notify kernel of partition table changes, swallows errors, just a best effort call
+	_, _ = pc.runner.Run("partprobe", pc.dev)
+
 	return string(out), err
 }
 


### PR DESCRIPTION
I encountered an issue while running the elemental toolkit in the Earthly, where the partition device 1 of device `/dev/loop2` could not be found. Calling `partprobe` shows the partition that we want. The fix is small and simple, and does not introduce additional dependency, as `partprobe` is part of `parted` package.

```log
buildkitsandbox:/work # qemu-img create -f raw a.img 32G
Formatting 'a.img', fmt=raw size=34359738368
buildkitsandbox:/work # losetup -f --show a.img 
/dev/loop2
buildkitsandbox:/work # elemental install --debug --firmware efi --system.uri 'oci:ghcr.io/doomshrine/cadia:v1.0.0' /dev/loop2
DEBU[2023-10-06T13:33:27Z] Starting elemental version v1.0.0 on commit 17e4895c6a6863f7eb22b0c4fdddd2dc297f71b8 
INFO[2023-10-06T13:33:27Z] Reading configuration from '/etc/elemental'  
DEBU[2023-10-06T13:33:27Z] Full config loaded: &v1.RunConfig{
  Reboot: false,
  PowerOff: false,
  EjectCD: false,
  Config: v1.Config{
    Logger: &v1.logrusWrapper{ // p0
      Logger: &logrus.Logger{
        Out: &os.File{},
        Hooks: logrus.LevelHooks{},
        Formatter: &logrus.TextFormatter{
          ForceColors: true,
          DisableColors: false,
          ForceQuote: false,
          DisableQuote: false,
          EnvironmentOverrideColors: false,
          DisableTimestamp: false,
          FullTimestamp: true,
          TimestampFormat: "",
          DisableSorting: false,
          SortingFunc: ,
          DisableLevelTruncation: false,
          PadLevelText: false,
          QuoteEmptyFields: false,
          FieldMap: logrus.FieldMap(nil),
          CallerPrettyfier: ,
        },
        ReportCaller: false,
        Level: 5,
        ExitFunc: os.Exit,
        BufferPool: nil,
      },
    },
    Fs: &vfs.osfs{}, // p1
    Mounter: &mount.Mounter{},
    Runner: &v1.RealRunner{ // p2
      Logger: p0,
    },
    Syscall: &v1.RealSyscall{},
    CloudInitRunner: &cloudinit.YipCloudInitRunner{},
    ImageExtractor: v1.OCIImageExtractor{},
    Client: &http.Client{},
    Platform: &v1.Platform{
      OS: "linux",
      Arch: "arm64",
      GolangArch: "arm64",
    },
    Cosign: false,
    Verify: false,
    CosignPubKey: "",
    LocalImage: false,
    Arch: "",
    SquashFsCompressionConfig: []string{
      "-comp",
      "xz",
      "-Xbcj",
      "arm",
    },
    SquashFsNoCompression: false,
    CloudInitPaths: []string{
      "/system/oem",
      "/oem/",
      "/usr/local/cloud-config/",
    },
    Strict: false,
  },
} 
DEBU[2023-10-06T13:33:27Z] Loaded install spec: &v1.InstallSpec{
  Target: "",
  Firmware: "efi",
  PartTable: "gpt",
  Partitions: v1.ElementalPartitions{
    BIOS: nil,
    EFI: &v1.Partition{
      Name: "efi",
      FilesystemLabel: "COS_GRUB",
      Size: 64,
      FS: "vfat",
      Flags: []string{
        "esp",
      },
      MountPoint: "/run/cos/efi",
      Path: "",
      Disk: "",
    },
    OEM: &v1.Partition{
      Name: "oem",
      FilesystemLabel: "COS_OEM",
      Size: 64,
      FS: "ext4",
      Flags: []string{}, // p0
      MountPoint: "/run/cos/oem",
      Path: "",
      Disk: "",
    },
    Recovery: &v1.Partition{
      Name: "recovery",
      FilesystemLabel: "COS_RECOVERY",
      Size: 4096,
      FS: "ext4",
      Flags: p0,
      MountPoint: "/run/cos/recovery",
      Path: "",
      Disk: "",
    },
    State: &v1.Partition{
      Name: "state",
      FilesystemLabel: "COS_STATE",
      Size: 8192,
      FS: "ext4",
      Flags: p0,
      MountPoint: "/run/cos/state",
      Path: "",
      Disk: "",
    },
    Persistent: &v1.Partition{
      Name: "persistent",
      FilesystemLabel: "COS_PERSISTENT",
      Size: 0,
      FS: "ext4",
      Flags: p0,
      MountPoint: "/run/cos/persistent",
      Path: "",
      Disk: "",
    },
  },
  ExtraPartitions: nil,
  NoFormat: false,
  Force: false,
  CloudInit: nil,
  Iso: "",
  GrubDefEntry: "",
  Active: v1.Image{
    File: "/run/cos/state/cOS/active.img",
    Label: "COS_ACTIVE",
    Size: 0,
    FS: "ext2",
    Source: &v1.ImageSource{},
    MountPoint: "/run/cos/active",
    LoopDevice: "",
  },
  Recovery: v1.Image{
    File: "/run/cos/recovery/cOS/recovery.img",
    Label: "COS_SYSTEM",
    Size: 0,
    FS: "ext2",
    Source: &v1.ImageSource{},
    MountPoint: "",
    LoopDevice: "",
  },
  Passive: v1.Image{
    File: "/run/cos/state/cOS/passive.img",
    Label: "COS_PASSIVE",
    Size: 0,
    FS: "ext2",
    Source: &v1.ImageSource{},
    MountPoint: "",
    LoopDevice: "",
  },
  GrubConf: "/etc/cos/grub.cfg",
  DisableBootEntry: false,
} 
INFO[2023-10-06T13:33:27Z] Install called                               
DEBU[2023-10-06T13:33:27Z] Running cmd: 'blkdeactivate --lvmoptions retry,wholevg --dmoptions force,retry --errors' 
DEBU[2023-10-06T13:33:27Z] blkdeactivate command output: Deactivating block devices: 
INFO[2023-10-06T13:33:27Z] Partitioning device...                       
DEBU[2023-10-06T13:33:27Z] Running cmd: 'parted --script --machine -- /dev/loop2 unit s mklabel gpt' 
DEBU[2023-10-06T13:33:27Z] Running cmd: 'parted --script --machine -- /dev/loop2 unit s print' 
DEBU[2023-10-06T13:33:27Z] Adding partition efi                         
DEBU[2023-10-06T13:33:27Z] Running cmd: 'parted --script --machine -- /dev/loop2 unit s mkpart efi fat32 2048 133119 set 1 esp on' 
DEBU[2023-10-06T13:33:27Z] partitioner output:                          
DEBU[2023-10-06T13:33:27Z] Running cmd: 'parted --script --machine -- /dev/loop2 unit s print' 
DEBU[2023-10-06T13:33:27Z] Trying to find the partition device 1 of device /dev/loop2 (try number 1) 
DEBU[2023-10-06T13:33:27Z] Running cmd: 'udevadm settle'                
DEBU[2023-10-06T13:33:28Z] Trying to find the partition device 1 of device /dev/loop2 (try number 2) 
DEBU[2023-10-06T13:33:28Z] Running cmd: 'udevadm settle'                
DEBU[2023-10-06T13:33:29Z] Trying to find the partition device 1 of device /dev/loop2 (try number 3) 
DEBU[2023-10-06T13:33:29Z] Running cmd: 'udevadm settle'                
DEBU[2023-10-06T13:33:31Z] Trying to find the partition device 1 of device /dev/loop2 (try number 4) 
DEBU[2023-10-06T13:33:31Z] Running cmd: 'udevadm settle'                
DEBU[2023-10-06T13:33:32Z] Trying to find the partition device 1 of device /dev/loop2 (try number 5) 
DEBU[2023-10-06T13:33:32Z] Running cmd: 'udevadm settle'                
DEBU[2023-10-06T13:33:33Z] Trying to find the partition device 1 of device /dev/loop2 (try number 6) 
DEBU[2023-10-06T13:33:33Z] Running cmd: 'udevadm settle'                
DEBU[2023-10-06T13:33:34Z] Trying to find the partition device 1 of device /dev/loop2 (try number 7) 
DEBU[2023-10-06T13:33:34Z] Running cmd: 'udevadm settle'                
DEBU[2023-10-06T13:33:35Z] Trying to find the partition device 1 of device /dev/loop2 (try number 8) 
DEBU[2023-10-06T13:33:35Z] Running cmd: 'udevadm settle'                
DEBU[2023-10-06T13:33:36Z] Trying to find the partition device 1 of device /dev/loop2 (try number 9) 
DEBU[2023-10-06T13:33:36Z] Running cmd: 'udevadm settle'                
DEBU[2023-10-06T13:33:37Z] Trying to find the partition device 1 of device /dev/loop2 (try number 10) 
DEBU[2023-10-06T13:33:37Z] Running cmd: 'udevadm settle'                
DEBU[2023-10-06T13:33:38Z] Trying to find the partition device 1 of device /dev/loop2 (try number 11) 
DEBU[2023-10-06T13:33:38Z] Running cmd: 'udevadm settle'                
Error: 1 error occurred:
        * could not find partition device '/dev/loop2p1' for partition 1


buildkitsandbox:/work # lsblk
NAME      MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
loop0       7:0    0  633M  1 loop 
loop1       7:1    0   32G  0 loop 
loop2       7:2    0   32G  0 loop 
`-loop2p1 259:3    0   64M  0 part 
nbd0       43:0    0    0B  0 disk 
nbd1       43:32   0    0B  0 disk 
nbd2       43:64   0    0B  0 disk 
nbd3       43:96   0    0B  0 disk 
nbd4       43:128  0    0B  0 disk 
nbd5       43:160  0    0B  0 disk 
nbd6       43:192  0    0B  0 disk 
nbd7       43:224  0    0B  0 disk 
vda       254:0    0 59.6G  0 disk 
`-vda1    254:1    0 59.6G  0 part /dev/otel-grpc.sock
                                   /etc/hosts
                                   /etc/resolv.conf
nbd8       43:256  0    0B  0 disk 
nbd9       43:288  0    0B  0 disk 
nbd10      43:320  0    0B  0 disk 
nbd11      43:352  0    0B  0 disk 
nbd12      43:384  0    0B  0 disk 
nbd13      43:416  0    0B  0 disk 
nbd14      43:448  0    0B  0 disk 
nbd15      43:480  0    0B  0 disk 
buildkitsandbox:/work # partprobe
buildkitsandbox:/work # lsblk
NAME      MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
loop0       7:0    0  633M  1 loop 
loop1       7:1    0   32G  0 loop 
`-loop1p1 259:2    0   64M  0 part 
loop2       7:2    0   32G  0 loop 
`-loop2p1 259:3    0   64M  0 part 
nbd0       43:0    0    0B  0 disk 
nbd1       43:32   0    0B  0 disk 
nbd2       43:64   0    0B  0 disk 
nbd3       43:96   0    0B  0 disk 
nbd4       43:128  0    0B  0 disk 
nbd5       43:160  0    0B  0 disk 
nbd6       43:192  0    0B  0 disk 
nbd7       43:224  0    0B  0 disk 
vda       254:0    0 59.6G  0 disk 
`-vda1    254:1    0 59.6G  0 part /dev/otel-grpc.sock
                                   /etc/hosts
                                   /etc/resolv.conf
nbd8       43:256  0    0B  0 disk 
nbd9       43:288  0    0B  0 disk 
nbd10      43:320  0    0B  0 disk 
nbd11      43:352  0    0B  0 disk 
nbd12      43:384  0    0B  0 disk 
nbd13      43:416  0    0B  0 disk 
nbd14      43:448  0    0B  0 disk 
nbd15      43:480  0    0B  0 disk 
buildkitsandbox:/work # exit
```