### PR TITLE
Move recovery hostname to cloud-config-defaults

### DIFF
--- a/pkg/features/embedded/cloud-config-defaults/system/oem/03_branding.yaml
+++ b/pkg/features/embedded/cloud-config-defaults/system/oem/03_branding.yaml
@@ -26,4 +26,8 @@ stages:
           permissions: 0644
           owner: 0
           group: 0
+   boot:
+    - name: "Recovery"
+      if: '[ -f "/run/cos/recovery_mode" ]'
+      hostname: "recovery"
 

--- a/pkg/features/embedded/cloud-config-essentials/system/oem/06_recovery.yaml
+++ b/pkg/features/embedded/cloud-config-essentials/system/oem/06_recovery.yaml
@@ -10,7 +10,6 @@ stages:
    boot:
      - name: "Recovery"
        if: '[ -f "/run/cos/recovery_mode" ]'
-       hostname: "recovery"
        commands:
        - |
             source /etc/os-release


### PR DESCRIPTION
Setting recovery hostname is mostly a nice-to-have and can be destructive so move it to cloud-config-defaults feature.