### PR TITLE
Use build-disk command

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -162,14 +162,14 @@ jobs:
       - if: ${{ env.ARCH == 'x86_64' }} 
         name: Prepare test (x86_64)
         run: |
-          make QCOW2=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ELMNTL_ACCEL=hvf ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=$(find /usr/local/Cellar/qemu -name edk2-${{ env.ARCH }}-code.fd -print -quit) prepare-test
+          make DISK=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ELMNTL_ACCEL=hvf ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=$(find /usr/local/Cellar/qemu -name edk2-${{ env.ARCH }}-code.fd -print -quit) prepare-test
       - if: ${{ env.ARCH == 'aarch64' }} 
         name: Prepare test (aarch64)
         run: |
-          make QCOW2=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ELMNTL_ACCEL=none ELMNTL_MACHINETYPE=virt ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=/usr/share/AAVMF/AAVMF_CODE.fd prepare-test
+          make DISK=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ELMNTL_ACCEL=none ELMNTL_MACHINETYPE=virt ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=/usr/share/AAVMF/AAVMF_CODE.fd prepare-test
       - name: Run ${{ matrix.test }}
         run: |
-          make QCOW2=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ${{ matrix.test }}
+          make DISK=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ${{ matrix.test }}
       # TODO include other logs SUT collects on failure
       - name: Upload serial console for ${{ matrix.test }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -128,7 +128,7 @@ jobs:
     env:
       FLAVOR: ${{ inputs.flavor }}
       ARCH: ${{ inputs.arch }}
-      COS_TIMEOUT: 800
+      COS_TIMEOUT: 1600
     strategy:
       matrix:
         test: ${{ fromJson(needs.detect.outputs.tests) }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ isowork/
 *.iso
 *.iso.sha256
 *.qcow2
+*.raw
+*.img
 *.log
 *.pid
 iso-meta.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN ARCH=$(uname -m); \
         mtools \
         xorriso \
         cosign \
+        gptfdisk \
         lvm2
 
 COPY --from=elemental-bin /usr/bin/elemental /usr/bin/elemental

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # Directory of Makefile
 export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-QCOW2?=$(shell ls $(ROOT_DIR)/build/*.qcow2 2> /dev/null)
+DISK?=$(shell ls $(ROOT_DIR)/build/*.qcow2 2> /dev/null)
+DISKSIZE?=20G
 ISO?=$(shell ls $(ROOT_DIR)/build/*.iso 2> /dev/null)
 FLAVOR?=green
 ARCH?=$(shell uname -m)
@@ -69,16 +70,16 @@ build-disk: build-os
 	@echo Building ${ARCH} disk
 	mkdir -p $(ROOT_DIR)/build
 	$(DOCKER) run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(ROOT_DIR)/build:/build \
-   		--entrypoint /usr/bin/elemental \
-   		${TOOLKIT_REPO}:${VERSION} --debug build-disk --unprivileged -n elemental-$(FLAVOR).$(ARCH) --local \
-   		--squash-no-compression -o /build ${REPO}:${VERSION}
-	qemu-img convert -O qcow2 build/elemental-$(FLAVOR).$(ARCH).raw build/elemental-$(FLAVOR).$(ARCH).qcow2
+		--entrypoint /usr/bin/elemental \
+		${TOOLKIT_REPO}:${VERSION} --debug build-disk --unprivileged --expandable -n elemental-$(FLAVOR).$(ARCH) --local \
+		--squash-no-compression -o /build ${REPO}:${VERSION}
+	dd if=$(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).raw of=$(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).img conv=notrunc
+	qemu-img convert -O qcow2 $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).img $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).qcow2
+	qemu-img resize $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).qcow2 $(DISKSIZE) 
 
 .PHONY: clean-disk
 clean-disk:
-	losetup -d $$(cat .loop)
-	rm build/*.img
-	rm .loop
+	rm $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).{raw,img,qcow2}
 
 .PHONY: vet
 vet:

--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -48,7 +48,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			var cfg *v1.BuildConfig
-			var spec *v1.Disk
+			var spec *v1.DiskSpec
 			var imgSource *v1.ImageSource
 
 			defer func() {

--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -108,8 +108,8 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().Bool("expandable", false, "Creates an expandable image including only the recovery image")
 	c.Flags().Bool("unprivileged", false, "Makes a build runnable within a non-privileged container, avoids mounting filesystems (experimental)")
 	c.Flags().VarP(imgType, "type", "t", "Type of image to create")
-	// TODO verify if cross-arch builds make any sense
-	//addArchFlags(c)
+	c.Flags().StringSliceP("cloud-init", "c", []string{}, "Cloud-init config files")
+	addPlatformFlags(c)
 	addLocalImageFlag(c)
 	addSquashFsCompressionFlags(c)
 	addCosignFlags(c)

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -319,7 +319,7 @@ func ReadBuildISO(b *v1.BuildConfig, flags *pflag.FlagSet) (*v1.LiveISO, error) 
 	return iso, err
 }
 
-func ReadBuildDisk(b *v1.BuildConfig, flags *pflag.FlagSet) (*v1.Disk, error) {
+func ReadBuildDisk(b *v1.BuildConfig, flags *pflag.FlagSet) (*v1.DiskSpec, error) {
 	disk := config.NewDisk(b)
 	vp := viper.Sub("disk")
 	if vp == nil {

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -13,6 +13,7 @@ ifeq ("$(DISK)","")
 endif
 	@scripts/run_vm.sh start $(DISK)
 	@echo "VM started from $(DISK)"
+	$(GINKGO) run $(GINKGO_ARGS) ./tests/wait-active
 
 .PHONY: prepare-installer-test
 prepare-installer-test:

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -7,12 +7,12 @@ GINKGO_ARGS?=-v --fail-fast -r --timeout=3h
 
 .PHONY: prepare-test
 prepare-test:
-ifeq ("$(QCOW2)","")
-	@echo "No qcow2 disk found, run 'make build-disk' first"
+ifeq ("$(DISK)","")
+	@echo "No disk image found, run 'make build-disk' first"
 	@exit 1
 endif
-	@scripts/run_vm.sh start $(QCOW2)
-	@echo "VM started from $(QCOW2)"
+	@scripts/run_vm.sh start $(DISK)
+	@echo "VM started from $(DISK)"
 
 .PHONY: prepare-installer-test
 prepare-installer-test:

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -219,7 +219,7 @@ var _ = Describe("Build Actions", func() {
 		})
 	})
 	Describe("Build disk", Label("disk", "build"), func() {
-		var disk *v1.Disk
+		var disk *v1.DiskSpec
 
 		BeforeEach(func() {
 			tmpDir, err := utils.TempDir(fs, "", "test")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -530,7 +530,7 @@ func NewDiskElementalParitions(workdir string) v1.ElementalPartitions {
 	return partitions
 }
 
-func NewDisk(cfg *v1.BuildConfig) *v1.Disk {
+func NewDisk(cfg *v1.BuildConfig) *v1.DiskSpec {
 	var workdir string
 	var recoveryImg, activeImg, passiveImg v1.Image
 
@@ -566,7 +566,7 @@ func NewDisk(cfg *v1.BuildConfig) *v1.Disk {
 		)+mountSuffix,
 	)
 
-	return &v1.Disk{
+	return &v1.DiskSpec{
 		Partitions: NewDiskElementalParitions(workdir),
 		GrubConf:   constants.GrubConf,
 		Active:     activeImg,

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -615,7 +615,7 @@ func (b *BuildConfig) Sanitize() error {
 	return b.Config.Sanitize()
 }
 
-type Disk struct {
+type DiskSpec struct {
 	Size         uint                `yaml:"size,omitempty" mapstructure:"size"`
 	Partitions   ElementalPartitions `yaml:"partitions,omitempty" mapstructure:"partitions"`
 	Expandable   bool                `yaml:"expandable,omitempty" mapstructure:"expandable"`
@@ -631,7 +631,7 @@ type Disk struct {
 
 // Sanitize checks the consistency of the struct, returns error
 // if unsolvable inconsistencies are found
-func (d *Disk) Sanitize() error {
+func (d *DiskSpec) Sanitize() error {
 	// Set passive filesystem as active
 	d.Passive.FS = d.Active.FS
 
@@ -654,7 +654,7 @@ func (d *Disk) Sanitize() error {
 }
 
 // minDiskSize counts the minimum size (MB) required for the disk given the partitions setup
-func (d *Disk) MinDiskSize() uint {
+func (d *DiskSpec) MinDiskSize() uint {
 	var minDiskSize uint
 
 	// First partition is aligned at the first 1MB and the last one ends at -1MB

--- a/pkg/types/v1/grub.go
+++ b/pkg/types/v1/grub.go
@@ -78,3 +78,16 @@ func (r ResetSpec) GetGrubLabels() map[string]string {
 
 	return grubVars
 }
+
+func (d DiskSpec) GetGrubLabels() map[string]string {
+	return map[string]string{
+		"efi_label":        d.Partitions.EFI.FilesystemLabel,
+		"oem_label":        d.Partitions.OEM.FilesystemLabel,
+		"recovery_label":   d.Partitions.Recovery.FilesystemLabel,
+		"state_label":      d.Partitions.State.FilesystemLabel,
+		"persistent_label": d.Partitions.Persistent.FilesystemLabel,
+		"active_label":     d.Active.Label,
+		"passive_label":    d.Passive.Label,
+		"system_label":     d.Recovery.Label,
+	}
+}

--- a/tests/wait-active/tests_suite_test.go
+++ b/tests/wait-active/tests_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package elemental_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Elemental wait test Suite")
+}

--- a/tests/wait-active/wait_test.go
+++ b/tests/wait-active/wait_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package elemental_test
+
+import (
+	"time"
+
+	sut "github.com/rancher-sandbox/ele-testhelpers/vm"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Elemental booting fallback tests", func() {
+	var s *sut.SUT
+
+	BeforeEach(func() {
+		s = sut.NewSUT()
+		s.EventuallyConnects()
+	})
+	Context("Wait until system is expanded", func() {
+		It("eventually is active", func() {
+			Eventually(func() string {
+				out, _ := s.Command("cat /run/cos/active_mode")
+				return out
+			}, 1*time.Minute, 10*time.Second).Should(ContainSubstring("1"))
+		})
+	})
+})

--- a/tests/wait-active/wait_test.go
+++ b/tests/wait-active/wait_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Elemental booting fallback tests", func() {
 			Eventually(func() string {
 				out, _ := s.Command("cat /run/cos/active_mode")
 				return out
-			}, 1*time.Minute, 10*time.Second).Should(ContainSubstring("1"))
+			}, 15*time.Minute, 10*time.Second).Should(ContainSubstring("1"))
 		})
 	})
 })


### PR DESCRIPTION
This commit changes the way we build our test disks.

It uses the new build-disk command instead of losetup and the install command. This means we can run build-disk without privileges and could also build expandable images.