### PR TITLE
Split arm and x86_64 tests

### DIFF
--- a/.github/workflows/build_and_test_arm.yaml
+++ b/.github/workflows/build_and_test_arm.yaml
@@ -1,0 +1,210 @@
+name: Build & test
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      flavor:
+        required: true
+        type: string
+
+concurrency:
+  group: ci-${{ inputs.flavor }}-aarch64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+
+  build-iso:
+    needs: detect
+    runs-on: [self-hosted, arm64]
+    env:
+      FLAVOR: ${{ inputs.flavor }}
+      ARCH: aarch64
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          git fetch --prune --unshallow
+      - name: Cached ISO
+        id: cache-iso
+        uses: actions/cache/restore@v3
+        env:
+          cache-name: pr-iso-build-aarch64-${{ inputs.flavor }}
+          enableCrossOsArchive: true
+          lookup-only: true
+        with:
+          path: /tmp/*.iso
+          key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
+      - if: ${{ steps.cache-iso.outputs.cache-hit != 'true' }}
+        name: Build toolkit
+        run: |
+          make build
+      - if: ${{ steps.cache-iso.outputs.cache-hit != 'true' }}
+        name: Build ISO
+        run: |
+          make build-iso
+          sudo mv build/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.iso /tmp/
+      - if: ${{ steps.cache-iso.outputs.cache-hit != 'true' }}
+        name: Save ISO
+        id: save-iso
+        uses: actions/cache/save@v3
+        env:
+          cache-name: pr-iso-build-aarch64-${{ inputs.flavor }}
+        with:
+          path: /tmp/*.iso
+          key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
+          enableCrossOsArchive: true
+  
+  build-disk:
+    needs: detect
+    runs-on: [self-hosted, arm64]
+    env:
+      FLAVOR: ${{ inputs.flavor }}
+      ARCH: aarch64
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          git fetch --prune --unshallow
+      - name: Checks cached Disk
+        uses: actions/cache/restore@v3
+        id: cache-check
+        env:
+          cache-name: pr-disk-build-aarch64-${{ inputs.flavor }}
+        with:
+          path: /tmp/*.qcow2
+          key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
+          enableCrossOsArchive: true
+          lookup-only: true
+      - if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
+        name: Cleanup worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+          sudo df -h
+      - if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
+        name: Install to disk
+        run: |
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends qemu-utils coreutils
+          make ARCH=${{ env.ARCH }} build-os
+          sudo -E make ARCH=${{ env.ARCH }} build-disk
+          sudo mv build/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 /tmp/
+      - if: ${{ steps.cache-check.outputs.cache-hit != 'true' }}
+        name: Save cached disk
+        id: cache-disk
+        uses: actions/cache/save@v3
+        env:
+          cache-name: pr-disk-build-aarch64-${{ inputs.flavor }}
+        with:
+          path: /tmp/*.qcow2
+          key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
+          enableCrossOsArchive: true
+
+  tests-matrix:
+    needs: 
+      - build-disk
+      - detect
+    runs-on: [self-hosted, arm64]
+    env:
+      FLAVOR: ${{ inputs.flavor }}
+      ARCH: aarch64
+      COS_TIMEOUT: 1600
+    strategy:
+      matrix:
+        test: 
+          - test-smoke
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Install deps
+        run: |
+          make test-deps
+      - run: |
+          git fetch --prune --unshallow
+      - name: Cached Disk
+        id: cache-disk
+        uses: actions/cache/restore@v3
+        env:
+          cache-name: pr-disk-build-aarch64-${{ inputs.flavor }}
+        with:
+          path: /tmp/*.qcow2
+          key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - name: Run ${{ matrix.test }} 
+        run: |
+          make DISK=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ELMNTL_ACCEL=none ELMNTL_MACHINETYPE=virt ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=/usr/share/AAVMF/AAVMF_CODE.fd ${{ matrix.test }}
+      - name: Upload serial console for ${{ matrix.test }}
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: serial-${{ env.ARCH }}-${{ env.FLAVOR }}-${{ matrix.test }}.log
+          path: tests/serial.log
+          if-no-files-found: error
+      - name: Upload qemu stdout for ${{ matrix.test }}
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: vmstdout-${{ env.ARCH }}-${{ env.FLAVOR }}-${{ matrix.test }}.log
+          path: tests/vmstdout
+          if-no-files-found: error
+      - name: Stop test VM
+        if: always()
+        run: |
+          make test-clean
+
+  test-installer:
+    needs: 
+      - build-iso
+      - detect
+    runs-on: [self-hosted, arm64]
+    env:
+      FLAVOR: ${{ inputs.flavor }}
+      ARCH: aarch64
+      COS_TIMEOUT: 1600
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+      - name: Install deps
+        run: |
+          make test-deps
+      - run: |
+          git fetch --prune --unshallow
+      - name: Cached ISO
+        id: cache-iso
+        uses: actions/cache/restore@v3
+        env:
+          cache-name: pr-iso-build-aarch64-${{ inputs.flavor }}
+        with:
+          path: /tmp/*.iso
+          key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
+          enableCrossOsArchive: true
+          fail-on-cache-miss: true
+      - name: Run installer test 
+        run: |
+          make ISO=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.iso ELMNTL_ACCEL=none ELMNTL_MACHINETYPE=virt ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=/usr/share/AAVMF/AAVMF_CODE.fd test-installer
+      - name: Upload serial console for installer tests
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: serial-${{ env.ARCH }}-${{ env.FLAVOR }}-installer.log
+          path: tests/serial.log
+          if-no-files-found: error
+      - name: Upload qemu stdout for installer tests
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: vmstdout-${{ env.ARCH }}-${{ env.FLAVOR }}-installer.log
+          path: tests/vmstdout
+          if-no-files-found: error
+      - name: Stop test VM
+        if: always()
+        run: |
+          make test-clean

--- a/.github/workflows/build_and_test_x86.yaml
+++ b/.github/workflows/build_and_test_x86.yaml
@@ -1,17 +1,14 @@
-name: Build & test
+name: Build & test x86_64
 
 on:
   workflow_call:
     inputs:
-      arch:
-        required: true
-        type: string
       flavor:
         required: true
         type: string
 
 concurrency:
-  group: ci-${{ inputs.flavor }}-${{ inputs.arch }}-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  group: ci-${{ inputs.flavor }}-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
 jobs:
@@ -19,36 +16,25 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      build-runs-on: ${{ steps.detect.outputs.buildon }}
-      tests-runs-on: ${{ steps.detect.outputs.testson }}
       tests: ${{ steps.detect.outputs.tests }}
     steps:
       - id: detect
         env:
           FLAVOR: ${{ inputs.flavor }}
         run: |
-          case "${{inputs.arch}}" in
-          x86_64)
-            echo "buildon='ubuntu-latest'" >> $GITHUB_OUTPUT
-            echo "testson='macos-latest'" >> $GITHUB_OUTPUT
-            if [ "${FLAVOR}" == green ]; then
-              echo "tests=['test-upgrade', 'test-recovery', 'test-fallback', 'test-fsck', 'test-grubfallback']" >> $GITHUB_OUTPUT
-            else
-              echo "tests=['test-active']" >> $GITHUB_OUTPUT
-            fi
-            ;;
-          aarch64)
-            echo "buildon=['self-hosted', 'arm64']" >> $GITHUB_OUTPUT
-            echo "testson=['self-hosted', 'arm64']" >> $GITHUB_OUTPUT
-            echo "tests=['test-smoke']" >> $GITHUB_OUTPUT ;;
-          esac
+          if [ "${FLAVOR}" == green ]; then
+            echo "tests=['test-upgrade', 'test-recovery', 'test-fallback', 'test-fsck', 'test-grubfallback']" >> $GITHUB_OUTPUT
+          else
+            echo "tests=['test-active']" >> $GITHUB_OUTPUT
+          fi
+
 
   build-iso:
     needs: detect
-    runs-on: ${{ fromJson(needs.detect.outputs.build-runs-on) }}
+    runs-on: ubuntu-latest
     env:
       FLAVOR: ${{ inputs.flavor }}
-      ARCH: ${{ inputs.arch }}
+      ARCH: x86_64
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -57,7 +43,7 @@ jobs:
         id: cache-iso
         uses: actions/cache/restore@v3
         env:
-          cache-name: pr-iso-build-${{ inputs.arch }}-${{ inputs.flavor }}
+          cache-name: pr-iso-build-x86_64-${{ inputs.flavor }}
           enableCrossOsArchive: true
           lookup-only: true
         with:
@@ -77,18 +63,18 @@ jobs:
         id: save-iso
         uses: actions/cache/save@v3
         env:
-          cache-name: pr-iso-build-${{ inputs.arch }}-${{ inputs.flavor }}
+          cache-name: pr-iso-build-x86_64-${{ inputs.flavor }}
         with:
           path: /tmp/*.iso
           key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
           enableCrossOsArchive: true
-  
+
   build-disk:
     needs: detect
-    runs-on: ${{ fromJson(needs.detect.outputs.build-runs-on) }}
+    runs-on: ubuntu-latest
     env:
       FLAVOR: ${{ inputs.flavor }}
-      ARCH: ${{ inputs.arch }}
+      ARCH: x86_64
     steps:
       - uses: actions/checkout@v3
       - run: |
@@ -97,7 +83,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: cache-check
         env:
-          cache-name: pr-disk-build-${{ inputs.arch }}-${{ inputs.flavor }}
+          cache-name: pr-disk-build-x86_64-${{ inputs.flavor }}
         with:
           path: /tmp/*.qcow2
           key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
@@ -121,20 +107,20 @@ jobs:
         id: cache-disk
         uses: actions/cache/save@v3
         env:
-          cache-name: pr-disk-build-${{ inputs.arch }}-${{ inputs.flavor }}
+          cache-name: pr-disk-build-x86_64-${{ inputs.flavor }}
         with:
           path: /tmp/*.qcow2
           key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
           enableCrossOsArchive: true
 
   tests-matrix:
-    needs: 
+    needs:
       - build-disk
       - detect
-    runs-on: ${{ fromJson(needs.detect.outputs.tests-runs-on) }}
+    runs-on: macos-latest
     env:
       FLAVOR: ${{ inputs.flavor }}
-      ARCH: ${{ inputs.arch }}
+      ARCH: x86_64
       COS_TIMEOUT: 1600
     strategy:
       matrix:
@@ -155,28 +141,18 @@ jobs:
         id: cache-disk
         uses: actions/cache/restore@v3
         env:
-          cache-name: pr-disk-build-${{ inputs.arch }}-${{ inputs.flavor }}
+          cache-name: pr-disk-build-x86_64-${{ inputs.flavor }}
         with:
           path: /tmp/*.qcow2
           key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
           enableCrossOsArchive: true
           fail-on-cache-miss: true
-      - if: ${{ env.ARCH == 'x86_64' }} 
-        name: Run VM script dependencies
+      - name: Run VM script dependencies
         run: |
           brew install bash coreutils
-      - if: ${{ env.ARCH == 'x86_64' }} 
-        name: Prepare test (x86_64)
-        run: |
-          make DISK=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ELMNTL_ACCEL=hvf ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=$(find /usr/local/Cellar/qemu -name edk2-${{ env.ARCH }}-code.fd -print -quit) prepare-test
-      - if: ${{ env.ARCH == 'aarch64' }} 
-        name: Prepare test (aarch64)
-        run: |
-          make DISK=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ELMNTL_ACCEL=none ELMNTL_MACHINETYPE=virt ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=/usr/share/AAVMF/AAVMF_CODE.fd prepare-test
       - name: Run ${{ matrix.test }}
         run: |
-          make DISK=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ${{ matrix.test }}
-      # TODO include other logs SUT collects on failure
+          make DISK=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.qcow2 ELMNTL_ACCEL=hvf ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=$(find /usr/local/Cellar/qemu -name edk2-${{ env.ARCH }}-code.fd -print -quit) ${{ matrix.test }}
       - name: Upload serial console for ${{ matrix.test }}
         uses: actions/upload-artifact@v3
         if: always()
@@ -197,13 +173,13 @@ jobs:
           make test-clean
 
   test-installer:
-    needs: 
+    needs:
       - build-iso
       - detect
-    runs-on: ${{ fromJson(needs.detect.outputs.tests-runs-on) }}
+    runs-on: macos-latest
     env:
       FLAVOR: ${{ inputs.flavor }}
-      ARCH: ${{ inputs.arch }}
+      ARCH: x86_64
       COS_TIMEOUT: 1600
     steps:
       - uses: actions/checkout@v3
@@ -220,28 +196,18 @@ jobs:
         id: cache-iso
         uses: actions/cache/restore@v3
         env:
-          cache-name: pr-iso-build-${{ inputs.arch }}-${{ inputs.flavor }}
+          cache-name: pr-iso-build-x86_64-${{ inputs.flavor }}
         with:
           path: /tmp/*.iso
           key: ${{ env.cache-name }}-${{ hashFiles('Dockerfile', '**/go.sum', '**/pkg/**', '**/examples/**', '**/cmd/**', '**/vendor/**', '**/Makefile', '**/main.go') }}
           enableCrossOsArchive: true
           fail-on-cache-miss: true
