### PR TITLE
Log errors of runner commands only in debug mode

### DIFF
--- a/pkg/types/v1/runner.go
+++ b/pkg/types/v1/runner.go
@@ -53,7 +53,8 @@ func (r RealRunner) Run(command string, args ...string) ([]byte, error) {
 	cmd := r.InitCmd(command, args...)
 	out, err := r.RunCmd(cmd)
 	if err != nil {
-		r.error(fmt.Sprintf("Error running command: %s", err.Error()))
+		r.debug(fmt.Sprintf("'%s' command reported an error: %s", command, err.Error()))
+		r.debug(fmt.Sprintf("'%s' command output: %s", command, out))
 	}
 	return out, err
 }

--- a/pkg/types/v1/runner.go
+++ b/pkg/types/v1/runner.go
@@ -67,12 +67,6 @@ func (r *RealRunner) SetLogger(logger Logger) {
 	r.Logger = logger
 }
 
-func (r RealRunner) error(msg string) {
-	if r.Logger != nil {
-		r.Logger.Error(msg)
-	}
-}
-
 func (r RealRunner) debug(msg string) {
 	if r.Logger != nil {
 		r.Logger.Debug(msg)

--- a/pkg/types/v1/runner_test.go
+++ b/pkg/types/v1/runner_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 
 	v1mock "github.com/rancher/elemental-toolkit/pkg/mocks"
 	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
@@ -56,15 +55,16 @@ var _ = Describe("Runner", Label("types", "runner"), func() {
 	It("logs the command when on debug", func() {
 		memLog := &bytes.Buffer{}
 		logger := v1.NewBufferLogger(memLog)
-		logger.SetLevel(logrus.DebugLevel)
+		logger.SetLevel(v1.DebugLevel())
 		r := v1.RealRunner{Logger: logger}
 		_, err := r.Run("echo", "-n", "Some message")
 		Expect(err).To(BeNil())
 		Expect(memLog.String()).To(ContainSubstring("echo -n Some message"))
 	})
-	It("logs when command is not found", func() {
+	It("logs when command is not found in debug mode", func() {
 		memLog := &bytes.Buffer{}
 		logger := v1.NewBufferLogger(memLog)
+		logger.SetLevel(v1.DebugLevel())
 		r := v1.RealRunner{Logger: logger}
 		_, err := r.Run("IAmMissing")
 		Expect(err).NotTo(BeNil())


### PR DESCRIPTION
During any installation we currently have this logs

```
INFO[2023-12-01T12:14:42Z] Partitioning device...                       
DEBU[2023-12-01T12:14:42Z] Running cmd: 'parted --script --machine -- /dev/vda unit s mklabel gpt' 
DEBU[2023-12-01T12:14:42Z] Running cmd: 'partx -u /dev/vda'             
ERRO[2023-12-01T12:14:42Z] Error running command: exit status 1
```
Where the error message is likely to appear in clearly visible red red. This particular error happens because after running any partition related change in disk run `partx` to reload and update partitions. This is only a best effort call, meaning we ignore any error (if running in a container this is likely to always fail, but doesn't necessarily mean there is an installation error).
Given the fact there a few command calls for which we ignore reported errors it doesn't make much sense having the `runner.Run` method to log at error level all command failures, this is caller responsibility to know if this should be logged at error level or not. 

Hence in this PR on `runner.Run` errors we actually log everything (command error and command output) at debug level. Since the method returns the error and the command output, the caller still has the chance to log error as error level if this is the desired behavior.