### PR TITLE
Remove existing file during build-disk

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,7 @@ jobs:
           username: ${{ secrets.ELEMENTAL_BOT_GITHUB_USERNAME }}
           password: ${{ secrets.ELEMENTAL_BOT_GITHUB_TOKEN }}
       - name: Build toolkit image
+        run: |
           make TOOLKIT_REPO=ghcr.io/${{ github.workspace }}/${{ github.repository }}/elemental-cli VERSION=$(git describe --abbrev=0 --tags) build push-toolkit
           make PLATFORM=linux/arm64,linux/amd64 TOOLKIT_REPO=ghcr.io/${{ github.workspace }}/${{ github.repository }}/elemental-cli VERSION=latest build push-toolkit
       - name: Build green example

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ build-iso: build-os
 	@echo Building ${ARCH} ISO
 	mkdir -p $(ROOT_DIR)/build
 	$(DOCKER) run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $(ROOT_DIR)/build:/build \
-		--entrypoint /usr/bin/elemental $(REPO):$(VERSION) --debug build-iso --bootloader-in-rootfs -n elemental-$(FLAVOR).$(ARCH) \
+		--entrypoint /usr/bin/elemental ${TOOLKIT_REPO}:${VERSION} --debug build-iso --bootloader-in-rootfs -n elemental-$(FLAVOR).$(ARCH) \
 		--local --platform $(PLATFORM) --squash-no-compression -o /build $(REPO):$(VERSION)
 
 .PHONY: clean-iso

--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -93,10 +93,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				spec.Recovery.Source = imgSource
 			}
 
-			// TODO add logic for an already existing output file
-
 			builder := action.NewBuildDiskAction(cfg, spec)
-
 			return builder.BuildDiskRun()
 		},
 	}

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -315,6 +315,15 @@ func (b *BuildDiskAction) CreateRAWDisk(e *elemental.Elemental, rawImg string) e
 		return err
 	}
 
+	// Check if disk already exists
+	if exists, _ := utils.Exists(b.cfg.Fs, rawImg); exists {
+		b.cfg.Logger.Warnf("Overwriting already existing %s", rawImg)
+		err := b.cfg.Fs.Remove(rawImg)
+		if err != nil {
+			return elementalError.NewFromError(err, elementalError.RemoveFile)
+		}
+	}
+
 	// Ensamble disk with all partitions
 	err = b.CreateDiskImage(rawImg, images...)
 	if err != nil {


### PR DESCRIPTION
The first commit makes build-disk command behave like build-iso in that it will remove an existing raw disk before writing the new disk and log a warning.

Second commit changes the build-iso Makefile target to use the toolkit image instead of the target derivative image to be consistent with build-disk target