-      - if: ${{ env.ARCH == 'x86_64' }} 
-        name: Run VM script dependencies
+      - name: Run VM script dependencies
         run: |
           brew install bash coreutils
-      - if: ${{ env.ARCH == 'x86_64' }} 
-        name: Prepare test (x86_64)
-        run: |
-          make ISO=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.iso ELMNTL_ACCEL=hvf ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=$(find /usr/local/Cellar/qemu -name edk2-${{ env.ARCH }}-code.fd -print -quit) prepare-installer-test
-      - if: ${{ env.ARCH == 'aarch64' }} 
-        name: Prepare test (aarch64)
-        run: |
-          make ISO=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.iso ELMNTL_ACCEL=none ELMNTL_MACHINETYPE=virt ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=/usr/share/AAVMF/AAVMF_CODE.fd prepare-installer-test
       - name: Run installer test
         run: |
-          make ISO=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.iso test-installer
-      # TODO include other logs SUT collects on failure
+          make ISO=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.iso ELMNTL_ACCEL=hvf ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=$(find /usr/local/Cellar/qemu -name edk2-${{ env.ARCH }}-code.fd -print -quit) test-installer
       - name: Upload serial console for installer tests
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/manual_arm.yaml
+++ b/.github/workflows/manual_arm.yaml
@@ -2,15 +2,15 @@ name: nightly
 
 on:
   workflow_dispatch:
