### PR TITLE
Change trigger to pull_request_target

### DIFF
--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -3,7 +3,7 @@
 
 name: Cleanup caches by a branch
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 


### PR DESCRIPTION
pull_request_target has write access to the target repository even when triggered from a 3rd party fork.

This is safe since we do not checkout any code and only run the workflow after closing the PR.