### PR TITLE
Changes to cleanup-cache workflow

### DIFF
--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -1,20 +1,21 @@
 # Copied from
 # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#managing-cache
 
-name: cleanup caches by a branch
+name: Cleanup caches by a branch
 on:
   pull_request:
     types:
       - closed
 
+permissions:
+  # `actions:write` permission is required to delete caches
+  #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
+  actions: write
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    permissions:
-      # `actions:write` permission is required to delete caches
-      #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
-      actions: write
-      contents: read
     steps:      
       - name: Cleanup
         run: |
@@ -23,8 +24,6 @@ jobs:
           echo "Fetching list of cache key"
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
 
-          ## Setting this to not fail the workflow while deleting cache keys. 
-          set +e
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do


### PR DESCRIPTION
Tested this in https://github.com/frelon/cache-test/actions/runs/7209527181/job/19640659692 and seems to work when permissions are added for the whole workflow and not only jobs.