### PR TITLE
Refactor some elemental package methods to be used as stand alone functions

### DIFF
--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -153,7 +153,7 @@ func (b *BuildDiskAction) BuildDiskRun() (err error) { //nolint:gocyclo
 	activeRoot := recRoot
 
 	// Create recovery root
-	recInfo, err = e.DumpSource(recRoot, b.spec.Recovery.Source)
+	recInfo, err = elemental.DumpSource(b.cfg.Config, recRoot, b.spec.Recovery.Source)
 	if err != nil {
 		b.cfg.Logger.Errorf("failed loading recovery image source tree: %s", err.Error())
 		return err
@@ -165,7 +165,7 @@ func (b *BuildDiskAction) BuildDiskRun() (err error) { //nolint:gocyclo
 		if !b.spec.Active.Source.IsEmpty() {
 			// Create active root
 			activeRoot = filepath.Join(workdir, filepath.Base(b.spec.Active.File)+rootSuffix)
-			activeInfo, err = e.DumpSource(activeRoot, b.spec.Active.Source)
+			activeInfo, err = elemental.DumpSource(b.cfg.Config, activeRoot, b.spec.Active.Source)
 			if err != nil {
 				b.cfg.Logger.Errorf("failed loading active image source tree: %s", err.Error())
 				return err
@@ -174,7 +174,7 @@ func (b *BuildDiskAction) BuildDiskRun() (err error) { //nolint:gocyclo
 	}
 
 	// Copy cloud-init if any
-	err = e.CopyCloudConfig(b.roots[constants.OEMPartName], b.spec.CloudInit)
+	err = elemental.CopyCloudConfig(b.cfg.Config, b.roots[constants.OEMPartName], b.spec.CloudInit)
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.CopyFile)
 	}
@@ -378,7 +378,7 @@ func (b *BuildDiskAction) CreatePartitionImages(e *elemental.Elemental) ([]*v1.I
 
 	b.cfg.Logger.Infof("Creating EFI partition image")
 	img = b.spec.Partitions.EFI.ToImage()
-	err = e.CreateFileSystemImage(img)
+	err = elemental.CreateFileSystemImage(b.cfg.Config, img, "", false)
 	if err != nil {
 		b.cfg.Logger.Errorf("failed creating EFI image: %s", err.Error())
 		return nil, err

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -251,12 +251,12 @@ func (b BuildISOAction) createEFI(root string, img string) error {
 	align := int64(4 * 1024 * 1024)
 	efiSizeMB := (efiSize/align*align + align) / (1024 * 1024)
 
-	err = b.e.CreateFileSystemImage(&v1.Image{
+	err = elemental.CreateFileSystemImage(b.cfg.Config, &v1.Image{
 		File:  img,
 		Size:  uint(efiSizeMB),
 		FS:    constants.EfiFs,
 		Label: constants.EfiLabel,
-	})
+	}, "", false)
 	if err != nil {
 		return err
 	}
@@ -329,7 +329,7 @@ func (b BuildISOAction) burnISO(root, efiImg string) error {
 
 func (b BuildISOAction) applySources(target string, sources ...*v1.ImageSource) error {
 	for _, src := range sources {
-		_, err := b.e.DumpSource(target, src)
+		_, err := elemental.DumpSource(b.cfg.Config, target, src)
 		if err != nil {
 			return elementalError.NewFromError(err, elementalError.DumpSource)
 		}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -155,11 +155,12 @@ func (i InstallAction) Run() (err error) {
 
 	// Set installation sources from a downloaded ISO
 	if i.spec.Iso != "" {
-		isoCleaner, err := e.UpdateSourceFormISO(i.spec.Iso, &i.spec.Active)
+		isoSrc, isoCleaner, err := elemental.SourceFormISO(i.cfg.Config, i.spec.Iso)
 		cleanup.Push(isoCleaner)
 		if err != nil {
 			return elementalError.NewFromError(err, elementalError.Unknown)
 		}
+		i.spec.Active.Source = isoSrc
 	}
 
 	// Partition and format device if needed
@@ -190,7 +191,7 @@ func (i InstallAction) Run() (err error) {
 	cleanup.Push(func() error { return treeCleaner() })
 
 	// Copy cloud-init if any
-	err = e.CopyCloudConfig(i.spec.Partitions.GetConfigStorage(), i.spec.CloudInit)
+	err = elemental.CopyCloudConfig(i.cfg.Config, i.spec.Partitions.GetConfigStorage(), i.spec.CloudInit)
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.CopyFile)
 	}

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -198,7 +198,7 @@ func (r ResetAction) Run() (err error) {
 	cleanup.Push(func() error { return treeCleaner() })
 
 	// Copy cloud-init if any
-	err = e.CopyCloudConfig(r.spec.Partitions.GetConfigStorage(), r.spec.CloudInit)
+	err = elemental.CopyCloudConfig(r.cfg.Config, r.spec.Partitions.GetConfigStorage(), r.spec.CloudInit)
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.CopyFile)
 	}

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -396,7 +396,7 @@ func IsHTTPURI(uri string) (bool, error) {
 
 // GetSource copies given source to destination, if source is a local path it simply
 // copies files, if source is a remote URL it tries to download URL to destination.
-func GetSource(config *v1.Config, source string, destination string) error {
+func GetSource(config v1.Config, source string, destination string) error {
 	local, err := IsLocalURI(source)
 	if err != nil {
 		config.Logger.Errorf("Not a valid url: %s", source)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -629,24 +629,24 @@ var _ = Describe("Utils", Label("utils"), func() {
 	})
 	Describe("GetSource", Label("GetSource"), func() {
 		It("Fails on invalid url", func() {
-			Expect(utils.GetSource(config, "$htt:|//insane.stuff", "/tmp/dest")).NotTo(BeNil())
+			Expect(utils.GetSource(*config, "$htt:|//insane.stuff", "/tmp/dest")).NotTo(BeNil())
 		})
 		It("Fails on readonly destination", func() {
 			config.Fs = vfs.NewReadOnlyFS(fs)
-			Expect(utils.GetSource(config, "http://something.org", "/tmp/dest")).NotTo(BeNil())
+			Expect(utils.GetSource(*config, "http://something.org", "/tmp/dest")).NotTo(BeNil())
 		})
 		It("Fails on non existing local source", func() {
-			Expect(utils.GetSource(config, "/some/missing/file", "/tmp/dest")).NotTo(BeNil())
+			Expect(utils.GetSource(*config, "/some/missing/file", "/tmp/dest")).NotTo(BeNil())
 		})
 		It("Fails on http client error", func() {
 			client.Error = true
 			url := "https://missing.io"
-			Expect(utils.GetSource(config, url, "/tmp/dest")).NotTo(BeNil())
+			Expect(utils.GetSource(*config, url, "/tmp/dest")).NotTo(BeNil())
 			client.WasGetCalledWith(url)
 		})
 		It("Copies local file to destination", func() {
 			fs.Create("/tmp/file")
-			Expect(utils.GetSource(config, "file:///tmp/file", "/tmp/dest")).To(BeNil())
+			Expect(utils.GetSource(*config, "file:///tmp/file", "/tmp/dest")).To(BeNil())
 			_, err := fs.Stat("/tmp/dest")
 			Expect(err).To(BeNil())
 		})


### PR DESCRIPTION
This PR refactors some methods in elemental package. Basically it turns some of the methods in to _static_ functions not tied to any object.

This is to allow reusing them without the need of an Elemental object. In fact I am also wondering of running a follow up PR completely removing the Elemental object from https://github.com/rancher/elemental-toolkit/blob/a7b7f2ea402359b952b4acae2bd89ec41f50d0c7/pkg/elemental/elemental.go#L33-L35
as this is a useless object. In only keeps the configuration which is anyway already available in all places where the elemental package is in use. So in a follow up PR I would even consider dropping the object entirely and simply pass the configuration struct as a parameter.

Part of #1874