### PR TITLE
Configurable build-disk deploy command

### DIFF
--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -109,6 +109,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().Bool("unprivileged", false, "Makes a build runnable within a non-privileged container, avoids mounting filesystems (experimental)")
 	c.Flags().VarP(imgType, "type", "t", "Type of image to create")
 	c.Flags().StringSliceP("cloud-init", "c", []string{}, "Cloud-init config files")
+	c.Flags().StringSlice("deploy-command", []string{"elemental", "--debug", "reset", "--reboot"}, "Deployment command for expandable images")
 	addPlatformFlags(c)
 	addLocalImageFlag(c)
 	addSquashFsCompressionFlags(c)

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -688,7 +688,7 @@ func (b *BuildDiskAction) createBuildDiskStateYaml(sysMeta, recMeta interface{},
 func (b *BuildDiskAction) SetExpandableCloudInitStage() error {
 	var deployCmd []string
 
-	deployCmd = []string{"elemental", "--debug", "reset", "--reboot"}
+	deployCmd = b.spec.DeployCmd
 	if !b.spec.Active.Source.IsEmpty() {
 		deployCmd = append(deployCmd, "--system.uri", b.spec.Active.Source.String())
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -573,6 +573,7 @@ func NewDisk(cfg *v1.BuildConfig) *v1.DiskSpec {
 		Recovery:   recoveryImg,
 		Passive:    passiveImg,
 		Type:       constants.RawType,
+		DeployCmd:  []string{"elemental", "--debug", "reset", "--reboot"},
 	}
 }
 

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -627,6 +627,7 @@ type DiskSpec struct {
 	CloudInit    []string `yaml:"cloud-init,omitempty" mapstructure:"cloud-init"`
 	GrubDefEntry string   `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
 	Type         string   `yaml:"type,omitempty" mapstructure:"type"`
+	DeployCmd    []string `yaml:"deploy-command,omitempty" mapstructure:"deploy-command"`
 }
 
 // Sanitize checks the consistency of the struct, returns error


### PR DESCRIPTION
This PR allows the deployment-command used when building expandable disk-images to be configured by the user.