### PR TITLE
Wrap mount.Interface to our own interface

### DIFF
--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/cmd/config"
 	"github.com/rancher/elemental-toolkit/pkg/action"
@@ -61,7 +60,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			mounter := mount.New(path)
+			mounter := v1.NewMounter(path)
 
 			flags := cmd.Flags()
 			cfg, err = config.ReadConfigBuild(viper.GetString("config-dir"), flags, mounter)

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/cmd/config"
 	"github.com/rancher/elemental-toolkit/pkg/action"
@@ -54,7 +53,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			if err != nil {
 				return elementalError.NewFromError(err, elementalError.StatFile)
 			}
-			mounter := mount.New(path)
+			mounter := v1.NewMounter(path)
 
 			cfg, err := config.ReadConfigBuild(viper.GetString("config-dir"), cmd.Flags(), mounter)
 			if err != nil {

--- a/cmd/cloud-init.go
+++ b/cmd/cloud-init.go
@@ -20,10 +20,9 @@ import (
 	"io"
 	"os"
 
-	"k8s.io/mount-utils"
-
 	"github.com/rancher/elemental-toolkit/cmd/config"
 	elementalError "github.com/rancher/elemental-toolkit/pkg/error"
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
 
 	"github.com/mudler/yip/pkg/schema"
 	"github.com/spf13/cobra"
@@ -39,7 +38,7 @@ func NewCloudInitCmd(root *cobra.Command) *cobra.Command {
 			_ = viper.BindPFlags(cmd.Flags())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), &mount.FakeMounter{})
+			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), v1.NewDummyMounter())
 			if err != nil {
 				return elementalError.NewFromError(err, elementalError.ReadingRunConfig)
 			}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/internal/version"
 	"github.com/rancher/elemental-toolkit/pkg/config"
@@ -98,7 +97,7 @@ func bindGivenFlags(vp *viper.Viper, flagSet *pflag.FlagSet) {
 	}
 }
 
