### PR TITLE
Rename overlay -> ephemeral mounts

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -124,7 +124,7 @@ upgrade:
 mount:
   sysroot: /sysroot # Path to mount system to
   write-fstab: true # Write fstab into sysroot/etc/fstab
-  overlay:
+  ephemeral:
     type: tmpfs # tmpfs|block
     device: /dev/sda6 # Block device used to store overlay. Used when type is set to block
     size: 25% # Size of tmpfs as percentag of system memory. Used when type is set to tmpfs

--- a/pkg/action/mount_test.go
+++ b/pkg/action/mount_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Mount Action", func() {
 		It("Writes a simple fstab", func() {
 			spec := &v1.MountSpec{
 				WriteFstab: true,
-				Overlay: v1.OverlayMounts{
+				Ephemeral: v1.EphemeralMounts{
 					Size: "30%",
 				},
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -255,7 +255,7 @@ func NewMountSpec() *v1.MountSpec {
 		Sysroot:    "/sysroot",
 		WriteFstab: true,
 		Partitions: partitions,
-		Overlay: v1.OverlayMounts{
+		Ephemeral: v1.EphemeralMounts{
 			Type:  constants.Tmpfs,
 			Size:  "25%",
 			Paths: []string{"/var", "/etc", "/srv"},

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -244,7 +244,7 @@ type MountSpec struct {
 	Sysroot    string `yaml:"sysroot,omitempty" mapstructure:"sysroot"`
 	Mode       string `yaml:"mode,omitempty" mapstructure:"mode"`
 	Partitions ElementalPartitions
-	Overlay    OverlayMounts    `yaml:"overlay,omitempty" mapstructure:"overlay"`
+	Ephemeral  EphemeralMounts  `yaml:"ephemeral,omitempty" mapstructure:"ephemeral"`
 	Persistent PersistentMounts `yaml:"persistent,omitempty" mapstructure:"persistent"`
 }
 
@@ -255,9 +255,9 @@ type PersistentMounts struct {
 	Paths []string `yaml:"paths,omitempty" mapstructure:"paths"`
 }
 
-// OverlayMounts contains information about the RW overlay mounted over the
+// EphemeralMounts contains information about the RW overlay mounted over the
 // immutable system.
-type OverlayMounts struct {
+type EphemeralMounts struct {
 	Type   string   `yaml:"type,omitempty" mapstructure:"type"`
 	Device string   `yaml:"device,omitempty" mapstructure:"device"`
 	Size   string   `yaml:"size,omitempty" mapstructure:"size"`
@@ -282,16 +282,16 @@ func (spec *MountSpec) Sanitize() error {
 		})
 	}
 
-	switch spec.Overlay.Type {
+	switch spec.Ephemeral.Type {
 	case constants.Tmpfs, constants.Block:
 		break
 	default:
-		return fmt.Errorf("unknown overlay type: '%s'", spec.Overlay.Type)
+		return fmt.Errorf("unknown overlay type: '%s'", spec.Ephemeral.Type)
 	}
 
-	if spec.Overlay.Paths != nil {
-		sort.Slice(spec.Overlay.Paths, func(i, j int) bool {
-			return strings.Count(spec.Overlay.Paths[i], separator) < strings.Count(spec.Overlay.Paths[j], separator)
+	if spec.Ephemeral.Paths != nil {
+		sort.Slice(spec.Ephemeral.Paths, func(i, j int) bool {
+			return strings.Count(spec.Ephemeral.Paths[i], separator) < strings.Count(spec.Ephemeral.Paths[j], separator)
 		})
 	}
 


### PR DESCRIPTION
This change aims to make the distinction between ephemeral, persistent, overlay and bind mounts a bit more clear.

The system mounts ephemeral and persistent directories on boot. A persistent mount can be materialized using a linux overlay-mount or a bind-mount.