### PR TITLE
Add default cloud-init-paths to build commands

### DIFF
--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -681,6 +681,8 @@ type BuildConfig struct {
 // Sanitize checks the consistency of the struct, returns error
 // if unsolvable inconsistencies are found
 func (b *BuildConfig) Sanitize() error {
+	// Always include default cloud-init paths
+	b.CloudInitPaths = append(constants.GetCloudInitPaths(), b.CloudInitPaths...)
 	return b.Config.Sanitize()
 }
 


### PR DESCRIPTION
This will run build-hooks from `/oem`, `/system/oem` and `/usr/local/cloud-config` by default.