-func ReadConfigBuild(configDir string, flags *pflag.FlagSet, mounter mount.Interface) (*v1.BuildConfig, error) {
+func ReadConfigBuild(configDir string, flags *pflag.FlagSet, mounter v1.Mounter) (*v1.BuildConfig, error) {
 	logger := v1.NewLogger()
 
 	cfg := config.NewBuildConfig(
@@ -144,7 +143,7 @@ func ReadConfigBuild(configDir string, flags *pflag.FlagSet, mounter mount.Inter
 	return cfg, err
 }
 
-func ReadConfigRun(configDir string, flags *pflag.FlagSet, mounter mount.Interface) (*v1.RunConfig, error) {
+func ReadConfigRun(configDir string, flags *pflag.FlagSet, mounter v1.Mounter) (*v1.RunConfig, error) {
 	cfg := config.NewRunConfig(
 		config.WithLogger(v1.NewLogger()),
 		config.WithMounter(mounter),

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -42,10 +42,10 @@ import (
 )
 
 var _ = Describe("Config", Label("config"), func() {
-	var mounter *v1mock.ErrorMounter
+	var mounter *v1mock.FakeMounter
 
 	BeforeEach(func() {
-		mounter = &v1mock.ErrorMounter{}
+		mounter = v1mock.NewFakeMounter()
 	})
 	AfterEach(func() {
 		viper.Reset()
@@ -133,7 +133,7 @@ var _ = Describe("Config", Label("config"), func() {
 		var runner *v1mock.FakeRunner
 		var fs vfs.FS
 		var logger v1.Logger
-		var mounter *v1mock.ErrorMounter
+		var mounter *v1mock.FakeMounter
 		var syscall *v1mock.FakeSyscall
 		var client *v1mock.FakeHTTPClient
 		var cloudInit *v1mock.FakeCloudInitRunner
@@ -144,7 +144,7 @@ var _ = Describe("Config", Label("config"), func() {
 		BeforeEach(func() {
 			runner = v1mock.NewFakeRunner()
 			syscall = &v1mock.FakeSyscall{}
-			mounter = v1mock.NewErrorMounter()
+			mounter = v1mock.NewFakeMounter()
 			client = &v1mock.FakeHTTPClient{}
 			memLog = &bytes.Buffer{}
 			logger = v1.NewBufferLogger(memLog)
@@ -251,7 +251,7 @@ var _ = Describe("Config", Label("config"), func() {
 		var runner *v1mock.FakeRunner
 		var fs vfs.FS
 		var logger v1.Logger
-		var mounter *v1mock.ErrorMounter
+		var mounter *v1mock.FakeMounter
 		var syscall *v1mock.FakeSyscall
 		var client *v1mock.FakeHTTPClient
 		var cloudInit *v1mock.FakeCloudInitRunner
@@ -262,7 +262,7 @@ var _ = Describe("Config", Label("config"), func() {
 		BeforeEach(func() {
 			runner = v1mock.NewFakeRunner()
 			syscall = &v1mock.FakeSyscall{}
-			mounter = v1mock.NewErrorMounter()
+			mounter = v1mock.NewFakeMounter()
 			client = &v1mock.FakeHTTPClient{}
 			memLog = &bytes.Buffer{}
 			logger = v1.NewBufferLogger(memLog)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/cmd/config"
 	"github.com/rancher/elemental-toolkit/pkg/action"
 	elementalError "github.com/rancher/elemental-toolkit/pkg/error"
 	"github.com/rancher/elemental-toolkit/pkg/features"
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
 )
 
 func InitCmd(root *cobra.Command) *cobra.Command {
@@ -39,7 +39,7 @@ func InitCmd(root *cobra.Command) *cobra.Command {
 			"    Defaults to all",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), &mount.FakeMounter{})
+			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), v1.NewDummyMounter())
 			if err != nil {
 				cfg.Logger.Errorf("Error reading config: %s\n", err)
 				return elementalError.NewFromError(err, elementalError.ReadingRunConfig)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/cmd/config"
 	"github.com/rancher/elemental-toolkit/pkg/action"
@@ -48,7 +47,7 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			mounter := mount.New(path)
+			mounter := v1.NewMounter(path)
 
 			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), mounter)
 			if err != nil {

--- a/cmd/pull-image.go
+++ b/cmd/pull-image.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/cmd/config"
 	elementalError "github.com/rancher/elemental-toolkit/pkg/error"
@@ -40,7 +39,7 @@ func NewPullImageCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), &mount.FakeMounter{})
+			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), v1.NewDummyMounter())
 			if err != nil {
 				cfg.Logger.Errorf("Error reading config: %s\n", err)
 				return elementalError.NewFromError(err, elementalError.ReadingRunConfig)

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/cmd/config"
 	"github.com/rancher/elemental-toolkit/pkg/action"
 	elementalError "github.com/rancher/elemental-toolkit/pkg/error"
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
 )
 
 func NewResetCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
@@ -44,7 +44,7 @@ func NewResetCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			mounter := mount.New(path)
+			mounter := v1.NewMounter(path)
 
 			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), mounter)
 			if err != nil {

--- a/cmd/run-stage.go
+++ b/cmd/run-stage.go
@@ -19,10 +19,10 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/cmd/config"
 	elementalError "github.com/rancher/elemental-toolkit/pkg/error"
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
 	"github.com/rancher/elemental-toolkit/pkg/utils"
 )
 
@@ -35,7 +35,7 @@ func NewRunStage(root *cobra.Command) *cobra.Command {
 
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), &mount.FakeMounter{})
+			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), v1.NewDummyMounter())
 			if err != nil {
 				cfg.Logger.Errorf("Error reading config: %s\n", err)
 				return elementalError.NewFromError(err, elementalError.ReadingRunConfig)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/cmd/config"
 	"github.com/rancher/elemental-toolkit/pkg/action"
 	elementalError "github.com/rancher/elemental-toolkit/pkg/error"
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
 )
 
 // NewUpgradeCmd returns a new instance of the upgrade subcommand and appends it to
@@ -48,7 +48,7 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			mounter := mount.New(path)
+			mounter := v1.NewMounter(path)
 
 			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), mounter)
 			if err != nil {

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Build Actions", func() {
 	var runner *v1mock.FakeRunner
 	var fs vfs.FS
 	var logger v1.Logger
-	var mounter *v1mock.ErrorMounter
+	var mounter *v1mock.FakeMounter
 	var syscall *v1mock.FakeSyscall
 	var client *v1mock.FakeHTTPClient
 	var cloudInit *v1mock.FakeCloudInitRunner
@@ -55,7 +55,7 @@ var _ = Describe("Build Actions", func() {
 	BeforeEach(func() {
 		runner = v1mock.NewFakeRunner()
 		syscall = &v1mock.FakeSyscall{}
-		mounter = v1mock.NewErrorMounter()
+		mounter = v1mock.NewFakeMounter()
 		client = &v1mock.FakeHTTPClient{}
 		memLog = &bytes.Buffer{}
 		bootloader = &v1mock.FakeBootloader{}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Install action tests", func() {
 	var runner *v1mock.FakeRunner
 	var fs vfs.FS
 	var logger v1.Logger
-	var mounter *v1mock.ErrorMounter
+	var mounter *v1mock.FakeMounter
 	var syscall *v1mock.FakeSyscall
 	var client *v1mock.FakeHTTPClient
 	var cloudInit *v1mock.FakeCloudInitRunner
@@ -60,7 +60,7 @@ var _ = Describe("Install action tests", func() {
 	BeforeEach(func() {
 		runner = v1mock.NewFakeRunner()
 		syscall = &v1mock.FakeSyscall{}
-		mounter = v1mock.NewErrorMounter()
+		mounter = v1mock.NewFakeMounter()
 		client = &v1mock.FakeHTTPClient{}
 		memLog = &bytes.Buffer{}
 		logger = v1.NewBufferLogger(memLog)

--- a/pkg/action/reset_test.go
+++ b/pkg/action/reset_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Reset action tests", func() {
 	var runner *v1mock.FakeRunner
 	var fs vfs.FS
 	var logger v1.Logger
-	var mounter *v1mock.ErrorMounter
+	var mounter *v1mock.FakeMounter
 	var syscall *v1mock.FakeSyscall
 	var client *v1mock.FakeHTTPClient
 	var cloudInit *v1mock.FakeCloudInitRunner
@@ -53,7 +53,7 @@ var _ = Describe("Reset action tests", func() {
 	BeforeEach(func() {
 		runner = v1mock.NewFakeRunner()
 		syscall = &v1mock.FakeSyscall{}
-		mounter = v1mock.NewErrorMounter()
+		mounter = v1mock.NewFakeMounter()
 		client = &v1mock.FakeHTTPClient{}
 		memLog = &bytes.Buffer{}
 		logger = v1.NewBufferLogger(memLog)

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Runtime Actions", func() {
 	var runner *v1mock.FakeRunner
 	var fs vfs.FS
 	var logger v1.Logger
-	var mounter *v1mock.ErrorMounter
+	var mounter *v1mock.FakeMounter
 	var syscall *v1mock.FakeSyscall
 	var client *v1mock.FakeHTTPClient
 	var cloudInit *v1mock.FakeCloudInitRunner
@@ -56,7 +56,7 @@ var _ = Describe("Runtime Actions", func() {
 	BeforeEach(func() {
 		runner = v1mock.NewFakeRunner()
 		syscall = &v1mock.FakeSyscall{}
-		mounter = v1mock.NewErrorMounter()
+		mounter = v1mock.NewFakeMounter()
 		client = &v1mock.FakeHTTPClient{}
 		memLog = &bytes.Buffer{}
 		logger = v1.NewBufferLogger(memLog)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/twpayne/go-vfs"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/pkg/cloudinit"
 	"github.com/rancher/elemental-toolkit/pkg/constants"
@@ -61,7 +60,7 @@ func WithSyscall(syscall v1.SyscallInterface) func(r *v1.Config) error {
 	}
 }
 
-func WithMounter(mounter mount.Interface) func(r *v1.Config) error {
+func WithMounter(mounter v1.Mounter) func(r *v1.Config) error {
 	return func(r *v1.Config) error {
 		r.Mounter = mounter
 		return nil
@@ -155,7 +154,7 @@ func NewConfig(opts ...GenericOptions) *v1.Config {
 	}
 
 	if c.Mounter == nil {
-		c.Mounter = mount.New(constants.MountBinary)
+		c.Mounter = v1.NewMounter(constants.MountBinary)
 	}
 
 	return c

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/twpayne/go-vfs/vfst"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/pkg/config"
 	"github.com/rancher/elemental-toolkit/pkg/constants"
@@ -37,7 +36,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 		var err error
 		var cleanup func()
 		var fs *vfst.TestFS
-		var mounter *v1mock.ErrorMounter
+		var mounter *v1mock.FakeMounter
 		var runner *v1mock.FakeRunner
 		var client *v1mock.FakeHTTPClient
 		var sysc *v1mock.FakeSyscall
@@ -47,7 +46,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 		BeforeEach(func() {
 			fs, cleanup, err = vfst.NewTestFS(nil)
 			Expect(err).ToNot(HaveOccurred())
-			mounter = v1mock.NewErrorMounter()
+			mounter = v1mock.NewFakeMounter()
 			runner = v1mock.NewFakeRunner()
 			client = &v1mock.FakeHTTPClient{}
 			sysc = &v1mock.FakeSyscall{}
@@ -99,7 +98,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					config.WithSyscall(sysc),
 					config.WithLogger(logger),
 				)
-				Expect(c.Mounter).To(Equal(mount.New(constants.MountBinary)))
+				Expect(c.Mounter).To(Equal(v1.NewMounter(constants.MountBinary)))
 			})
 		})
 		Describe("RunConfig", func() {

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/twpayne/go-vfs"
 	"github.com/twpayne/go-vfs/vfst"
-	"k8s.io/mount-utils"
 
 	conf "github.com/rancher/elemental-toolkit/pkg/config"
 	"github.com/rancher/elemental-toolkit/pkg/constants"
@@ -55,14 +54,14 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 	var logger v1.Logger
 	var syscall v1.SyscallInterface
 	var client *v1mock.FakeHTTPClient
-	var mounter *v1mock.ErrorMounter
+	var mounter *v1mock.FakeMounter
 	var extractor *v1mock.FakeImageExtractor
 	var fs *vfst.TestFS
 	var cleanup func()
 	BeforeEach(func() {
 		runner = v1mock.NewFakeRunner()
 		syscall = &v1mock.FakeSyscall{}
-		mounter = v1mock.NewErrorMounter()
+		mounter = v1mock.NewFakeMounter()
 		client = &v1mock.FakeHTTPClient{}
 		logger = v1.NewNullLogger()
 		extractor = v1mock.NewFakeImageExtractor(logger)
@@ -977,7 +976,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 })
 
 // PathInMountPoints will check if the given path is in the mountPoints list
-func pathInMountPoints(mounter mount.Interface, path string) bool {
+func pathInMountPoints(mounter *v1mock.FakeMounter, path string) bool {
 	mountPoints, _ := mounter.List()
 	for _, m := range mountPoints {
 		if path == m.Path {

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
-	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/pkg/constants"
 )
@@ -45,7 +44,7 @@ const (
 type Config struct {
 	Logger                    Logger
 	Fs                        FS
-	Mounter                   mount.Interface
+	Mounter                   Mounter
 	Runner                    Runner
 	Syscall                   SyscallInterface
 	CloudInitRunner           CloudInitRunner

--- a/pkg/types/v1/config_test.go
+++ b/pkg/types/v1/config_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 		var config *v1.RunConfig
 		var runner *v1mocks.FakeRunner
 		var fs vfs.FS
-		var mounter *v1mocks.ErrorMounter
+		var mounter *v1mocks.FakeMounter
 		var cleanup func()
 		var err error
 		var dockerState, channelState *v1.ImageState
@@ -46,7 +46,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 
 		BeforeEach(func() {
 			runner = v1mocks.NewFakeRunner()
-			mounter = v1mocks.NewErrorMounter()
+			mounter = v1mocks.NewFakeMounter()
 			fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{})
 			Expect(err).Should(BeNil())
 
@@ -375,7 +375,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 		var spec *v1.InstallSpec
 
 		BeforeEach(func() {
-			cfg := config.NewConfig(config.WithMounter(v1mocks.NewErrorMounter()))
+			cfg := config.NewConfig(config.WithMounter(v1mocks.NewFakeMounter()))
 			spec = config.NewInstallSpec(*cfg)
 		})
 		Describe("sanitize", func() {

--- a/pkg/types/v1/mounter.go
+++ b/pkg/types/v1/mounter.go
@@ -1,0 +1,36 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"k8s.io/mount-utils"
+)
+
+// This is is just a redefinition of mount.Interface to v1.Mounter types
+type Mounter interface {
+	Mount(source string, target string, fstype string, options []string) error
+	Unmount(target string) error
+	IsLikelyNotMountPoint(file string) (bool, error)
+}
+
+func NewMounter(binary string) Mounter {
+	return mount.New(binary)
+}
+
+func NewDummyMounter() Mounter {
+	return mount.NewFakeMounter([]mount.MountPoint{})
+}

--- a/pkg/utils/runstage_test.go
+++ b/pkg/utils/runstage_test.go
@@ -55,7 +55,7 @@ var _ = Describe("run stage", Label("RunStage"), func() {
 	var logger v1.Logger
 	var syscall *v1mock.FakeSyscall
 	var client *v1mock.FakeHTTPClient
-	var mounter *v1mock.ErrorMounter
+	var mounter *v1mock.FakeMounter
 	var fs vfs.FS
 	var memLog *bytes.Buffer
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 	var logger v1.Logger
 	var syscall *v1mock.FakeSyscall
 	var client *v1mock.FakeHTTPClient
-	var mounter *v1mock.ErrorMounter
+	var mounter *v1mock.FakeMounter
 	var extractor *v1mock.FakeImageExtractor
 	var fs vfs.FS
 	var cleanup func()
@@ -63,7 +63,7 @@ var _ = Describe("Utils", Label("utils"), func() {
 	BeforeEach(func() {
 		runner = v1mock.NewFakeRunner()
 		syscall = &v1mock.FakeSyscall{}
-		mounter = v1mock.NewErrorMounter()
+		mounter = v1mock.NewFakeMounter()
 		client = &v1mock.FakeHTTPClient{}
 		logger = v1.NewNullLogger()
 		realRunner = &v1.RealRunner{Logger: logger}


### PR DESCRIPTION
This sets the actual mount interface we need in elemental and wraps `k8s.io/mount-utils` use in a single place. This makes our mounter interface way easier to substitute by another implementation if needed at some point. It also makes evident we need a simple mount interface.

Part of #1874