-  schedule:
+  #schedule:
     # run at 02:30 UTC every night
-    - cron:  '30 2 * * *'
+    #- cron:  '30 2 * * *'
 
 jobs:
   build-matrix:
     strategy:
       matrix:
         flavor: ['green', 'tumbleweed']
-    uses: ./.github/workflows/build_and_test_x86.yaml
+    uses: ./.github/workflows/build_and_test_arm.yaml
     with:
       flavor: ${{ matrix.flavor }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,16 +16,10 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      arch: ${{ steps.set-matrix.outputs.arch }}
       flavor: ${{ steps.set-matrix.outputs.flavor }}
     steps:
     - id: set-matrix
       run: |
-        if [ "${{ contains(github.event.pull_request.labels.*.name, 'arm64') }}" == "true" ]; then
-          echo "arch=['x86_64', 'aarch64']" >> $GITHUB_OUTPUT
-        else
-          echo "arch=['x86_64']" >> $GITHUB_OUTPUT
-        fi
         if [ "${{ contains(github.event.pull_request.labels.*.name, 'all-distros') }}" == "true" ]; then
           echo "flavor=['green', 'tumbleweed', 'blue', 'orange']" >> $GITHUB_OUTPUT
         else
@@ -36,15 +30,8 @@ jobs:
     needs: detect
     strategy:
       matrix:
-        arch: ${{fromJson(needs.detect.outputs.arch)}}
         flavor: ${{fromJson(needs.detect.outputs.flavor)}}
-        exclude:
-          - arch: aarch64
-            flavor: blue
-          - arch: aarch64
-            flavor: orange
       fail-fast: false
-    uses: ./.github/workflows/build_and_test.yaml
+    uses: ./.github/workflows/build_and_test_x86.yaml
     with:
-      arch: ${{ matrix.arch }}
       flavor: ${{ matrix.flavor }}


### PR DESCRIPTION
This commit splits arm64 and x86_64 tests. With this PR arm64 tests on self hosted runners can only be executed on demand, they are no longer possible in PRs.

Later on we can consider making them executable on scheduled basis if we consider them to be stable enough.