### PR TITLE
Make use of partx instead of partprobe

### DIFF
--- a/.obs/specfile/elemental-toolkit.spec
+++ b/.obs/specfile/elemental-toolkit.spec
@@ -36,6 +36,8 @@ Requires:       udev
 Requires:       xfsprogs
 Requires:       xorriso
 Requires:       mtools
+Requires:       util-linux
+Requires:       gptfdisk
 
 %if 0%{?suse_version}
 BuildRequires:  golang(API) >= 1.18

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -277,7 +277,7 @@ var _ = Describe("Build Actions", func() {
 				{"mkfs.ext4", "-L", "COS_PERSISTENT"},
 				{"losetup", "--show", "-f", "/tmp/test/build/persistent.part"},
 				{"sgdisk", "-p", "/tmp/test/elemental.raw"},
-				{"partprobe", "/tmp/test/elemental.raw"},
+				{"partx", "-u", "/tmp/test/elemental.raw"},
 			})).To(Succeed())
 		})
 		It("Successfully builds a full raw disk with an unprivileged setup", func() {
@@ -303,7 +303,7 @@ var _ = Describe("Build Actions", func() {
 				{"mkfs.ext4", "-L", "COS_STATE"},
 				{"mkfs.ext4", "-L", "COS_PERSISTENT"},
 				{"sgdisk", "-p", "/tmp/test/elemental.raw"},
-				{"partprobe", "/tmp/test/elemental.raw"},
+				{"partx", "-u", "/tmp/test/elemental.raw"},
 			})).To(Succeed())
 		})
 		It("Successfully builds a full raw disk with an unprivileged setup and a different active image", func() {
@@ -355,7 +355,7 @@ var _ = Describe("Build Actions", func() {
 				{"mkfs.ext4", "-L", "COS_STATE"},
 				{"mkfs.ext4", "-L", "COS_PERSISTENT"},
 				{"sgdisk", "-p", "/tmp/test/elemental.raw"},
-				{"partprobe", "/tmp/test/elemental.raw"},
+				{"partx", "-u", "/tmp/test/elemental.raw"},
 			})).To(Succeed())
 		})
 		It("Successfully builds an expandable disk with an unprivileged setup", func() {
@@ -380,7 +380,7 @@ var _ = Describe("Build Actions", func() {
 				{"mkfs.ext4", "-L", "COS_RECOVERY"},
 				{"mkfs.ext4", "-L", "COS_STATE"},
 				{"sgdisk", "-p", "/tmp/test/elemental.raw"},
-				{"partprobe", "/tmp/test/elemental.raw"},
+				{"partx", "-u", "/tmp/test/elemental.raw"},
 			})).To(Succeed())
 		})
 		It("Fails to build an expandable disk with privileged setup when mounts are not possible", func() {

--- a/pkg/features/embedded/immutable-rootfs/usr/lib/dracut/modules.d/30elemental-immutable-rootfs/module-setup.sh
+++ b/pkg/features/embedded/immutable-rootfs/usr/lib/dracut/modules.d/30elemental-immutable-rootfs/module-setup.sh
@@ -29,7 +29,7 @@ install() {
     # Include utilities required for elemental-setup services,
     # probably a devoted dracut module makes sense
     inst_multiple -o \
-        "$systemdutildir"/systemd-fsck partprobe sync udevadm parted mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat mkfs.xfs blkid e2fsck resize2fs mount xfs_growfs umount sgdisk elemental
+        "$systemdutildir"/systemd-fsck partx sync udevadm parted mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat mkfs.xfs blkid e2fsck resize2fs mount xfs_growfs umount sgdisk elemental
     inst_hook cmdline 30 "${moddir}/parse-elemental-cmdline.sh"
     inst_script "${moddir}/elemental-generator.sh" \
         "${systemdutildir}/system-generators/dracut-elemental-generator"

--- a/pkg/partitioner/parted.go
+++ b/pkg/partitioner/parted.go
@@ -115,8 +115,10 @@ func (pc *partedCall) WriteChanges() (string, error) {
 	if len(opts) == 0 {
 		return "", nil
 	}
-
 	out, err := pc.runner.Run("parted", opts...)
+
+	// Notify kernel of partition table changes, swallows errors, just a best effort call
+	_, _ = pc.runner.Run("partx", "-u", pc.dev)
 	pc.wipe = false
 	pc.parts = []*Partition{}
 	pc.deletions = []int{}

--- a/pkg/partitioner/partitioner_test.go
+++ b/pkg/partitioner/partitioner_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 					"-n=1:206848:+0", "-c=1:p.root", "-t=1:8300", "/dev/device"},
 				{"sgdisk", "--zap-all", "-n=0:2048:+204800", "-c=0:p.efi", "-t=0:EF00",
 					"-n=1:206848:+0", "-c=1:p.root", "-t=1:8300", "/dev/device"},
-				{"partprobe", "/dev/device"},
+				{"partx", "-u", "/dev/device"},
 			}
 			part1 := part.Partition{
 				Number: 0, StartS: 2048, SizeS: 204800,
@@ -101,7 +101,7 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 			cmds := [][]string{
 				{"sgdisk", "-P", "--zap-all", "/dev/device"},
 				{"sgdisk", "--zap-all", "/dev/device"},
-				{"partprobe", "/dev/device"},
+				{"partx", "-u", "/dev/device"},
 			}
 			Expect(gc.SetPartitionTableLabel(v1.GPT)).To(Succeed())
 			gc.WipeTable(true)
@@ -115,9 +115,9 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 		It("Creates a new partition", func() {
 			cmds := [][]string{
 				{"sgdisk", "-n=0:2048:+204800", "-c=0:p.root", "-t=0:8300", "/dev/device"},
-				{"partprobe", "/dev/device"},
+				{"partx", "-u", "/dev/device"},
 				{"sgdisk", "-n=0:2048:+0", "-c=0:p.root", "-t=0:8300", "/dev/device"},
-				{"partprobe", "/dev/device"},
+				{"partx", "-u", "/dev/device"},
 			}
 			partition := part.Partition{
 				Number: 0, StartS: 2048, SizeS: 204800,
@@ -139,7 +139,7 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 			cmds := [][]string{
 				{"sgdisk", "-P", "-d=1", "-d=2", "/dev/device"},
 				{"sgdisk", "-d=1", "-d=2", "/dev/device"},
-				{"partprobe", "/dev/device"},
+				{"partx", "-u", "/dev/device"},
 			}
 			gc.DeletePartition(1)
 			gc.DeletePartition(2)
@@ -150,7 +150,7 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 		It("Wipes partition table creating a new one", func() {
 			cmds := [][]string{
 				{"sgdisk", "-P", "--zap-all", "/dev/device"}, {"sgdisk", "--zap-all", "/dev/device"},
-				{"partprobe", "/dev/device"},
+				{"partx", "-u", "/dev/device"},
 			}
 			gc.WipeTable(true)
 			_, err := gc.WriteChanges()
@@ -201,6 +201,8 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 				"parted", "--script", "--machine", "--", "/dev/device",
 				"unit", "s", "mklabel", "gpt", "mkpart", "p.efi", "fat32",
 				"2048", "206847", "mkpart", "p.root", "ext4", "206848", "100%",
+			}, {
+				"partx", "-u", "/dev/device",
 			}}
 			part1 := part.Partition{
 				Number: 0, StartS: 2048, SizeS: 204800,
@@ -221,6 +223,8 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 			cmds := [][]string{{
 				"parted", "--script", "--machine", "--", "/dev/device",
 				"unit", "s", "mklabel", "msdos",
+			}, {
+				"partx", "-u", "/dev/device",
 			}}
 			pc.SetPartitionTableLabel("msdos")
 			pc.WipeTable(true)
@@ -233,8 +237,12 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 				"parted", "--script", "--machine", "--", "/dev/device",
 				"unit", "s", "mkpart", "p.root", "ext4", "2048", "206847",
 			}, {
+				"partx", "-u", "/dev/device",
+			}, {
 				"parted", "--script", "--machine", "--", "/dev/device",
 				"unit", "s", "mkpart", "p.root", "ext4", "2048", "100%",
+			}, {
+				"partx", "-u", "/dev/device",
 			}}
 			partition := part.Partition{
 				Number: 0, StartS: 2048, SizeS: 204800,
@@ -253,20 +261,24 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 			Expect(runner.CmdsMatch(cmds)).To(BeNil())
 		})
 		It("Deletes a partition", func() {
-			cmd := []string{
+			cmds := [][]string{{
 				"parted", "--script", "--machine", "--", "/dev/device",
 				"unit", "s", "rm", "1", "rm", "2",
-			}
+			}, {
+				"partx", "-u", "/dev/device",
+			}}
 			pc.DeletePartition(1)
 			pc.DeletePartition(2)
 			_, err := pc.WriteChanges()
 			Expect(err).To(BeNil())
-			Expect(runner.CmdsMatch([][]string{cmd})).To(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
 		})
 		It("Set a partition flag", func() {
 			cmds := [][]string{{
 				"parted", "--script", "--machine", "--", "/dev/device",
 				"unit", "s", "set", "1", "flag", "on", "set", "2", "flag", "off",
+			}, {
+				"partx", "-u", "/dev/device",
 			}}
 			pc.SetPartitionFlag(1, "flag", true)
 			pc.SetPartitionFlag(2, "flag", false)
@@ -275,14 +287,16 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 			Expect(runner.CmdsMatch(cmds)).To(BeNil())
 		})
 		It("Wipes partition table creating a new one", func() {
-			cmd := []string{
+			cmds := [][]string{{
 				"parted", "--script", "--machine", "--", "/dev/device",
 				"unit", "s", "mklabel", "gpt",
-			}
+			}, {
+				"partx", "-u", "/dev/device",
+			}}
 			pc.WipeTable(true)
 			_, err := pc.WriteChanges()
 			Expect(err).To(BeNil())
-			Expect(runner.CmdsMatch([][]string{cmd})).To(BeNil())
+			Expect(runner.CmdsMatch(cmds)).To(BeNil())
 		})
 		It("Prints partitin table info", func() {
 			cmd := []string{
@@ -418,6 +432,8 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 				cmds = [][]string{{
 					"parted", "--script", "--machine", "--", "/dev/device",
 					"unit", "s", "mklabel", "gpt",
+				}, {
+					"partx", "-u", "/dev/device",
 				}, printCmd}
 				runner.ReturnValue = []byte(partedPrint)
 				_, err := dev.NewPartitionTable("gpt")
@@ -429,6 +445,8 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 					"parted", "--script", "--machine", "--", "/dev/device",
 					"unit", "s", "mkpart", "primary", "ext4", "50331648", "100%",
 					"set", "5", "boot", "on",
+				}, {
+					"partx", "-u", "/dev/device",
 				}, printCmd}
 				runner.ReturnValue = []byte(partedPrint)
 				num, err := dev.AddPartition(0, "ext4", "ignored", "boot")
@@ -483,6 +501,8 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 						printCmd, {
 							"parted", "--script", "--machine", "--", "/dev/device",
 							"unit", "s", "rm", "4", "mkpart", "primary", "", "45019136", "100%",
+						}, {
+							"partx", "-u", "/dev/device",
 						}, printCmd, {"udevadm", "settle"},
 					}
 					runFunc := func(cmd string, args ...string) ([]byte, error) {

--- a/pkg/partitioner/sgdisk.go
+++ b/pkg/partitioner/sgdisk.go
@@ -115,7 +115,7 @@ func (gd *gdiskCall) WriteChanges() (string, error) {
 	out, err = gd.runner.Run("sgdisk", opts...)
 
 	// Notify kernel of partition table changes, swallows errors, just a best effort call
-	_, _ = gd.runner.Run("partprobe", gd.dev)
+	_, _ = gd.runner.Run("partx", "-u", gd.dev)
 	gd.wipe = false
 	gd.parts = []*Partition{}
 	gd.deletions = []int{}


### PR DESCRIPTION
This commit makes use of partx to notify the kernel on partition updates. This fixes the installation over loop devices on some distributions (e.g. Leap 15.5).