### PR TITLE
Add backwards-compatibility for liveCD detection

### DIFF
--- a/pkg/features/embedded/cloud-config-essentials/system/oem/07_live.yaml
+++ b/pkg/features/embedded/cloud-config-essentials/system/oem/07_live.yaml
@@ -9,10 +9,15 @@ name: "LiveCD Detection"
 stages:
    rootfs.before:
      - if: |
-            cat /proc/cmdline | grep -q "CDLABEL" || cat /proc/cmdline | grep -q "elemental.disable"
+            cat /proc/cmdline | grep -q "CDLABEL" || cat /proc/cmdline | grep -q "elemental.disable"  || cat /proc/cmdline | grep -q "rd.cos.disable"
        name: "Identify live mode"
        files:
        - path: /run/elemental/live_mode
+         content: "1"
+         permissions: 0600
+         owner: 0
+         group: 0
+       - path: /run/cos/live_mode
          content: "1"
          permissions: 0600
          owner: 0


### PR DESCRIPTION
This commit adds back the /run/cos/live_mode file if booting in live-mode. /run/elemental/live_mode will exist side-by-side while /run/cos is removed.