### PR TITLE
Adding new snapshotter interface

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -219,6 +219,7 @@ var _ = Describe("Config", Label("config"), func() {
 			Expect(cfg.Runner != nil).To(BeTrue())
 			_, ok := cfg.Runner.(*v1.RealRunner)
 			Expect(ok).To(BeTrue())
+			Expect(cfg.Snapshotter.MaxSnaps).To(Equal(constants.MaxSnaps))
 		})
 		It("uses provided configs and flags, flags have priority", func() {
 			cfg, err := ReadConfigRun("fixtures/config/", flags, mounter)
@@ -244,6 +245,17 @@ var _ = Describe("Config", Label("config"), func() {
 			debug = viper.GetBool("debug")
 			Expect(debug).To(BeTrue())
 			Expect(cfg.Logger.GetLevel()).To(Equal(logrus.DebugLevel))
+		})
+		It("reads the snaphotter configuration", func() {
+			// Default value
+			cfg, err := ReadConfigRun("fixtures/config/", nil, mounter)
+			Expect(err).To(BeNil())
+			Expect(cfg.Snapshotter.Type).To(Equal(constants.LoopDeviceSnapshotterType))
+			Expect(cfg.Snapshotter.MaxSnaps).To(Equal(7))
+			snapshooterCfg, ok := cfg.Snapshotter.Config.(v1.LoopDeviceConfig)
+			Expect(ok).To(BeTrue())
+			Expect(snapshooterCfg.FS).To(Equal("xfs"))
+			Expect(snapshooterCfg.Size).To(Equal(uint(1024)))
 		})
 	})
 	Describe("Read runtime specs", Label("spec"), func() {

--- a/cmd/config/fixtures/config/config.yaml
+++ b/cmd/config/fixtures/config/config.yaml
@@ -20,3 +20,10 @@ upgrade:
     uri: some/image:latest
   recovery-system:
     uri: recovery/image:latest
+
+snapshotter:
+  type: loopdevice
+  max-snaps: 7
+  config:
+    fs: xfs
+    size: 1024

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -164,6 +164,11 @@ func NewRunConfig(opts ...GenericOptions) *v1.RunConfig {
 	config := NewConfig(opts...)
 	r := &v1.RunConfig{
 		Config: *config,
+		Snapshotter: v1.SnapshotterConfig{
+			Type:     constants.LoopDeviceSnapshotterType,
+			MaxSnaps: constants.MaxSnaps,
+			Config:   v1.NewLoopDeviceConfig(),
+		},
 	}
 	return r
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -105,6 +105,14 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			cfg := config.NewRunConfig(config.WithMounter(mounter))
 			Expect(cfg.Mounter).To(Equal(mounter))
 			Expect(cfg.Runner).NotTo(BeNil())
+			It("sets the default snapshot as expected", func() {
+				Expect(cfg.Snapshotter.MaxSnaps).To(Equal(constants.MaxSnaps))
+				Expect(cfg.Snapshotter.Type).To(Equal(constants.LoopDeviceSnapshotterType))
+				snapshotterCfg, ok := cfg.Snapshotter.Config.(v1.LoopDeviceConfig)
+				Expect(ok).To(BeTrue())
+				Expect(snapshotterCfg.FS).To(Equal(constants.LinuxFs))
+				Expect(snapshotterCfg.Size).To(Equal(constants.ImgSize))
+			})
 		})
 		Describe("InstallSpec", func() {
 			It("sets installation defaults from install media with recovery", Label("install"), func() {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -166,6 +166,10 @@ const (
 	ArchRiscV64 = "riscv64"
 
 	Rsync = "rsync"
+
+	// Snapshotters
+	MaxSnaps                  = 4
+	LoopDeviceSnapshotterType = "loopdevice"
 )
 
 func GetKernelPatterns() []string {

--- a/pkg/snapshotter/loopdevice.go
+++ b/pkg/snapshotter/loopdevice.go
@@ -1,0 +1,77 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshotter
+
+import (
+	"path/filepath"
+
+	"github.com/rancher/elemental-toolkit/pkg/constants"
+
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
+	"github.com/rancher/elemental-toolkit/pkg/utils"
+)
+
+const (
+	loopDeviceSnapsPath    = ".snapshots"
+	loopDeviceImgName      = "snapshot.img"
+	loopDeviceWorkDir      = "snapshot.workDir"
+	loopDeviceLabelPattern = "EL_SNAP%d"
+	loopDevicePassiveSnaps = loopDeviceSnapsPath + "/passives"
+)
+
+var _ v1.Snapshotter = (*LoopDevice)(nil)
+
+type LoopDevice struct {
+	cfg            v1.Config
+	snapshotterCfg v1.SnapshotterConfig
+	loopDevCfg     v1.LoopDeviceConfig
+	rootDir        string
+	/*currentSnapshotID int
+	activeSnapshotID  int*/
+	bootloader v1.Bootloader
+}
+
+func NewLoopDeviceSnapshotter(cfg v1.Config, snapCfg v1.SnapshotterConfig, bootloader v1.Bootloader) *LoopDevice {
+	loopDevCfg := snapCfg.Config.(v1.LoopDeviceConfig)
+	return &LoopDevice{cfg: cfg, snapshotterCfg: snapCfg, loopDevCfg: loopDevCfg, bootloader: bootloader}
+}
+
+func (l *LoopDevice) InitSnapshotter(rootDir string) error {
+	l.cfg.Logger.Infof("Initiating a LoopDevice snapshotter at %s", rootDir)
+	l.rootDir = rootDir
+	return utils.MkdirAll(l.cfg.Fs, filepath.Join(rootDir, loopDevicePassiveSnaps), constants.DirPerm)
+}
+
+func (l *LoopDevice) StartTransaction() (*v1.Snapshot, error) {
+	var snap *v1.Snapshot
+
+	return snap, nil
+}
+
+func (l *LoopDevice) CloseTransactionOnError(_ *v1.Snapshot) error {
+	var err error
+	return err
+}
+
+func (l *LoopDevice) CloseTransaction(_ *v1.Snapshot) (err error) {
+	return err
+}
+
+func (l *LoopDevice) DeleteSnapshot(_ int) error {
+	var err error
+	return err
+}

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -157,9 +157,10 @@ func (c *Config) Sanitize() error {
 }
 
 type RunConfig struct {
-	Reboot   bool `yaml:"reboot,omitempty" mapstructure:"reboot"`
-	PowerOff bool `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
-	EjectCD  bool `yaml:"eject-cd,omitempty" mapstructure:"eject-cd"`
+	Reboot      bool              `yaml:"reboot,omitempty" mapstructure:"reboot"`
+	PowerOff    bool              `yaml:"poweroff,omitempty" mapstructure:"poweroff"`
+	EjectCD     bool              `yaml:"eject-cd,omitempty" mapstructure:"eject-cd"`
+	Snapshotter SnapshotterConfig `yaml:"snapshotter,omitempty" mapstructure:"snapshotter"`
 
 	// 'inline' and 'squash' labels ensure config fields
 	// are embedded from a yaml and map PoV

--- a/pkg/types/v1/snapshotter.go
+++ b/pkg/types/v1/snapshotter.go
@@ -1,0 +1,125 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+
+	mapstructure "github.com/mitchellh/mapstructure"
+	"github.com/rancher/elemental-toolkit/pkg/constants"
+)
+
+type Snapshotter interface {
+	InitSnapshotter(rootDir string) error
+	StartTransaction() (*Snapshot, error)
+	CloseTransaction(snap *Snapshot) error
+	CloseTransactionOnError(snap *Snapshot) error
+	DeleteSnapshot(id int) error
+}
+
+type SnapshotterConfig struct {
+	Type     string      `yaml:"type,omitempty" mapstructure:"type"`
+	MaxSnaps int         `yaml:"max-snaps,omitempty" mapstructure:"max-snaps"`
+	Config   interface{} `yaml:"config,omitempty" mapstructure:"config"`
+}
+
+type Snapshot struct {
+	ID         int
+	MountPoint string
+	Path       string
+	WorkDir    string
+	Label      string
+	InProgress bool
+}
+
+type LoopDeviceConfig struct {
+	Size uint   `yaml:"size,omitempty" mapstructure:"size"`
+	FS   string `yaml:"fs,omitempty" mapstructure:"fs"`
+}
+
+func NewLoopDeviceConfig() LoopDeviceConfig {
+	return LoopDeviceConfig{
+		FS:   constants.LinuxFs,
+		Size: constants.ImgSize,
+	}
+}
+
+type snapshotterConfFactory func(defConfig interface{}, data interface{}) (interface{}, error)
+
+func newLoopDeviceConfig(defConfig interface{}, data interface{}) (interface{}, error) {
+	cfg, ok := defConfig.(LoopDeviceConfig)
+	if !ok {
+		cfg = NewLoopDeviceConfig()
+	}
+	return innerConfigDecoder[LoopDeviceConfig](cfg, data)
+}
+
+var snapshotterConfFactories = map[string]snapshotterConfFactory{}
+
+func innerConfigDecoder[T any](defaultConf T, data interface{}) (T, error) {
+	confMap, ok := data.(map[string]interface{})
+	if !ok {
+		return defaultConf, fmt.Errorf("invalid 'config' format for loopdevice type")
+	}
+
+	cfg := &mapstructure.DecoderConfig{
+		Result: &defaultConf,
+	}
+	dec, err := mapstructure.NewDecoder(cfg)
+	if err != nil {
+		return defaultConf, fmt.Errorf("failed creating a decoder to unmarshal a loop device snapshotter: %v", err)
+	}
+	err = dec.Decode(confMap)
+	if err != nil {
+		return defaultConf, fmt.Errorf("failed to decode loopdevice configuration, invalid format: %v", err)
+	}
+	return defaultConf, nil
+}
+
+func (c *SnapshotterConfig) CustomUnmarshal(data interface{}) (bool, error) {
+	mData, ok := data.(map[string]interface{})
+	if len(mData) > 0 && ok {
+		snaphotterType, ok := mData["type"].(string)
+		if ok && snaphotterType != "" {
+			c.Type = snaphotterType
+		} else {
+			return false, fmt.Errorf("'type' is a required field for snapshotter setup")
+		}
+
+		if mData["max-snaps"] != nil {
+			maxSnaps, ok := mData["max-snaps"].(int)
+			if !ok {
+				return false, fmt.Errorf("'max-snap' must be of integer type")
+			}
+			c.MaxSnaps = maxSnaps
+		}
+
+		if mData["config"] != nil {
+			factory := snapshotterConfFactories[c.Type]
+			conf, err := factory(c.Config, mData["config"])
+			if err != nil {
+				return false, fmt.Errorf("failed decoding snapshotter configuration: %v", err)
+			}
+			c.Config = conf
+		}
+	}
+	return false, nil
+}
+
+func init() {
+	snapshotterConfFactories[constants.LoopDeviceSnapshotterType] = newLoopDeviceConfig
+}


### PR DESCRIPTION
This PR defines the snapshotter interface and snapshotter configuration structures. I does not provide any implementation of the interface it just provides all the required pieces to read the snapshotter configuration:

```yaml
snapshotter:
  type: loopdevice
  max-snaps: 4
  config:
    fs: ext2
    size: 0
 ```
 
 Config is defined internally as a `interface{}` and the format and schema of `config` depends on the `type` value. This PR essentially provides the structures definition and the logic to unmarshall `config` depending on `types` value.
 
In a follow up PR I expect to include the loopdevice implementation and its unit tests (but keeping the interface unused still). Finally in third of forth PR I expect to include the full refactor to actually start using the interface in `install`, `reset` and `upgrade`, commands.  All this is an effort to make PRs easier to follow and review.

Part of #1874 