### PR TITLE
Refactor to switch to snapshotter interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ build-disk: build-os
 	mkdir -p $(ROOT_DIR)/build
 	$(DOCKER) run --rm -v $(DOCKER_SOCK):$(DOCKER_SOCK) -v $(ROOT_DIR)/build:/build \
 		--entrypoint /usr/bin/elemental \
-		$(TOOLKIT_REPO):$(VERSION) --debug build-disk --platform $(PLATFORM) --unprivileged --expandable -n elemental-$(FLAVOR).$(ARCH) --local \
-		--squash-no-compression -o /build $(REPO):$(VERSION)
+		$(TOOLKIT_REPO):$(VERSION) --debug build-disk --platform $(PLATFORM) --expandable -n elemental-$(FLAVOR).$(ARCH) --local \
+		--squash-no-compression -o /build --system $(REPO):$(VERSION)
 	qemu-img convert -O qcow2 $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).raw $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).qcow2
 	qemu-img resize $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).qcow2 $(DISKSIZE) 
 

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -305,22 +304,20 @@ func applyKernelCmdline(r *v1.RunConfig, mount *v1.MountSpec) error {
 		}
 
 		switch split[0] {
-		case "elemental.image":
-			mount.Mode = val
-		case "elemental.disable", "rd.cos.disable":
-			mount.Disable = true
-		case "cos-img/filename":
-			switch val {
-			case constants.ActiveImgPath:
+		case "elemental.image", "cos-img/filename":
+			switch {
+			case strings.Contains(val, constants.ActiveImgName):
 				mount.Mode = constants.ActiveImgName
-			case constants.PassiveImgPath:
+			case strings.Contains(val, constants.PassiveImgName):
 				mount.Mode = constants.PassiveImgName
-			case constants.RecoveryImgPath:
+			case strings.Contains(val, constants.RecoveryImgName):
 				mount.Mode = constants.RecoveryImgName
 			default:
 				r.Logger.Errorf("Error parsing cmdline %s", cmd)
-				return errors.New("Unknown image path")
+				return fmt.Errorf("Unknown image path: %s", val)
 			}
+		case "elemental.disable", "rd.cos.disable":
+			mount.Disable = true
 		case "elemental.overlay", "rd.cos.overlay":
 			err := applyMountOverlay(mount, val)
 			if err != nil {

--- a/cmd/config/fixtures/config/config.yaml
+++ b/cmd/config/fixtures/config/config.yaml
@@ -7,17 +7,15 @@ install:
   target: "someDisk"
 
   no-format: true
-  system:
-    uri: docker:some/image:latest
+  system: docker:some/image:latest
   recovery-system:
     uri: docker:recovery/image:latest
-
+    
 reset:
   disable-boot-entry: true
 
 upgrade:
-  system:
-    uri: some/image:latest
+  system: some/image:latest
   recovery-system:
     uri: recovery/image:latest
 

--- a/cmd/config/fixtures/config/manifest.yaml
+++ b/cmd/config/fixtures/config/manifest.yaml
@@ -19,10 +19,9 @@ disk:
     persistent:
       size: 0
       fs: xfs
-  unprivileged: true
   expandable: true
+  system: some.registry.org/my/image:mytag
   recovery-system:
-    uri: some.registry.org/my/image:mytag
     fs: squashfs
   type: raw
 

--- a/cmd/config/fixtures/simple/config.yaml
+++ b/cmd/config/fixtures/simple/config.yaml
@@ -3,17 +3,18 @@ verify: true
 
 install:
   grub-entry-name: "mockme"
-  system:
-    size: 2000
   recovery-system:
     size: 2000
 upgrade:
   grub-entry-name: "so"
   recovery-system:
     size: 2000
-  system:
-    size: 2000
 reset:
   grub-entry-name: "awesome"
-  system:
+
+snapshotter:
+  type: loopdevice
+  max-snaps: 7
+  config:
+    fs: xfs
     size: 2000

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -43,7 +43,7 @@ func addPowerFlags(cmd *cobra.Command) {
 // addSharedInstallUpgradeFlags add flags shared between install, upgrade and reset
 func addSharedInstallUpgradeFlags(cmd *cobra.Command) {
 	addResetFlags(cmd)
-	cmd.Flags().String("recovery-system.uri", "", "Sets the recovery image source and its type (e.g. 'docker:registry.org/image:tag')")
+	addRecoverySystemFlag(cmd)
 	addSquashFsCompressionFlags(cmd)
 }
 
@@ -55,12 +55,22 @@ func addResetFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("docker-image", "d", "", "Install a specified container image")
 	_ = cmd.Flags().MarkDeprecated("docker-image", "'docker-image' is deprecated please use 'system' instead")
 
-	cmd.Flags().String("system.uri", "", "Sets the system image source and its type (e.g. 'docker:registry.org/image:tag')")
 	cmd.Flags().Bool("verify", false, "Enable mtree checksum verification (requires images manifests generated with mtree separately)")
 	cmd.Flags().Bool("strict", false, "Enable strict check of hooks (They need to exit with 0)")
 
+	addSystemFlag(cmd)
 	addCosignFlags(cmd)
 	addPowerFlags(cmd)
+}
+
+// addSystemFlag adds system flag to define source OS
+func addSystemFlag(cmd *cobra.Command) {
+	cmd.Flags().String("system", "", "Sets the system image source and its type (e.g. 'docker:registry.org/image:tag')")
+}
+
+// addRecoverySystemFlag adds the recovery-system.uri flag to define recovery source OS
+func addRecoverySystemFlag(cmd *cobra.Command) {
+	cmd.Flags().String("recovery-system.uri", "", "Sets the recovery image source and its type (e.g. 'docker:registry.org/image:tag')")
 }
 
 // addLocalImageFlag add local image flag shared between install, pull-image, upgrade
@@ -69,7 +79,7 @@ func addLocalImageFlag(cmd *cobra.Command) {
 }
 
 func adaptDockerImageAndDirectoryFlagsToSystem(flags *pflag.FlagSet) {
-	systemFlag := "system.uri"
+	systemFlag := "system"
 	doc, _ := flags.GetString("docker-image")
 	if doc != "" {
 		_ = flags.Set(systemFlag, fmt.Sprintf("docker:%s", doc))
@@ -96,7 +106,7 @@ func validateCosignFlags(log v1.Logger, flags *pflag.FlagSet) error {
 
 func validateSourceFlags(_ v1.Logger, flags *pflag.FlagSet) error {
 	msg := "flags docker-image, directory and system are mutually exclusive, please only set one of them"
-	system, _ := flags.GetString("system.uri")
+	system, _ := flags.GetString("system")
 	directory, _ := flags.GetString("directory")
 	dockerImg, _ := flags.GetString("docker-image")
 	// docker-image, directory and system are mutually exclusive. Can't have your cake and eat it too.

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -80,7 +80,11 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			}
 
 			cfg.Logger.Infof("Install called")
-			install := action.NewInstallAction(cfg, spec)
+			install, err := action.NewInstallAction(cfg, spec)
+			if err != nil {
+				cfg.Logger.Errorf("failed to initialize install action: %v", err)
+				return err
+			}
 			return install.Run()
 		},
 	}

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -65,14 +65,14 @@ var _ = Describe("Install", Label("install", "cmd"), func() {
 		Expect(err.(*elementalError.ElementalError).ExitCode()).To(Equal(elementalError.ReadingInstallUpgradeFlags))
 	})
 	It("Errors out if no installation source is defined", Label("args"), func() {
-		_, _, err := executeCommandC(rootCmd, "install")
+		_, _, err := executeCommandC(rootCmd, "install", "/dev/nonexisting")
 		Expect(err).ToNot(BeNil())
 		Expect(buf.String()).To(ContainSubstring("undefined system source to install"))
 	})
 	It("Errors out if no installation target is defined", Label("args"), func() {
 		_, _, err := executeCommandC(rootCmd, "install", "--directory", "dir")
 		Expect(err).ToNot(BeNil())
-		Expect(buf.String()).To(ContainSubstring("at least a target device must be supplied"))
+		Expect(buf.String()).To(ContainSubstring("target device must be supplied"))
 		Expect(err.(*elementalError.ElementalError)).ToNot(BeNil())
 		Expect(err.(*elementalError.ElementalError).ExitCode()).To(Equal(elementalError.InvalidTarget))
 	})

--- a/cmd/pull-image.go
+++ b/cmd/pull-image.go
@@ -64,11 +64,14 @@ func NewPullImageCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 
 			cfg.Logger.Infof("Pulling image %s platform %s", image, cfg.Platform.String())
 
+			var digest string
 			e := v1.OCIImageExtractor{}
-			if err = e.ExtractImage(image, destination, cfg.Platform.String(), local); err != nil {
+			if digest, err = e.ExtractImage(image, destination, cfg.Platform.String(), local); err != nil {
 				cfg.Logger.Error(err.Error())
 				return elementalError.NewFromError(err, elementalError.UnpackImage)
 			}
+
+			cfg.Logger.Info("Extracted image digest: %s", digest)
 
 			return nil
 		},

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -67,7 +67,11 @@ func NewResetCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			}
 
 			cfg.Logger.Infof("Reset called")
-			reset := action.NewResetAction(cfg, spec)
+			reset, err := action.NewResetAction(cfg, spec)
+			if err != nil {
+				cfg.Logger.Errorf("failed to initialize reset action: %v", err)
+				return err
+			}
 			return reset.Run()
 		},
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -75,7 +75,12 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			}
 
 			cfg.Logger.Infof("Upgrade called")
-			upgrade := action.NewUpgradeAction(cfg, spec)
+			upgrade, err := action.NewUpgradeAction(cfg, spec)
+			if err != nil {
+				cfg.Logger.Errorf("failed to initialize upgrade action: %v", err)
+				return err
+			}
+
 			return upgrade.Run()
 		},
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -85,7 +85,8 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		},
 	}
 	root.AddCommand(c)
-	c.Flags().Bool("recovery", false, "Upgrade the recovery")
+	c.Flags().Bool("recovery", false, "Upgrade recovery image too")
+	c.Flags().Bool("bootloader", false, "Reinstall bootloader during the upgrade")
 	addSharedInstallUpgradeFlags(c)
 	addLocalImageFlag(c)
 	return c

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -59,20 +59,20 @@ install:
   iso: https://my.domain.org/some/powerful.iso
 
   # main OS image
-  # size in MiB
-  system:
-    label: COS_ACTIVE
-    size: 1024
-    fs: ext2
-    uri: oci:some.registry.org/elemental/image:latest
+  system: oci:some.registry.org/elemental/image:latest
 
   # recovery OS image
   recovery-system:
     fs: squashfs
     uri: oci:recovery/elemental
 
-  # filesystem label of the passive backup image
-  passive.label: COS_PASSIVE
+  snapshotter:
+    type: loopdevice
+    max-snaps: 4
+    config:
+      size: 0
+      fs: ext2
+      
 
   # extra cloud-init config file URI to include during the installation
   cloud-init: "https://some.cloud-init.org/my-config-file"

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -123,7 +123,6 @@ func (b *BuildDiskAction) preparePartitionsRoot() error {
 }
 
 func (b *BuildDiskAction) BuildDiskRun() (err error) { //nolint:gocyclo
-	var recInfo, activeInfo interface{}
 	var rawImg string
 
 	b.cfg.Logger.Infof("Building disk image type %s for arch %s", b.spec.Type, b.cfg.Arch)
@@ -170,7 +169,7 @@ func (b *BuildDiskAction) BuildDiskRun() (err error) { //nolint:gocyclo
 	}
 
 	// Install grub
-	err = b.bootloader.InstallConfig(recRoot, b.roots[constants.StatePartName])
+	err = b.bootloader.InstallConfig(recRoot, b.roots[constants.EfiPartName])
 	if err != nil {
 		b.cfg.Logger.Errorf("failed installing grub configuration: %s", err.Error())
 		return err

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -329,7 +329,7 @@ func (b BuildISOAction) burnISO(root, efiImg string) error {
 
 func (b BuildISOAction) applySources(target string, sources ...*v1.ImageSource) error {
 	for _, src := range sources {
-		_, err := elemental.DumpSource(b.cfg.Config, target, src)
+		err := elemental.DumpSource(b.cfg.Config, target, src)
 		if err != nil {
 			return elementalError.NewFromError(err, elementalError.DumpSource)
 		}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -219,6 +219,11 @@ func (u *UpgradeAction) Run() (err error) {
 		return elementalError.NewFromError(err, elementalError.MountRecoveryPartition)
 	}
 	cleanup.Push(umount)
+	umount, err = elemental.MountRWPartition(u.cfg.Config, u.spec.Partitions.EFI)
+	if err != nil {
+		return elementalError.NewFromError(err, elementalError.MountEFIPartition)
+	}
+	cleanup.Push(umount)
 
 	// Recovery does not mount persistent, so try to mount it. Ignore errors, as it's not mandatory.
 	persistentPart := u.spec.Partitions.Persistent

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -279,6 +279,18 @@ func (u *UpgradeAction) Run() (err error) {
 		return err
 	}
 
+	// Manage legacy recovery. This logic should be removed once toolkit v1.1 gets unsupported.
+	legacyImg := filepath.Join(u.spec.Partitions.Recovery.MountPoint, constants.LegacyImagesPath, constants.RecoveryImgFile)
+	if ok, _ := utils.Exists(u.cfg.Fs, legacyImg); ok {
+		u.cfg.Logger.Debug("Manage legacy recovery image")
+		recoveryImg := filepath.Join(u.spec.Partitions.Recovery.MountPoint, constants.RecoveryImgFile)
+		err = u.cfg.Fs.Rename(legacyImg, recoveryImg)
+		if err != nil {
+			u.cfg.Logger.Error("failed renaming recovery image from legacy path")
+			return err
+		}
+	}
+
 	// Closing snapshotter transaction
 	u.cfg.Logger.Info("Closing snapshotter transaction")
 	err = u.snapshotter.CloseTransaction(u.snapshot)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -351,8 +351,8 @@ func (u *UpgradeAction) refineDeployment() error { //nolint:dupl
 	if u.spec.BootloaderUpgrade {
 		err = u.bootloader.Install(
 			u.snapshot.WorkDir,
-			u.spec.Partitions.State.MountPoint,
-			u.spec.Partitions.State.FilesystemLabel,
+			u.spec.Partitions.EFI.MountPoint,
+			u.spec.Partitions.EFI.FilesystemLabel,
 		)
 		if err != nil {
 			u.cfg.Logger.Errorf("failed installing grub: %v", err)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -364,7 +364,6 @@ func (u *UpgradeAction) refineDeployment() error { //nolint:dupl
 		err = u.bootloader.Install(
 			u.snapshot.WorkDir,
 			u.spec.Partitions.EFI.MountPoint,
-			u.spec.Partitions.EFI.FilesystemLabel,
 		)
 		if err != nil {
 			u.cfg.Logger.Errorf("failed installing grub: %v", err)

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -19,9 +19,7 @@ package action_test
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/jaypipes/ghw/pkg/block"
 	. "github.com/onsi/ginkgo/v2"
@@ -86,10 +84,6 @@ var _ = Describe("Runtime Actions", func() {
 		var spec *v1.UpgradeSpec
 		var upgrade *action.UpgradeAction
 		var memLog *bytes.Buffer
-		activeImg := fmt.Sprintf("%s%s", constants.RunningStateDir, constants.ActiveImgPath)
-		passiveImg := fmt.Sprintf("%s%s", constants.RunningStateDir, constants.PassiveImgPath)
-
-		recoveryImg := fmt.Sprintf("%s%s", constants.LiveDir, constants.RecoveryImgPath)
 
 		BeforeEach(func() {
 			memLog = &bytes.Buffer{}
@@ -98,9 +92,9 @@ var _ = Describe("Runtime Actions", func() {
 			logger.SetLevel(logrus.DebugLevel)
 
 			// Create paths used by tests
-			utils.MkdirAll(fs, constants.EfiDir, constants.DirPerm)
-			utils.MkdirAll(fs, fmt.Sprintf("%s/cOS", constants.RunningStateDir), constants.DirPerm)
-			utils.MkdirAll(fs, fmt.Sprintf("%s/cOS", constants.LiveDir), constants.DirPerm)
+			Expect(utils.MkdirAll(fs, constants.RunningStateDir, constants.DirPerm)).To(Succeed())
+			Expect(utils.MkdirAll(fs, constants.LiveDir, constants.DirPerm)).To(Succeed())
+			Expect(utils.MkdirAll(fs, filepath.Dir(constants.ActiveMode), constants.DirPerm)).To(Succeed())
 
 			mainDisk := block.Disk{
 				Name: "device",
@@ -116,11 +110,6 @@ var _ = Describe("Runtime Actions", func() {
 						FilesystemLabel: "COS_STATE",
 						Type:            "ext4",
 						MountPoint:      constants.RunningStateDir,
-					},
-					{
-						Name:            "loop0",
-						FilesystemLabel: "COS_ACTIVE",
-						Type:            "ext4",
 					},
 					{
 						Name:            "device5",
@@ -148,8 +137,10 @@ var _ = Describe("Runtime Actions", func() {
 				spec, err = conf.NewUpgradeSpec(config.Config)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				spec.Active.Source = v1.NewDockerSrc("alpine")
-				spec.Active.Size = 16
+				spec.System = v1.NewDockerSrc("alpine")
+				loopCfg, ok := config.Snapshotter.Config.(*v1.LoopDeviceConfig)
+				Expect(ok).To(BeTrue())
+				loopCfg.Size = 16
 
 				err = utils.MkdirAll(config.Fs, filepath.Join(constants.WorkingImgDir, "etc"), constants.DirPerm)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -161,87 +152,54 @@ var _ = Describe("Runtime Actions", func() {
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				runner.SideEffect = func(command string, args ...string) ([]byte, error) {
-					if command == "cat" && args[0] == "/proc/cmdline" {
-						return []byte(constants.ActiveLabel), nil
-					}
-					if command == "mv" && args[0] == "-f" && args[1] == activeImg && args[2] == passiveImg {
-						// we doing backup, do the "move"
-						source, _ := fs.ReadFile(activeImg)
-						_ = fs.WriteFile(passiveImg, source, constants.FilePerm)
-						_ = fs.RemoveAll(activeImg)
-					}
-					if command == "mv" && args[0] == "-f" && args[1] == spec.Active.File && args[2] == activeImg {
-						// we doing the image substitution, do the "move"
-						source, _ := fs.ReadFile(spec.Active.File)
-						_ = fs.WriteFile(activeImg, source, constants.FilePerm)
-						_ = fs.RemoveAll(spec.Active.File)
-					}
-					if command == "grub2-editenv" && args[1] == "set" {
-						f, err := fs.OpenFile(args[0], os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-						Expect(err).To(BeNil())
-
-						_, err = f.Write([]byte(fmt.Sprintf("%s\n", args[2])))
-						Expect(err).To(BeNil())
-					}
-
-					return []byte{}, nil
-				}
-				config.Runner = runner
-				// Create fake active/passive files
-				_ = fs.WriteFile(activeImg, []byte("active"), constants.FilePerm)
-				_ = fs.WriteFile(passiveImg, []byte("passive"), constants.FilePerm)
-				// Mount state partition as it is expected to be mounted when booting from active
 				mounter.Mount("device2", constants.RunningStateDir, "auto", []string{"ro"})
 			})
 			AfterEach(func() {
-				_ = fs.RemoveAll(activeImg)
-				_ = fs.RemoveAll(passiveImg)
+				//fmt.Println(memLog.String())
 			})
 			It("Fails if some hook fails and strict is set", func() {
-				runner.SideEffect = func(command string, args ...string) ([]byte, error) {
-					if command == "cat" && args[0] == "/proc/cmdline" {
-						return []byte(constants.ActiveLabel), nil
-					}
-					return []byte{}, nil
-				}
+				Expect(fs.WriteFile(constants.ActiveMode, []byte("1"), constants.FilePerm)).To(Succeed())
 				config.Strict = true
 				cloudInit.Error = true
-				upgrade = action.NewUpgradeAction(config, spec)
+				upgrade, err = action.NewUpgradeAction(config, spec, action.WithUpgradeBootloader(bootloader))
+				Expect(err).NotTo(HaveOccurred())
 				err := upgrade.Run()
 				Expect(err).To(HaveOccurred())
-				// Make sure is a cloud init error!
 				Expect(err.Error()).To(ContainSubstring("cloud init"))
 			})
 			It("Fails setting the grub labels", func() {
 				bootloader.ErrorSetPersistentVariables = true
-				upgrade = action.NewUpgradeAction(config, spec, action.WithUpgradeBootloader(bootloader))
+				upgrade, err = action.NewUpgradeAction(config, spec, action.WithUpgradeBootloader(bootloader))
+				Expect(err).NotTo(HaveOccurred())
 				err := upgrade.Run()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("setting persistent variables"))
 			})
 			It("Fails setting the grub default entry", func() {
 				bootloader.ErrorSetDefaultEntry = true
-				upgrade = action.NewUpgradeAction(config, spec, action.WithUpgradeBootloader(bootloader))
+				upgrade, err = action.NewUpgradeAction(config, spec, action.WithUpgradeBootloader(bootloader))
+				Expect(err).NotTo(HaveOccurred())
 				err := upgrade.Run()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("setting default entry"))
 			})
-			It("Successfully upgrades from docker image with custom labels", Label("docker"), func() {
+			It("Successfully upgrades from docker image", func() {
+				Expect(v1mock.FakeLoopDeviceSnapshotsStatus(fs, constants.RunningStateDir, 2)).To(Succeed())
 				// Create installState with previous install state
 				statePath := filepath.Join(constants.RunningStateDir, constants.InstallStateFile)
 				installState := &v1.InstallState{
 					Partitions: map[string]*v1.PartitionState{
 						constants.StatePartName: {
 							FSLabel: "COS_STATE",
-							Images: map[string]*v1.ImageState{
-								constants.ActiveImgName: {
-									Label: "CUSTOM_ACTIVE_LABEL",
-									FS:    constants.LinuxImgFs,
+							Snapshots: map[int]*v1.SystemState{
+								2: {
+									Source: v1.NewDockerSrc("some/image:v2"),
+									Digest: "somehash2",
+									Active: true,
 								},
-								constants.PassiveImgName: {
-									Label: "CUSTOM_PASSIVE_LABEL",
-									FS:    constants.LinuxImgFs,
+								1: {
+									Source: v1.NewDockerSrc("some/image:v1"),
+									Digest: "somehash",
 								},
 							},
 						},
@@ -249,513 +207,164 @@ var _ = Describe("Runtime Actions", func() {
 				}
 				err = config.WriteInstallState(installState, statePath, statePath)
 				Expect(err).ShouldNot(HaveOccurred())
+
+				// Limit maximum snapshots to 2
+				config.Snapshotter.MaxSnaps = 2
 
 				// Create a new spec to load state yaml
 				spec, err = conf.NewUpgradeSpec(config.Config)
-				spec.Active.Size = 16
-				Expect(err).ShouldNot(HaveOccurred())
 
-				spec.Active.Source = v1.NewDockerSrc("alpine")
-				upgrade = action.NewUpgradeAction(config, spec)
+				spec.System = v1.NewDockerSrc("alpine")
+				upgrade, err = action.NewUpgradeAction(config, spec)
+				Expect(err).NotTo(HaveOccurred())
 				err := upgrade.Run()
 				Expect(err).ToNot(HaveOccurred())
 
 				// Check that the rebrand worked with our os-release value
 				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
 
-				// This should be the new image
-				info, err := fs.Stat(activeImg)
-				Expect(err).ToNot(HaveOccurred())
-				// Image size should be the config.ImgSize as its truncated from the upgrade
-				Expect(info.Size()).To(BeNumerically("==", int64(spec.Active.Size*1024*1024)))
-				Expect(info.IsDir()).To(BeFalse())
+				// Writes filesystem labels to GRUB oem env file
+				grubOEMEnv := filepath.Join(spec.Partitions.State.MountPoint, constants.GrubOEMEnv)
+				Expect(runner.IncludesCmds(
+					[][]string{{"grub2-editenv", grubOEMEnv, "set", "passive_snaps=passive_2"}},
+				)).To(Succeed())
 
-				// Should have backed up active to passive
-				info, err = fs.Stat(passiveImg)
-				Expect(err).ToNot(HaveOccurred())
-				// Should be a tiny image as it should only contain our text
-				// As this was generated by us at the start test and moved by the upgrade from active.iomg
-				Expect(info.Size()).To(BeNumerically(">", 0))
-				Expect(info.Size()).To(BeNumerically("<", int64(spec.Active.Size*1024*1024)))
-				f, _ := fs.ReadFile(passiveImg)
-				// This should be a backup so it should read active
-				Expect(f).To(ContainSubstring("active"))
-
-				// Expect transition image to be gone
-				_, err = fs.Stat(spec.Active.File)
-				Expect(err).To(HaveOccurred())
+				// Expect snapshot 2 and 3 to be there and 1 deleted
+				ok, _ := utils.Exists(fs, filepath.Join(constants.RunningStateDir, ".snapshots/3/snapshot.img"))
+				Expect(ok).To(BeTrue())
+				ok, _ = utils.Exists(fs, filepath.Join(constants.RunningStateDir, ".snapshots/2/snapshot.img"))
+				Expect(ok).To(BeTrue())
+				ok, _ = utils.Exists(fs, filepath.Join(constants.RunningStateDir, ".snapshots/1/snapshot.img"))
+				Expect(ok).To(BeFalse())
 
 				// An upgraded state yaml file should exist
 				state, err := config.LoadInstallState()
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(
-					state.Partitions[constants.StatePartName].
-						Images[constants.ActiveImgName].Source.String()).
+				Expect(state.Partitions[constants.StatePartName].Snapshots[3].Active).
+					To(BeTrue())
+				Expect(state.Partitions[constants.StatePartName].Snapshots[2].Active).
+					To(BeFalse())
+				Expect(state.Partitions[constants.StatePartName].Snapshots[3].Digest).
+					To(Equal(v1mock.FakeDigest))
+				Expect(state.Partitions[constants.StatePartName].Snapshots[3].Source.String()).
 					To(Equal("oci://alpine:latest"))
-				Expect(
-					state.Partitions[constants.StatePartName].
-						Images[constants.ActiveImgName].Label).
-					To(Equal("CUSTOM_ACTIVE_LABEL"))
-				Expect(
-					state.Partitions[constants.StatePartName].
-						Images[constants.PassiveImgName].Label).
-					To(Equal("CUSTOM_PASSIVE_LABEL"))
+				Expect(state.Partitions[constants.StatePartName].Snapshots[2].Source.String()).
+					To(Equal("oci://some/image:v2"))
+				// Snapshot 1 was deleted
+				Expect(state.Partitions[constants.StatePartName].Snapshots[1]).
+					To(BeNil())
 			})
-			It("Writes filesystem labels to GRUB oem env file", Label("grub"), func() {
-				statePath := filepath.Join(constants.RunningStateDir, constants.InstallStateFile)
+			It("Successfully reboots after upgrade from docker image", func() {
+				Expect(v1mock.FakeLoopDeviceSnapshotsStatus(fs, constants.RunningStateDir, 1)).To(Succeed())
+				spec.System = v1.NewDockerSrc("alpine")
+				config.Reboot = true
+				upgrade, err = action.NewUpgradeAction(config, spec)
+				Expect(err).NotTo(HaveOccurred())
+				err := upgrade.Run()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check that the rebrand worked with our os-release value
+				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
+
+				// Expect snapshot 2 to be there
+				ok, _ := utils.Exists(fs, filepath.Join(constants.RunningStateDir, ".snapshots/2/snapshot.img"))
+				Expect(ok).To(BeTrue())
+
+				// Expect reboot executed
+				Expect(runner.IncludesCmds([][]string{{"reboot", "-f"}})).To(BeNil())
+			})
+			It("Successfully powers off after upgrade from docker image", func() {
+				Expect(v1mock.FakeLoopDeviceSnapshotsStatus(fs, constants.RunningStateDir, 1)).To(Succeed())
+				spec.System = v1.NewDockerSrc("alpine")
+				config.PowerOff = true
+				upgrade, err = action.NewUpgradeAction(config, spec)
+				Expect(err).NotTo(HaveOccurred())
+				err := upgrade.Run()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Check that the rebrand worked with our os-release value
+				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
+
+				// Expect snapshot 2 to be there
+				ok, _ := utils.Exists(fs, filepath.Join(constants.RunningStateDir, ".snapshots/2/snapshot.img"))
+				Expect(ok).To(BeTrue())
+
+				// Expect poweroff executed
+				Expect(runner.IncludesCmds([][]string{{"poweroff", "-f"}})).To(BeNil())
+			})
+		})
+		Describe(fmt.Sprintf("Booting from %s", constants.RecoveryLabel), Label("recovery_label"), func() {
+			var err error
+			var recoveryImg string
+
+			BeforeEach(func() {
+				// Mount recovery partition as it is expected to be mounted when booting from recovery
+				//mounter.Mount("device5", constants.LiveDir, "auto", []string{"ro"})
+				// Create installState with squashed recovery
+				statePath := filepath.Join(constants.LiveDir, constants.InstallStateFile)
 				installState := &v1.InstallState{
 					Partitions: map[string]*v1.PartitionState{
 						constants.RecoveryPartName: {
-							FSLabel: "COS_RECOVERY",
-							Images: map[string]*v1.ImageState{
-								constants.RecoveryImgName: {
-									Label: "CUSTOM_RECOVERYIMG_LABEL",
-									FS:    constants.LinuxImgFs,
-								},
-							},
-						},
-						constants.StatePartName: {
-							FSLabel: "COS_STATE",
-							Images: map[string]*v1.ImageState{
-								constants.ActiveImgName: {
-									Label: "CUSTOM_ACTIVE_LABEL",
-									FS:    constants.LinuxImgFs,
-								},
-								constants.PassiveImgName: {
-									Label: "CUSTOM_PASSIVE_LABEL",
-									FS:    constants.LinuxImgFs,
-								},
+							FSLabel: constants.RecoveryLabel,
+							RecoveryImage: &v1.SystemState{
+								Label:  constants.SystemLabel,
+								FS:     constants.SquashFs,
+								Source: v1.NewDirSrc("/some/dir"),
 							},
 						},
 					},
 				}
-
 				err = config.WriteInstallState(installState, statePath, statePath)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				spec, err = conf.NewUpgradeSpec(config.Config)
-				spec.Active.Source = v1.NewDockerSrc("alpine")
-				upgrade = action.NewUpgradeAction(config, spec)
-				err := upgrade.Run()
-				Expect(err).ToNot(HaveOccurred())
-
-				actualBytes, err := fs.ReadFile(filepath.Join(constants.EfiDir, "grub_oem_env"))
-				Expect(err).To(BeNil())
-
-				expected := map[string]string{
-					"state_label":        "COS_STATE",
-					"active_label":       "CUSTOM_ACTIVE_LABEL",
-					"passive_label":      "CUSTOM_PASSIVE_LABEL",
-					"recovery_label":     "COS_RECOVERY",
-					"system_label":       "CUSTOM_RECOVERYIMG_LABEL",
-					"oem_label":          "COS_OEM",
-					"persistent_label":   "COS_PERSISTENT",
-					"default_menu_entry": "TESTOS",
-				}
-
-				lines := strings.Split(string(actualBytes), "\n")
-
-				By(string(actualBytes))
-
-				Expect(len(lines)).To(Equal(len(expected)))
-
-				for _, line := range lines {
-					if line == "" {
-						continue
-					}
-
-					split := strings.SplitN(line, "=", 2)
-
-					Expect(split[1]).To(Equal(expected[split[0]]))
-				}
-			})
-			It("Successfully reboots after upgrade from docker image", Label("docker"), func() {
-				spec.Active.Source = v1.NewDockerSrc("alpine")
-				config.Reboot = true
-				upgrade = action.NewUpgradeAction(config, spec)
-				err := upgrade.Run()
-				Expect(err).ToNot(HaveOccurred())
-
-				// Check that the rebrand worked with our os-release value
-				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
-
-				// This should be the new image
-				info, err := fs.Stat(activeImg)
-				Expect(err).ToNot(HaveOccurred())
-				// Image size should be the config.ImgSize as its truncated from the upgrade
-				Expect(info.Size()).To(BeNumerically("==", int64(spec.Active.Size*1024*1024)))
-				Expect(info.IsDir()).To(BeFalse())
-
-				// Should have backed up active to passive
-				info, err = fs.Stat(passiveImg)
-				Expect(err).ToNot(HaveOccurred())
-				// Should be a tiny image as it should only contain our text
-				// As this was generated by us at the start test and moved by the upgrade from active.iomg
-				Expect(info.Size()).To(BeNumerically(">", 0))
-				Expect(info.Size()).To(BeNumerically("<", int64(spec.Active.Size*1024*1024)))
-				f, _ := fs.ReadFile(passiveImg)
-				// This should be a backup so it should read active
-				Expect(f).To(ContainSubstring("active"))
-
-				// Expect transition image to be gone
-				_, err = fs.Stat(spec.Active.File)
-				Expect(err).To(HaveOccurred())
-				Expect(runner.IncludesCmds([][]string{{"reboot", "-f"}})).To(BeNil())
-			})
-			It("Successfully powers off after upgrade from docker image", Label("docker"), func() {
-				spec.Active.Source = v1.NewDockerSrc("alpine")
-				config.PowerOff = true
-				upgrade = action.NewUpgradeAction(config, spec)
-				err := upgrade.Run()
-				Expect(err).ToNot(HaveOccurred())
-
-				// Check that the rebrand worked with our os-release value
-				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
-
-				// This should be the new image
-				info, err := fs.Stat(activeImg)
-				Expect(err).ToNot(HaveOccurred())
-				// Image size should be the config.ImgSize as its truncated from the upgrade
-				Expect(info.Size()).To(BeNumerically("==", int64(spec.Active.Size*1024*1024)))
-				Expect(info.IsDir()).To(BeFalse())
-
-				// Should have backed up active to passive
-				info, err = fs.Stat(passiveImg)
-				Expect(err).ToNot(HaveOccurred())
-				// Should be a tiny image as it should only contain our text
-				// As this was generated by us at the start test and moved by the upgrade from active.iomg
-				Expect(info.Size()).To(BeNumerically(">", 0))
-				Expect(info.Size()).To(BeNumerically("<", int64(spec.Active.Size*1024*1024)))
-				f, _ := fs.ReadFile(passiveImg)
-				// This should be a backup so it should read active
-				Expect(f).To(ContainSubstring("active"))
-
-				// Expect transition image to be gone
-				_, err = fs.Stat(spec.Active.File)
-				Expect(err).To(HaveOccurred())
-				Expect(runner.IncludesCmds([][]string{{"poweroff", "-f"}})).To(BeNil())
-
-				// An upgraded state yaml file should exist
-				state, err := config.LoadInstallState()
+				recoveryImg = filepath.Join(constants.LiveDir, constants.RecoveryImgFile)
+				err = fs.WriteFile(recoveryImg, []byte("recovery"), constants.FilePerm)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(
-					state.Partitions[constants.StatePartName].
-						Images[constants.ActiveImgName].Source.String()).
-					To(Equal("oci://alpine:latest"))
-				Expect(
-					state.Partitions[constants.StatePartName].
-						Images[constants.PassiveImgName].Label).
-					To(Equal(constants.PassiveLabel))
-			})
-			It("Successfully upgrades from directory", Label("directory"), func() {
-				dirSrc, _ := utils.TempDir(fs, "", "elementalupgrade")
-				// Create the dir on real os as rsync works on the real os
-				defer fs.RemoveAll(dirSrc)
-				spec.Active.Source = v1.NewDirSrc(dirSrc)
-				// create a random file on it
-				err := fs.WriteFile(fmt.Sprintf("%s/file.file", dirSrc), []byte("something"), constants.FilePerm)
-				Expect(err).ToNot(HaveOccurred())
 
-				upgrade = action.NewUpgradeAction(config, spec)
-				err = upgrade.Run()
-				Expect(err).ToNot(HaveOccurred())
-
-				// Check that the rebrand worked with our os-release value
-				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
-
-				// Not much that we can create here as the dir copy was done on the real os, but we do the rest of the ops on a mem one
-				// This should be the new image
-				info, err := fs.Stat(activeImg)
-				Expect(err).ToNot(HaveOccurred())
-				// Image size should not be empty
-				Expect(info.Size()).To(BeNumerically("==", int64(spec.Active.Size*1024*1024)))
-				Expect(info.IsDir()).To(BeFalse())
-
-				// Should have backed up active to passive
-				info, err = fs.Stat(passiveImg)
-				Expect(err).ToNot(HaveOccurred())
-				// Should be a tiny image as it should only contain our text
-				// As this was generated by us at the start test and moved by the upgrade from active.img
-				Expect(info.Size()).To(BeNumerically(">", 0))
-				Expect(info.Size()).To(BeNumerically("<", int64(spec.Active.Size*1024*1024)))
-				f, _ := fs.ReadFile(passiveImg)
-				// This should be a backup so it should read active
-				Expect(f).To(ContainSubstring("active"))
-
-				// Expect transition image to be gone
-				_, err = fs.Stat(spec.Active.File)
-				Expect(err).To(HaveOccurred())
-
-			})
-			It("Successfully upgrades with cosign", Pending, Label("channel", "cosign"), func() {})
-			It("Successfully upgrades with strict", Pending, Label("channel", "strict"), func() {})
-		})
-		Describe(fmt.Sprintf("Booting from %s", constants.PassiveLabel), Label("passive_label"), func() {
-			var err error
-			BeforeEach(func() {
 				spec, err = conf.NewUpgradeSpec(config.Config)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				spec.Active.Source = v1.NewDockerSrc("elementalos:latest")
-				spec.Active.Size = 16
-
-				err = utils.MkdirAll(config.Fs, filepath.Join(constants.WorkingImgDir, "etc"), constants.DirPerm)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				err = fs.WriteFile(
-					filepath.Join(constants.WorkingImgDir, "etc", "os-release"),
-					[]byte("GRUB_ENTRY_NAME=TESTOS"),
-					constants.FilePerm,
-				)
-				Expect(err).ShouldNot(HaveOccurred())
+				spec.System = v1.NewDockerSrc("alpine")
+				spec.RecoveryUpgrade = true
+				spec.RecoverySystem.Source = spec.System
+				spec.RecoverySystem.Size = 16
 
 				runner.SideEffect = func(command string, args ...string) ([]byte, error) {
-					if command == "cat" && args[0] == "/proc/cmdline" {
-						return []byte(constants.PassiveLabel), nil
-					}
-					if command == "mv" && args[0] == "-f" && args[1] == spec.Active.File && args[2] == activeImg {
-						// we doing the image substitution, do the "move"
-						source, _ := fs.ReadFile(spec.Active.File)
-						_ = fs.WriteFile(activeImg, source, constants.FilePerm)
-						_ = fs.RemoveAll(spec.Active.File)
+					if command == "mksquashfs" && args[1] == spec.RecoverySystem.File {
+						// create the transition img for squash to fake it
+						_, _ = fs.Create(spec.RecoverySystem.File)
 					}
 					return []byte{}, nil
 				}
 				config.Runner = runner
-				// Create fake active/passive files
-				_ = fs.WriteFile(activeImg, []byte("active"), constants.FilePerm)
-				_ = fs.WriteFile(passiveImg, []byte("passive"), constants.FilePerm)
-				// Mount state partition as it is expected to be mounted when booting from active
-				mounter.Mount("device2", constants.RunningStateDir, "auto", []string{"ro"})
 			})
-			AfterEach(func() {
-				_ = fs.RemoveAll(activeImg)
-				_ = fs.RemoveAll(passiveImg)
-			})
-			It("does not backup active img to passive", Label("docker"), func() {
-				spec.Active.Source = v1.NewDockerSrc("alpine")
-				upgrade = action.NewUpgradeAction(config, spec)
-				err := upgrade.Run()
+			It("Successfully upgrades recovery from docker image", Label("docker"), func() {
+				// This should be the old image
+				info, err := fs.Stat(recoveryImg)
 				Expect(err).ToNot(HaveOccurred())
+				// Image size should be empty
+				Expect(info.Size()).To(BeNumerically(">", 0))
+				Expect(info.IsDir()).To(BeFalse())
+				f, _ := fs.ReadFile(recoveryImg)
+				Expect(f).To(ContainSubstring("recovery"))
 
-				// Check that the rebrand worked with our os-release value
-				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
+				upgrade, err = action.NewUpgradeAction(config, spec)
+				Expect(err).NotTo(HaveOccurred())
+				err = upgrade.Run()
+				Expect(err).ToNot(HaveOccurred())
 
 				// This should be the new image
-				info, err := fs.Stat(activeImg)
+				info, err = fs.Stat(recoveryImg)
 				Expect(err).ToNot(HaveOccurred())
-				// Image size should not be empty
-				Expect(info.Size()).To(BeNumerically("==", int64(spec.Active.Size*1024*1024)))
+				// Image size should be empty
+				Expect(info.Size()).To(BeNumerically("==", 0))
 				Expect(info.IsDir()).To(BeFalse())
+				f, _ = fs.ReadFile(recoveryImg)
+				Expect(f).ToNot(ContainSubstring("recovery"))
 
-				// Passive should have not been touched
-				info, err = fs.Stat(passiveImg)
-				Expect(err).ToNot(HaveOccurred())
-				// Should be a tiny image as it should only contain our text
-				// As this was generated by us at the start test and moved by the upgrade from active.iomg
-				Expect(info.Size()).To(BeNumerically(">", 0))
-				Expect(info.Size()).To(BeNumerically("<", int64(spec.Active.Size*1024*1024)))
-				f, _ := fs.ReadFile(passiveImg)
-				Expect(f).To(ContainSubstring("passive"))
-
-				// Expect transition image to be gone
-				_, err = fs.Stat(spec.Active.File)
+				// Transition squash should not exist
+				info, err = fs.Stat(spec.RecoverySystem.File)
 				Expect(err).To(HaveOccurred())
-
-			})
-		})
-		Describe(fmt.Sprintf("Booting from %s", constants.RecoveryLabel), Label("recovery_label"), func() {
-			Describe("Using squashfs", Label("squashfs"), func() {
-				var err error
-				BeforeEach(func() {
-					// Mount recovery partition as it is expected to be mounted when booting from recovery
-					mounter.Mount("device5", constants.LiveDir, "auto", []string{"ro"})
-					// Create installState with squashed recovery
-					statePath := filepath.Join(constants.RunningStateDir, constants.InstallStateFile)
-					installState := &v1.InstallState{
-						Partitions: map[string]*v1.PartitionState{
-							constants.RecoveryPartName: {
-								FSLabel: constants.RecoveryLabel,
-								Images: map[string]*v1.ImageState{
-									constants.RecoveryImgName: {
-										FS: constants.SquashFs,
-									},
-								},
-							},
-						},
-					}
-					err = config.WriteInstallState(installState, statePath, statePath)
-					Expect(err).ShouldNot(HaveOccurred())
-					err = fs.WriteFile(recoveryImg, []byte("recovery"), constants.FilePerm)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					spec, err = conf.NewUpgradeSpec(config.Config)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					spec.RecoveryUpgrade = true
-					spec.Recovery.Source = v1.NewDockerSrc("alpine")
-					spec.Recovery.Size = 16
-
-					runner.SideEffect = func(command string, args ...string) ([]byte, error) {
-						if command == "cat" && args[0] == "/proc/cmdline" {
-							return []byte(constants.RecoveryLabel), nil
-						}
-						if command == "mksquashfs" && args[1] == spec.Recovery.File {
-							// create the transition img for squash to fake it
-							_, _ = fs.Create(spec.Recovery.File)
-						}
-						if command == "mv" && args[0] == "-f" && args[1] == spec.Recovery.File && args[2] == recoveryImg {
-							// fake "move"
-							f, _ := fs.ReadFile(spec.Recovery.File)
-							_ = fs.WriteFile(recoveryImg, f, constants.FilePerm)
-							_ = fs.RemoveAll(spec.Recovery.File)
-						}
-						return []byte{}, nil
-					}
-					config.Runner = runner
-				})
-				It("Successfully upgrades recovery from docker image", Label("docker"), func() {
-					// This should be the old image
-					info, err := fs.Stat(recoveryImg)
-					Expect(err).ToNot(HaveOccurred())
-					// Image size should be empty
-					Expect(info.Size()).To(BeNumerically(">", 0))
-					Expect(info.IsDir()).To(BeFalse())
-					f, _ := fs.ReadFile(recoveryImg)
-					Expect(f).To(ContainSubstring("recovery"))
-
-					spec.Recovery.Source = v1.NewDockerSrc("alpine")
-					upgrade = action.NewUpgradeAction(config, spec)
-					err = upgrade.Run()
-					Expect(err).ToNot(HaveOccurred())
-
-					// This should be the new image
-					info, err = fs.Stat(recoveryImg)
-					Expect(err).ToNot(HaveOccurred())
-					// Image size should be empty
-					Expect(info.Size()).To(BeNumerically("==", 0))
-					Expect(info.IsDir()).To(BeFalse())
-					f, _ = fs.ReadFile(recoveryImg)
-					Expect(f).ToNot(ContainSubstring("recovery"))
-
-					// Transition squash should not exist
-					info, err = fs.Stat(spec.Recovery.File)
-					Expect(err).To(HaveOccurred())
-
-				})
-				It("Successfully upgrades recovery from directory", Label("directory"), func() {
-					srcDir, _ := utils.TempDir(fs, "", "elemental")
-					// create a random file on it
-					_ = fs.WriteFile(fmt.Sprintf("%s/file.file", srcDir), []byte("something"), constants.FilePerm)
-
-					spec.Recovery.Source = v1.NewDirSrc(srcDir)
-					upgrade = action.NewUpgradeAction(config, spec)
-					err := upgrade.Run()
-					Expect(err).ToNot(HaveOccurred())
-
-					// This should be the new image
-					info, err := fs.Stat(recoveryImg)
-					Expect(err).ToNot(HaveOccurred())
-					// Image size should be empty
-					Expect(info.Size()).To(BeNumerically("==", 0))
-					Expect(info.IsDir()).To(BeFalse())
-
-					// Transition squash should not exist
-					info, err = fs.Stat(spec.Recovery.File)
-					Expect(err).To(HaveOccurred())
-
-				})
-			})
-			Describe("Not using squashfs", Label("non-squashfs"), func() {
-				var err error
-				BeforeEach(func() {
-					// Create recoveryImg so it identifies that we are using nonsquash recovery
-					err = fs.WriteFile(recoveryImg, []byte("recovery"), constants.FilePerm)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					spec, err = conf.NewUpgradeSpec(config.Config)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					spec.RecoveryUpgrade = true
-					spec.Recovery.Source = v1.NewDockerSrc("alpine")
-					spec.Recovery.Size = 16
-
-					runner.SideEffect = func(command string, args ...string) ([]byte, error) {
-						if command == "cat" && args[0] == "/proc/cmdline" {
-							return []byte(constants.RecoveryLabel), nil
-						}
-						if command == "mv" && args[0] == "-f" && args[1] == spec.Recovery.File && args[2] == recoveryImg {
-							// fake "move"
-							f, _ := fs.ReadFile(spec.Recovery.File)
-							_ = fs.WriteFile(recoveryImg, f, constants.FilePerm)
-							_ = fs.RemoveAll(spec.Recovery.File)
-						}
-						return []byte{}, nil
-					}
-					config.Runner = runner
-					_ = fs.WriteFile(recoveryImg, []byte("recovery"), constants.FilePerm)
-					// Mount recovery partition as it is expected to be mounted when booting from recovery
-					mounter.Mount("device5", constants.LiveDir, "auto", []string{"ro"})
-				})
-				It("Successfully upgrades recovery from docker image", Label("docker"), func() {
-					// This should be the old image
-					info, err := fs.Stat(recoveryImg)
-					Expect(err).ToNot(HaveOccurred())
-					// Image size should not be empty
-					Expect(info.Size()).To(BeNumerically(">", 0))
-					Expect(info.Size()).To(BeNumerically("<", int64(spec.Recovery.Size*1024*1024)))
-					Expect(info.IsDir()).To(BeFalse())
-					f, _ := fs.ReadFile(recoveryImg)
-					Expect(f).To(ContainSubstring("recovery"))
-
-					spec.Recovery.Source = v1.NewDockerSrc("apline")
-
-					upgrade = action.NewUpgradeAction(config, spec)
-					err = upgrade.Run()
-					Expect(err).ToNot(HaveOccurred())
-
-					// Should have created recovery image
-					info, err = fs.Stat(recoveryImg)
-					Expect(err).ToNot(HaveOccurred())
-					// Image size should be default size
-					Expect(info.Size()).To(BeNumerically("==", int64(spec.Recovery.Size*1024*1024)))
-
-					// Expect the rest of the images to not be there
-					for _, img := range []string{activeImg, passiveImg} {
-						_, err := fs.Stat(img)
-						Expect(err).To(HaveOccurred())
-					}
-				})
-				It("Successfully upgrades recovery from directory", Label("directory"), func() {
-					srcDir, _ := utils.TempDir(fs, "", "elemental")
-					// create a random file on it
-					_ = fs.WriteFile(fmt.Sprintf("%s/file.file", srcDir), []byte("something"), constants.FilePerm)
-
-					spec.Recovery.Source = v1.NewDirSrc(srcDir)
-
-					upgrade = action.NewUpgradeAction(config, spec)
-					err := upgrade.Run()
-					Expect(err).ToNot(HaveOccurred())
-
-					// This should be the new image
-					info, err := fs.Stat(recoveryImg)
-					Expect(err).ToNot(HaveOccurred())
-					// Image size should be default size
-					Expect(info.Size()).To(BeNumerically("==", int64(spec.Recovery.Size*1024*1024)))
-					Expect(info.IsDir()).To(BeFalse())
-
-					// Transition should not exist
-					info, err = fs.Stat(spec.Recovery.File)
-					Expect(err).To(HaveOccurred())
-
-					// An upgraded state yaml file should exist
-					state, err := config.LoadInstallState()
-					Expect(err).ShouldNot(HaveOccurred())
-					Expect(
-						state.Partitions[constants.RecoveryPartName].
-							Images[constants.RecoveryImgName].Source.String()).
-						To(Equal(spec.Recovery.Source.String()))
-				})
 			})
 		})
 	})

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Runtime Actions", func() {
 				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
 
 				// Writes filesystem labels to GRUB oem env file
-				grubOEMEnv := filepath.Join(spec.Partitions.State.MountPoint, constants.GrubOEMEnv)
+				grubOEMEnv := filepath.Join(spec.Partitions.EFI.MountPoint, constants.GrubOEMEnv)
 				Expect(runner.IncludesCmds(
 					[][]string{{"grub2-editenv", grubOEMEnv, "set", "passive_snaps=passive_2"}},
 				)).To(Succeed())

--- a/pkg/bootloader/grub_test.go
+++ b/pkg/bootloader/grub_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Booloader", Label("bootloader", "grub"), func() {
 		Expect(fs.WriteFile(filepath.Join(rootDir, "/usr/share/grub2/x86_64-efi/squash4.mod"), []byte(""), constants.FilePerm)).To(Succeed())
 		Expect(fs.WriteFile(filepath.Join(rootDir, "/usr/share/grub2/x86_64-efi/xzio.mod"), []byte(""), constants.FilePerm)).To(Succeed())
 
-		// os-release file
+		// OS-Release file
 		Expect(utils.MkdirAll(fs, filepath.Join(rootDir, "/etc"), constants.DirPerm)).To(Succeed())
 		Expect(fs.WriteFile(filepath.Join(rootDir, "/etc/os-release"), osRelease, constants.FilePerm)).To(Succeed())
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -197,9 +197,10 @@ func NewInstallSpec(cfg v1.Config) *v1.InstallSpec {
 	}
 
 	recoverySystem.Source = system
-	recoverySystem.FS = constants.SquashFs
-	recoverySystem.Label = ""
+	recoverySystem.FS = constants.LinuxImgFs
+	recoverySystem.Label = constants.SystemLabel
 	recoverySystem.File = filepath.Join(constants.RecoveryDir, constants.RecoveryImgFile)
+	recoverySystem.MountPoint = constants.TransitionDir
 
 	return &v1.InstallSpec{
 		Firmware:       v1.EFI,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -373,6 +373,12 @@ func NewUpgradeSpec(cfg v1.Config) (*v1.UpgradeSpec, error) {
 		}
 	}
 
+	if ep.EFI != nil {
+		if ep.EFI.MountPoint == "" {
+			ep.EFI.MountPoint = constants.EfiDir
+		}
+	}
+
 	// This is needed if we want to use the persistent as tmpdir for the upgrade images
 	// as tmpfs is 25% of the total RAM, we cannot rely on the tmp dir having enough space for our image
 	// This enables upgrades on low ram devices

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -97,14 +97,12 @@ const (
 	OEMDir             = "/run/elemental/oem"
 	PersistentDir      = "/run/elemental/persistent"
 	PersistentStateDir = "/run/elemental/persistent/.state"
-	ActiveDir          = "/run/elemental/active"
 	TransitionDir      = "/run/elemental/transition"
 	EfiDir             = "/run/elemental/efi"
 	ImgSrcDir          = "/run/elemental/imgsrc"
 	WorkingImgDir      = "/run/elemental/workingtree"
 	OverlayDir         = "/run/elemental/overlay"
 	RunningStateDir    = "/run/initramfs/elemental-state" // TODO: converge this constant with StateDir/RecoveryDir when moving to elemental-rootfs as default rootfs feature.
-	LegacyStateDir     = "/run/initramfs/cos-state"
 
 	// Running mode sentinel files
 	ActiveMode   = "/run/elemental/active_mode"
@@ -183,6 +181,7 @@ const (
 	LegacyImagesPath  = "cOS"
 	LegacyPassivePath = LegacyImagesPath + "/passive.img"
 	LegacyActivePath  = LegacyImagesPath + "/active.img"
+	LegacyStateDir    = "/run/initramfs/cos-state"
 )
 
 // GetDefaultSystemEcludes returns a list of transient paths

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -57,15 +57,14 @@ const (
 	HTTPTimeout        = 60
 	GPT                = "gpt"
 	BuildImgName       = "elemental"
-	//UsrLocalPath       = "/usr/local"
-	OEMPath        = "/oem"
-	PersistentPath = PersistentDir
-	ConfigDir      = "/etc/elemental"
-	OverlayMode    = "overlay"
-	BindMode       = "bind"
-	Tmpfs          = "tmpfs"
-	Autofs         = "auto"
-	Block          = "block"
+	OEMPath            = "/oem"
+	PersistentPath     = PersistentDir
+	ConfigDir          = "/etc/elemental"
+	OverlayMode        = "overlay"
+	BindMode           = "bind"
+	Tmpfs              = "tmpfs"
+	Autofs             = "auto"
+	Block              = "block"
 
 	// Maxium number of nested symlinks to resolve
 	MaxLinkDepth = 4
@@ -175,7 +174,7 @@ const (
 	Rsync = "rsync"
 
 	// Snapshotters
-	MaxSnaps                  = 4
+	MaxSnaps                  = 2
 	LoopDeviceSnapshotterType = "loopdevice"
 	ActiveSnapshot            = "active"
 	PassiveSnapshot           = "passive_%d"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -105,6 +105,7 @@ const (
 	WorkingImgDir      = "/run/elemental/workingtree"
 	OverlayDir         = "/run/elemental/overlay"
 	RunningStateDir    = "/run/initramfs/elemental-state" // TODO: converge this constant with StateDir/RecoveryDir when moving to elemental-rootfs as default rootfs feature.
+	LegacyStateDir     = "/run/initramfs/cos-state"
 
 	// Running mode sentinel files
 	ActiveMode   = "/run/elemental/active_mode"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -57,14 +57,15 @@ const (
 	HTTPTimeout        = 60
 	GPT                = "gpt"
 	BuildImgName       = "elemental"
-	UsrLocalPath       = "/usr/local"
-	OEMPath            = "/oem"
-	ConfigDir          = "/etc/elemental"
-	OverlayMode        = "overlay"
-	BindMode           = "bind"
-	Tmpfs              = "tmpfs"
-	Autofs             = "auto"
-	Block              = "block"
+	//UsrLocalPath       = "/usr/local"
+	OEMPath        = "/oem"
+	PersistentPath = PersistentDir
+	ConfigDir      = "/etc/elemental"
+	OverlayMode    = "overlay"
+	BindMode       = "bind"
+	Tmpfs          = "tmpfs"
+	Autofs         = "auto"
+	Block          = "block"
 
 	// Maxium number of nested symlinks to resolve
 	MaxLinkDepth = 4
@@ -105,6 +106,11 @@ const (
 	OverlayDir         = "/run/elemental/overlay"
 	RunningStateDir    = "/run/initramfs/elemental-state" // TODO: converge this constant with StateDir/RecoveryDir when moving to elemental-rootfs as default rootfs feature.
 
+	// Running mode sentinel files
+	ActiveMode   = "/run/elemental/active_mode"
+	PassiveMode  = "/run/elemental/passive_mode"
+	RecoveryMode = "/run/elemental/recovery_mode"
+
 	// Live image mountpoints
 	ISOBaseTree = "/run/rootfsbase"
 	LiveDir     = "/run/initramfs/live"
@@ -113,13 +119,8 @@ const (
 	ActiveImgName     = "active"
 	PassiveImgName    = "passive"
 	RecoveryImgName   = "recovery"
-	ActiveImgFile     = "active.img"
-	PassiveImgFile    = "passive.img"
 	RecoveryImgFile   = "recovery.img"
 	TransitionImgFile = "transition.img"
-	ActiveImgPath     = "/cOS/active.img"
-	PassiveImgPath    = "/cOS/passive.img"
-	RecoveryImgPath   = "/cOS/recovery.img"
 
 	// Yip stages evaluated on reset/upgrade/install/build-disk actions
 	AfterInstallChrootHook = "after-install-chroot"
@@ -282,23 +283,23 @@ func GetMountKeyEnvMap() map[string]string {
 // GetInstallKeyEnvMap returns environment variable bindings to InstallSpec data
 func GetInstallKeyEnvMap() map[string]string {
 	return map[string]string{
-		"target":              "TARGET",
-		"system.uri":          "SYSTEM",
-		"recovery-system.uri": "RECOVERY_SYSTEM",
-		"cloud-init":          "CLOUD_INIT",
-		"iso":                 "ISO",
-		"firmware":            "FIRMWARE",
-		"part-table":          "PART_TABLE",
-		"no-format":           "NO_FORMAT",
-		"grub-entry-name":     "GRUB_ENTRY_NAME",
-		"disable-boot-entry":  "DISABLE_BOOT_ENTRY",
+		"target":             "TARGET",
+		"system":             "SYSTEM",
+		"recovery-system":    "RECOVERY_SYSTEM",
+		"cloud-init":         "CLOUD_INIT",
+		"iso":                "ISO",
+		"firmware":           "FIRMWARE",
+		"part-table":         "PART_TABLE",
+		"no-format":          "NO_FORMAT",
+		"grub-entry-name":    "GRUB_ENTRY_NAME",
+		"disable-boot-entry": "DISABLE_BOOT_ENTRY",
 	}
 }
 
 // GetResetKeyEnvMap returns environment variable bindings to ResetSpec data
 func GetResetKeyEnvMap() map[string]string {
 	return map[string]string{
-		"system.uri":         "SYSTEM",
+		"system":             "SYSTEM",
 		"grub-entry-name":    "GRUB_ENTRY_NAME",
 		"cloud-init":         "CLOUD_INIT",
 		"reset-persistent":   "PERSISTENT",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -178,6 +178,11 @@ const (
 	LoopDeviceSnapshotterType = "loopdevice"
 	ActiveSnapshot            = "active"
 	PassiveSnapshot           = "passive_%d"
+
+	// Legacy paths
+	LegacyImagesPath  = "cOS"
+	LegacyPassivePath = LegacyImagesPath + "/passive.img"
+	LegacyActivePath  = LegacyImagesPath + "/active.img"
 )
 
 // GetDefaultSystemEcludes returns a list of transient paths

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -181,6 +181,23 @@ const (
 	PassiveSnapshot           = "passive_%d"
 )
 
+// GetDefaultSystemEcludes returns a list of transient paths
+// that are commonly present in an Elemental based running system.
+// Those paths are not needed or wanted in order to replicate the
+// root-tree as they are generated at runtime.
+func GetDefaultSystemExcludes() []string {
+	return []string{
+		"/mnt",
+		"/proc",
+		"/sys",
+		"/dev",
+		"/tmp",
+		"/run",
+		"/host",
+		"/etc/resolv.conf",
+	}
+}
+
 func GetKernelPatterns() []string {
 	return []string{
 		"/boot/uImage*",

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -496,7 +496,7 @@ func DumpSource(c v1.Config, target string, imgSrc *v1.ImageSource) error { // n
 		}
 		imgSrc.SetDigest(digest)
 	} else if imgSrc.IsDir() {
-		excludes := []string{"/mnt", "/proc", "/sys", "/dev", "/tmp", "/host", "/run"}
+		excludes := cnst.GetDefaultSystemExcludes()
 		err = utils.SyncData(c.Logger, c.Runner, c.Fs, imgSrc.Value(), target, excludes...)
 		if err != nil {
 			return err
@@ -512,8 +512,7 @@ func DumpSource(c v1.Config, target string, imgSrc *v1.ImageSource) error { // n
 			return err
 		}
 		defer UnmountFileSystemImage(c, img) // nolint:errcheck
-		excludes := []string{"/mnt", "/proc", "/sys", "/dev", "/tmp", "/host", "/run"}
-		err = utils.SyncData(c.Logger, c.Runner, c.Fs, cnst.ImgSrcDir, target, excludes...)
+		err = utils.SyncData(c.Logger, c.Runner, c.Fs, cnst.ImgSrcDir, target)
 		if err != nil {
 			return err
 		}

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -324,29 +324,29 @@ func CreateFileSystemImage(c v1.Config, img *v1.Image, rootDir string, preload b
 	return nil
 }
 
-// DeployImgTree will deploy the given image into the given root tree. Returns source metadata in info,
-// a tree cleaner function and error. The given root will be a bind mount of a temporary directory into the same
+// DeployImgTree will deploy the given image into the given root tree. Returns a tree cleaner
+// function and error. The given root will be a bind mount of a temporary directory into the same
 // filesystem of img.File, this is helpful to make the deployment easily accessible in after-* hooks.
-func DeployImgTree(c v1.Config, img *v1.Image, root string) (info interface{}, cleaner func() error, err error) {
+func DeployImgTree(c v1.Config, img *v1.Image, root string) (cleaner func() error, err error) {
 	// We prepare the rootTree next to the target image file, in the same base path
 	c.Logger.Infof("Preparing root tree for image: %s", img.File)
 	tmp := strings.TrimSuffix(img.File, filepath.Ext(img.File))
 	tmp += ".imgTree"
 	err = utils.MkdirAll(c.Fs, tmp, cnst.DirPerm)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	err = utils.MkdirAll(c.Fs, root, cnst.DirPerm)
 	if err != nil {
 		_ = c.Fs.RemoveAll(tmp)
-		return nil, nil, err
+		return nil, err
 	}
 	err = c.Mounter.Mount(tmp, root, "bind", []string{"bind"})
 	if err != nil {
 		_ = c.Fs.RemoveAll(tmp)
 		_ = c.Fs.RemoveAll(root)
-		return nil, nil, err
+		return nil, err
 	}
 
 	cleaner = func() error {
@@ -358,18 +358,13 @@ func DeployImgTree(c v1.Config, img *v1.Image, root string) (info interface{}, c
 		return c.Fs.RemoveAll(tmp)
 	}
 
-	info, err = DumpSource(c, root, img.Source)
+	err = DumpSource(c, root, img.Source)
 	if err != nil {
 		_ = cleaner()
-		return nil, nil, err
-	}
-	err = utils.CreateDirStructure(c.Fs, root)
-	if err != nil {
-		_ = cleaner()
-		return nil, nil, err
+		return nil, err
 	}
 
-	return info, cleaner, err
+	return cleaner, err
 }
 
 // CreateImageFromTree creates the given image including the given root tree. If preload flag is true
@@ -455,28 +450,31 @@ func CopyFileImg(c v1.Config, img *v1.Image) error {
 
 // DeployImage will deploy the given image into the target. This method
 // creates the filesystem image file and fills it with the correspondant data
-func DeployImage(c v1.Config, img *v1.Image) (interface{}, error) {
+func DeployImage(c v1.Config, img *v1.Image) error {
 	c.Logger.Infof("Deploying image: %s", img.File)
-	info, cleaner, err := DeployImgTree(c, img, cnst.WorkingImgDir)
+	cleaner, err := DeployImgTree(c, img, cnst.WorkingImgDir)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	err = CreateImageFromTree(c, img, cnst.WorkingImgDir, false, cleaner)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return info, nil
+	return nil
 }
 
 // DumpSource sets the image data according to the image source type
-func DumpSource(c v1.Config, target string, imgSrc *v1.ImageSource) (info interface{}, err error) { // nolint:gocyclo
+func DumpSource(c v1.Config, target string, imgSrc *v1.ImageSource) error { // nolint:gocyclo
+	var err error
+	var digest string
+
 	c.Logger.Infof("Copying %s source...", imgSrc.Value())
 
 	err = utils.MkdirAll(c.Fs, target, cnst.DirPerm)
 	if err != nil {
 		c.Logger.Errorf("failed to create target directory %s", target)
-		return nil, err
+		return err
 	}
 
 	if imgSrc.IsImage() {
@@ -488,41 +486,47 @@ func DumpSource(c v1.Config, target string, imgSrc *v1.ImageSource) (info interf
 			)
 			if err != nil {
 				c.Logger.Errorf("Cosign verification failed: %s", out)
-				return nil, err
+				return err
 			}
 		}
 
-		err = c.ImageExtractor.ExtractImage(imgSrc.Value(), target, c.Platform.String(), c.LocalImage)
+		digest, err = c.ImageExtractor.ExtractImage(imgSrc.Value(), target, c.Platform.String(), c.LocalImage)
 		if err != nil {
-			return nil, err
+			return err
 		}
+		imgSrc.SetDigest(digest)
 	} else if imgSrc.IsDir() {
 		excludes := []string{"/mnt", "/proc", "/sys", "/dev", "/tmp", "/host", "/run"}
 		err = utils.SyncData(c.Logger, c.Runner, c.Fs, imgSrc.Value(), target, excludes...)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	} else if imgSrc.IsFile() {
 		err = utils.MkdirAll(c.Fs, cnst.ImgSrcDir, cnst.DirPerm)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		img := &v1.Image{File: imgSrc.Value(), MountPoint: cnst.ImgSrcDir}
 		err = MountFileSystemImage(c, img, "auto", "ro")
 		if err != nil {
-			return nil, err
+			return err
 		}
 		defer UnmountFileSystemImage(c, img) // nolint:errcheck
 		excludes := []string{"/mnt", "/proc", "/sys", "/dev", "/tmp", "/host", "/run"}
 		err = utils.SyncData(c.Logger, c.Runner, c.Fs, cnst.ImgSrcDir, target, excludes...)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	} else {
-		return nil, fmt.Errorf("unknown image source type")
+		return fmt.Errorf("unknown image source type")
+	}
+	// Create essential directories such as /tmp, /dev, etc.
+	err = utils.CreateDirStructure(c.Fs, target)
+	if err != nil {
+		return err
 	}
 	c.Logger.Infof("Finished copying %s into %s", imgSrc.Value(), target)
-	return info, nil
+	return nil
 }
 
 // CopyCloudConfig will check if there is a cloud init in the config and store it on the target
@@ -570,16 +574,54 @@ func SelinuxRelabel(c v1.Config, rootDir string, raiseError bool) error {
 	return nil
 }
 
-// CheckActiveDeployment returns true if at least one of the provided filesystem labels is found within the system
-func CheckActiveDeployment(c v1.Config, labels []string) bool {
-	c.Logger.Infof("Checking for active deployment")
+// ApplySelinuxLabels sets SELinux extended attributes to the root-tree being installed
+func ApplySelinuxLabels(cfg v1.Config, parts v1.ElementalPartitions) error {
+	binds := map[string]string{}
+	if mnt, _ := IsMounted(cfg, parts.Persistent); mnt {
+		binds[parts.Persistent.MountPoint] = cnst.PersistentPath
+	}
+	if mnt, _ := IsMounted(cfg, parts.OEM); mnt {
+		binds[parts.OEM.MountPoint] = cnst.OEMPath
+	}
+	return utils.ChrootedCallback(
+		&cfg, cnst.WorkingImgDir, binds, func() error { return SelinuxRelabel(cfg, "/", true) },
+	)
+}
 
-	for _, label := range labels {
-		found, _ := utils.GetDeviceByLabel(c.Runner, label, 1)
-		if found != "" {
-			c.Logger.Debug("there is already an active deployment in the system")
+// CheckActiveDeployment returns true if at least one of the mode sentinel files is found
+func CheckActiveDeployment(cfg v1.Config) bool {
+	cfg.Logger.Infof("Checking for active deployment")
+
+	tests := []func(v1.Config) bool{IsActiveMode, IsPassiveMode, IsRecoveryMode}
+	for _, t := range tests {
+		if t(cfg) {
 			return true
 		}
+	}
+
+	return false
+}
+
+// IsActiveMode checks if the active mode sentinel file exists
+func IsActiveMode(cfg v1.Config) bool {
+	if ok, _ := utils.Exists(cfg.Fs, cnst.ActiveMode); ok {
+		return true
+	}
+	return false
+}
+
+// IsPassiveMode checks if the passive mode sentinel file exists
+func IsPassiveMode(cfg v1.Config) bool {
+	if ok, _ := utils.Exists(cfg.Fs, cnst.PassiveMode); ok {
+		return true
+	}
+	return false
+}
+
+// IsRecoveryMode checks if the recovery mode sentinel file exists
+func IsRecoveryMode(cfg v1.Config) bool {
+	if ok, _ := utils.Exists(cfg.Fs, cnst.RecoveryMode); ok {
+		return true
 	}
 	return false
 }
@@ -634,11 +676,17 @@ func SourceFormISO(c v1.Config, iso string) (*v1.ImageSource, func() error, erro
 // DeactivateDevice deactivates unmounted the block devices present within the system.
 // Useful to deactivate LVM volumes, if any, related to the target device.
 func DeactivateDevices(c v1.Config) error {
-	out, err := c.Runner.Run(
-		"blkdeactivate", "--lvmoptions", "retry,wholevg",
-		"--dmoptions", "force,retry", "--errors",
-	)
-	c.Logger.Debugf("blkdeactivate command output: %s", string(out))
+	var err error
+	var out []byte
+
+	// Best effort, just deactivate devices if lvm is installed
+	if c.Runner.CommandExists("blkdeactivate") {
+		out, err = c.Runner.Run(
+			"blkdeactivate", "--lvmoptions", "retry,wholevg",
+			"--dmoptions", "force,retry", "--errors",
+		)
+		c.Logger.Debugf("blkdeactivate command output: %s", string(out))
+	}
 	return err
 }
 

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -23,8 +23,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jaypipes/ghw/pkg/block"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/twpayne/go-vfs/v4"
@@ -223,10 +221,21 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			Expect(err).NotTo(BeNil())
 		})
 
-		It("Fails if oem partition is not found ", func() {
+		It("does not mount partitions without a mountpoint ", func() {
+			parts.OEM.MountPoint = ""
+			err := elemental.MountPartitions(*config, parts.PartitionsByMountPoint(false))
+			Expect(err).To(BeNil())
+			lst, _ := mounter.List()
+			for _, i := range lst {
+				Expect(i.Path).NotTo(Equal("/dev/device2"))
+			}
+		})
+
+		It("fails to mount missing partitions", func() {
+			// Without path tries to get devices by label
 			parts.OEM.Path = ""
 			err := elemental.MountPartitions(*config, parts.PartitionsByMountPoint(false))
-			Expect(err).NotTo(BeNil())
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
@@ -337,7 +346,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			img = &v1.Image{
 				Label:      constants.ActiveLabel,
 				Size:       32,
-				File:       filepath.Join(constants.StateDir, constants.ActiveImgPath),
+				File:       filepath.Join(constants.StateDir, "some.img"),
 				FS:         constants.LinuxImgFs,
 				MountPoint: constants.ActiveDir,
 				Source:     v1.NewDirSrc(constants.ISOBaseTree),
@@ -549,46 +558,48 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 				return []byte{}, nil
 			}
 
-			_, err := elemental.DumpSource(*config, "/dest", v1.NewDirSrc("/source"))
+			err := elemental.DumpSource(*config, "/dest", v1.NewDirSrc("/source"))
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(rsyncCount).To(Equal(1))
 			Expect(src).To(HaveSuffix("/source/"))
 			Expect(dest).To(HaveSuffix("/dest/"))
 		})
 		It("Unpacks a docker image to target", Label("docker"), func() {
-			_, err := elemental.DumpSource(*config, destDir, v1.NewDockerSrc("docker/image:latest"))
+			dockerSrc := v1.NewDockerSrc("docker/image:latest")
+			err := elemental.DumpSource(*config, destDir, dockerSrc)
+			Expect(dockerSrc.GetDigest()).To(Equal("fakeDigest"))
 			Expect(err).To(BeNil())
 		})
 		It("Unpacks a docker image to target with cosign validation", Label("docker", "cosign"), func() {
 			config.Cosign = true
-			_, err := elemental.DumpSource(*config, destDir, v1.NewDockerSrc("docker/image:latest"))
+			err := elemental.DumpSource(*config, destDir, v1.NewDockerSrc("docker/image:latest"))
 			Expect(err).To(BeNil())
 			Expect(runner.CmdsMatch([][]string{{"cosign", "verify", "docker/image:latest"}}))
 		})
 		It("Fails cosign validation", Label("cosign"), func() {
 			runner.ReturnError = errors.New("cosign error")
 			config.Cosign = true
-			_, err := elemental.DumpSource(*config, destDir, v1.NewDockerSrc("docker/image:latest"))
+			err := elemental.DumpSource(*config, destDir, v1.NewDockerSrc("docker/image:latest"))
 			Expect(err).NotTo(BeNil())
 			Expect(runner.CmdsMatch([][]string{{"cosign", "verify", "docker/image:latest"}}))
 		})
 		It("Fails to unpack a docker image to target", Label("docker"), func() {
 			unpackErr := errors.New("failed to unpack")
-			extractor.SideEffect = func(_, _, _ string, _ bool) error { return unpackErr }
-			_, err := elemental.DumpSource(*config, destDir, v1.NewDockerSrc("docker/image:latest"))
+			extractor.SideEffect = func(_, _, _ string, _ bool) (string, error) { return "", unpackErr }
+			err := elemental.DumpSource(*config, destDir, v1.NewDockerSrc("docker/image:latest"))
 			Expect(err).To(Equal(unpackErr))
 		})
 		It("Copies image file to target", func() {
 			sourceImg := "/source.img"
 			destFile := filepath.Join(destDir, "active.img")
 
-			_, err := elemental.DumpSource(*config, destFile, v1.NewFileSrc(sourceImg))
+			err := elemental.DumpSource(*config, destFile, v1.NewFileSrc(sourceImg))
 			Expect(err).To(BeNil())
 			Expect(runner.IncludesCmds([][]string{{"rsync"}}))
 		})
 		It("Fails to copy, source can't be mounted", func() {
 			mounter.ErrorOnMount = true
-			_, err := elemental.DumpSource(*config, "whatever", v1.NewFileSrc("/source.img"))
+			err := elemental.DumpSource(*config, "whatever", v1.NewFileSrc("/source.img"))
 			Expect(err).To(HaveOccurred())
 		})
 		It("Fails to copy, no write permissions", func() {
@@ -596,7 +607,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			_, err := fs.Create(sourceImg)
 			Expect(err).To(BeNil())
 			config.Fs = vfs.NewReadOnlyFS(fs)
-			_, err = elemental.DumpSource(*config, "whatever", v1.NewFileSrc("/source.img"))
+			err = elemental.DumpSource(*config, "whatever", v1.NewFileSrc("/source.img"))
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -617,14 +628,14 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			}
 		})
 		It("Deploys an image including the root tree contents", func() {
-			_, cleaner, err := elemental.DeployImgTree(*config, img, root)
+			cleaner, err := elemental.DeployImgTree(*config, img, root)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(runner.IncludesCmds([][]string{{"rsync"}}))
 			Expect(cleaner()).To(Succeed())
 		})
 		It("Fails setting a bind mount to root", func() {
 			mounter.ErrorOnMount = true
-			_, _, err := elemental.DeployImgTree(*config, img, root)
+			_, err := elemental.DeployImgTree(*config, img, root)
 			Expect(err).Should(HaveOccurred())
 		})
 	})
@@ -712,13 +723,13 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			}
 		})
 		It("Deploys image source into a filesystem image", func() {
-			_, err := elemental.DeployImage(*config, img)
+			err := elemental.DeployImage(*config, img)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(runner.IncludesCmds([][]string{{"mkfs.ext2"}, {"rsync"}})).To(Succeed())
 		})
 		It("Fails to dump source without write permissions", func() {
 			config.Fs = vfs.NewReadOnlyFS(fs)
-			_, err := elemental.DeployImage(*config, img)
+			err := elemental.DeployImage(*config, img)
 			Expect(err).Should(HaveOccurred())
 			Expect(runner.IncludesCmds([][]string{{"mkfs.ext2"}})).NotTo(Succeed())
 		})
@@ -729,7 +740,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 				}
 				return []byte{}, nil
 			}
-			_, err := elemental.DeployImage(*config, img)
+			err := elemental.DeployImage(*config, img)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("calling mkfs.ext2"))
 			Expect(runner.IncludesCmds([][]string{{"mkfs.ext2"}})).To(Succeed())
@@ -794,30 +805,26 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		})
 	})
 	Describe("CheckActiveDeployment", Label("check"), func() {
-		It("deployment found", func() {
-			ghwTest := v1mock.GhwMock{}
-			disk := block.Disk{Name: "device", Partitions: []*block.Partition{
-				{
-					Name:            "device1",
-					FilesystemLabel: constants.ActiveLabel,
-				},
-			}}
-			ghwTest.AddDisk(disk)
-			ghwTest.CreateDevices()
-			defer ghwTest.Clean()
-			runner.ReturnValue = []byte(
-				fmt.Sprintf(
-					`{"blockdevices": [{"label": "%s", "type": "loop", "path": "/some/device"}]}`,
-					constants.ActiveLabel,
-				),
-			)
+		BeforeEach(func() {
+			Expect(utils.MkdirAll(config.Fs, filepath.Dir(constants.ActiveMode), constants.DirPerm)).To(Succeed())
+		})
+		It("deployment found on active", func() {
+			Expect(fs.WriteFile(constants.ActiveMode, []byte("1"), constants.FilePerm)).To(Succeed())
+			Expect(elemental.CheckActiveDeployment(*config)).To(BeTrue())
+		})
 
-			Expect(elemental.CheckActiveDeployment(*config, []string{constants.ActiveLabel, constants.PassiveLabel})).To(BeTrue())
+		It("deployment found on passive", func() {
+			Expect(fs.WriteFile(constants.PassiveMode, []byte("1"), constants.FilePerm)).To(Succeed())
+			Expect(elemental.CheckActiveDeployment(*config)).To(BeTrue())
+		})
+
+		It("deployment found on recovery", func() {
+			Expect(fs.WriteFile(constants.RecoveryMode, []byte("1"), constants.FilePerm)).To(Succeed())
+			Expect(elemental.CheckActiveDeployment(*config)).To(BeTrue())
 		})
 
 		It("Should not error out", func() {
-			runner.ReturnValue = []byte("")
-			Expect(elemental.CheckActiveDeployment(*config, []string{constants.ActiveLabel, constants.PassiveLabel})).To(BeFalse())
+			Expect(elemental.CheckActiveDeployment(*config)).To(BeFalse())
 		})
 	})
 	Describe("SelinuxRelabel", Label("SelinuxRelabel", "selinux"), func() {

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -348,7 +348,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 				Size:       32,
 				File:       filepath.Join(constants.StateDir, "some.img"),
 				FS:         constants.LinuxImgFs,
-				MountPoint: constants.ActiveDir,
+				MountPoint: constants.TransitionDir,
 				Source:     v1.NewDirSrc(constants.ISOBaseTree),
 			}
 			_ = utils.MkdirAll(fs, constants.ISOBaseTree, constants.DirPerm)

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -253,5 +253,8 @@ const SnapshotterInit = 84
 // Error occured starting an snapshotter transaction
 const SnapshotterStart = 85
 
+// Error mounting EFI partition
+const MountEFIPartition = 86
+
 // Unknown error
 const Unknown int = 255

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -247,5 +247,11 @@ const HookPostDisk = 82
 // Error occured checking configured size is bigger than minimum required size
 const InvalidSize = 83
 
+// Error occured initializing snapshotter
+const SnapshotterInit = 84
+
+// Error occured starting an snapshotter transaction
+const SnapshotterStart = 85
+
 // Unknown error
 const Unknown int = 255

--- a/pkg/features/embedded/cloud-config-essentials/system/oem/08_boot_assessment.yaml
+++ b/pkg/features/embedded/cloud-config-essentials/system/oem/08_boot_assessment.yaml
@@ -17,8 +17,7 @@ stages:
     # This can be then customized easily by having a cloud-config file which always enables boot assessment on 
     # the boot stage.
     - name: "Remove GRUB sentinels"
-      if: |
-          cat /proc/cmdline | grep -q "active"
+      if: '[ -f "/run/elemental/active_mode" ]'
       commands:
       - |
           mount -o rw,remount /run/elemental/efi
@@ -26,8 +25,7 @@ stages:
           grub2-editenv /run/elemental/efi/boot_assessment set boot_assessment_tentative=
           mount -o ro,remount /run/elemental/efi
     - name: "Create upgrade failure sentinel if necessary"
-      if: |
-          cat /proc/cmdline | grep -q "upgrade_failure"
+      if: cat /proc/cmdline | grep -q "upgrade_failure"
       files:
       - path: /run/elemental/upgrade_failure
         content: "1"
@@ -37,29 +35,22 @@ stages:
     after-install:
     # After install, reset, and upgrade, we install additional GRUB configuration for boot assessment into COS_GRUB.
 
-    - &efimount
-      name: "Mount efi"
-      commands:
-      - |
-          EFIDIR=/tmp/mnt/EFI
-          EFI=$(blkid -L COS_GRUB || true)
-          mkdir -p $EFIDIR || true
-          mount ${EFI} $EFIDIR
     # Here we hook the boot assessment configuration to 'grubcustom'
     # we do that selectively in order to just "append" eventual other configuration provided.
     # XXX: maybe we should just write to /grubcustom and override any other custom grub?
     - &customhook
       name: "Hook boot assessment grub configuration"
-      if: |
-           ! grep -q "grub_boot_assessment" /tmp/mnt/EFI/grubcustom
-      commands:
-      - |
-        cat << 'EOF' >> /tmp/mnt/EFI/grubcustom
-        set bootfile="/grub_boot_assessment"
-        if [ "${bootfile}" ]; then
-           source "${bootfile}"
-        fi
-        EOF
+      if: '[ ! -f "/run/elemental/efi/grubcustom" ]'
+      files:
+      - path: "/run/elemental/efi/grubcustom"
+        permissions: 0600
+        content: |
+          set bootfile="/grub_boot_assessment"
+          search --no-floppy --file --set=bootfile_loc "${bootfile}"
+          if [ "${bootfile_loc}" ]; then
+            source "(${bootfile_loc})${bootfile}"
+          fi
+
     # Overrides the active cmdline by adding "rd.emergency=reboot", "rd.shell=0" and "panic=5"
     # so that any failure in booting initramfs or kernel loading results in a reboot.
     # It loads then the boot assessment environment and overrides default boot target if
@@ -70,8 +61,9 @@ stages:
     # 
     - &bootgrub
       name: "Add boot assessment grub configuration"
+      if: '[ ! -f "/run/elemental/state/grub_boot_assessment" ]'
       files:
-       - path: "/tmp/mnt/EFI/grub_boot_assessment"
+       - path: "/run/elemental/efi/grub_boot_assessment"
          owner: 0
          group: 0
          permissions: 0600
@@ -84,7 +76,7 @@ stages:
             if [ "${enable_boot_assessment}" = "yes" -o "${enable_boot_assessment_always}" = "yes" ]; then
               if [ -z "${selected_entry}" ]; then
                 if [ "${boot_assessment_tentative}" = "yes" ]; then
-                  set default="fallback"
+                  set default="1"
                   set extra_passive_cmdline="upgrade_failure"
                 else
                   set boot_assessment_tentative="yes"
@@ -92,33 +84,28 @@ stages:
                 fi
               fi
             fi
-    - &efiumount
-      name: "umount EFI"
-      commands:
-      - |
-          umount /tmp/mnt/EFI
 
     # Here we do enable boot assessment for the next bootup.
     # Similarly, we could trigger boot assessment in other cases
     after-upgrade:
-    - <<: *efimount
-    - name: "Set upgrade sentinel"
+    - name: "Set upgrade sentinel on active"
+      if: '[ ! -f "/run/elemental/recovery_mode" ]' 
       commands:
-      - |
-          grub2-editenv /tmp/mnt/EFI/boot_assessment set enable_boot_assessment=yes
+      - grub2-editenv /run/elemental/efi/boot_assessment set enable_boot_assessment=yes
+    - name: "Set upgrade sentinel on recovery"
+      if: '[ -f "/run/elemental/recovery_mode" ]' 
+      commands:
+      - grub2-editenv /run/elemental/efi/boot_assessment set enable_boot_assessment=yes
     # We do re-install hooks here if needed to track upgrades of boot assessment
     - <<: *customhook
     - <<: *bootgrub
-    - <<: *efiumount
 
     after-reset:
-    - <<: *efimount
     - name: "Remove GRUB sentinels"
       commands:
       - |
-          grub2-editenv /tmp/mnt/EFI/boot_assessment set enable_boot_assessment=
-          grub2-editenv /tmp/mnt/EFI/boot_assessment set boot_assessment_tentative=
+          grub2-editenv /run/elemental/efi/boot_assessment set enable_boot_assessment=
+          grub2-editenv /run/elemental/efi/boot_assessment set boot_assessment_tentative=
     # Reset completely restores COS_STATE, so we re-inject ourselves
     - <<: *customhook
     - <<: *bootgrub
-    - <<: *efiumount

--- a/pkg/features/embedded/elemental-sysroot/usr/lib/dracut/modules.d/20elemental-sysroot/sysroot-generator.sh
+++ b/pkg/features/embedded/elemental-sysroot/usr/lib/dracut/modules.d/20elemental-sysroot/sysroot-generator.sh
@@ -16,7 +16,7 @@ fi
 cos_img=$(getarg cos-img/filename=)
 elemental_img=$(getarg elemental.image=)
 [ -z "${cos_img}" && -z "${elemental_img}" ] && exit 0
-[ -z "${cos_img}" ] && cos_img="/cOS/${elemental_img}.img"
+[ -z "${cos_img}" ] && cos_img="${elemental_img}"
 
 [ -z "${root}" ] && root=$(getarg root=)
 

--- a/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
+++ b/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
@@ -44,44 +44,35 @@ insmod loopback
 insmod squash4
 
 set loopdev="loop0"
+search --no-floppy --label --set=root $state_label
 
 menuentry "${display_name}" --id cos {
-  search --no-floppy --label --set=root $state_label
-  # label is kept around for backward compatibility
-  set label=${active_label}
-  set img=/cOS/active.img
+  set img=/.snapshots/active
   set mode=active
-  loopback $loopdev /$img
+  loopback $loopdev $img
   source ($loopdev)/etc/cos/bootargs.cfg
   linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_active_cmdline}
   initrd ($loopdev)$initramfs
   loopback -d $loopdev
 }
 
-menuentry "${display_name} (fallback)" --id fallback {
-  search --no-floppy --label --set=root $state_label
-  # label is kept around for backward compatibility
-  set label=${passive_label}
-  set img=/cOS/passive.img
-  set mode=passive
-  loopback $loopdev /$img
-  source ($loopdev)/etc/cos/bootargs.cfg
-  linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_passive_cmdline}
-  initrd ($loopdev)$initramfs
-  loopback -d $loopdev
-}
+for passive_snap in ${passive_snaps}; do
+  menuentry "${display_name} (snapshot ${passive_snap})" --id ${passive_snap} {
+    set img=/.snapshots/passives/${passive_snap}
+    set mode=passive
+    loopback $loopdev $img
+    source ($loopdev)/etc/cos/bootargs.cfg
+    linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_passive_cmdline}
+    initrd ($loopdev)$initramfs
+    loopback -d $loopdev
+  }
+done
 
 menuentry "${display_name} recovery" --id recovery {
-  # label and recoverylabel are kept around for backward compatibility
-  if [ -n "${system_label}" ]; then
-    set label=${system_label}
-  else
-    set recoverylabel=${recovery_label}
-  fi
-  set img=/cOS/recovery.img
+  set img=/recovery.img
   set mode=recovery
   search --no-floppy --label --set=root $recovery_label
-  loopback $loopdev /$img
+  loopback $loopdev $img
   source ($loopdev)/etc/cos/bootargs.cfg
   linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_recovery_cmdline}
   initrd ($loopdev)$initramfs

--- a/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
+++ b/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
@@ -38,6 +38,11 @@ else
   set fallback="0 1 2"
 fi
 
+## Include custom file if any
+if [ -f "${custom_file}" ]; then
+  source "${custom_file}"
+fi
+
 insmod all_video
 insmod gfxterm
 insmod loopback
@@ -46,7 +51,7 @@ insmod squash4
 set loopdev="loop0"
 search --no-floppy --label --set=root $state_label
 
-menuentry "${display_name}" --id cos {
+menuentry "${display_name}" --id active {
   set img=/.snapshots/active
   set mode=active
   loopback $loopdev $img
@@ -78,7 +83,3 @@ menuentry "${display_name} recovery" --id recovery {
   initrd ($loopdev)$initramfs
   loopback -d $loopdev
 }
-
-if [ -f "${custom_file}" ]; then
-  source "${custom_file}"
-fi

--- a/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
+++ b/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
@@ -49,11 +49,11 @@ insmod loopback
 insmod squash4
 
 set loopdev="loop0"
-search --no-floppy --label --set=root $state_label
 
 menuentry "${display_name}" --id active {
   set img=/.snapshots/active
   set mode=active
+  search --no-floppy --label --set=root $state_label
   loopback $loopdev $img
   source ($loopdev)/etc/cos/bootargs.cfg
   linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_active_cmdline}
@@ -65,6 +65,7 @@ for passive_snap in ${passive_snaps}; do
   menuentry "${display_name} (snapshot ${passive_snap})" --id ${passive_snap} {
     set img=/.snapshots/passives/${passive_snap}
     set mode=passive
+    search --no-floppy --label --set=root $state_label
     loopback $loopdev $img
     source ($loopdev)/etc/cos/bootargs.cfg
     linux ($loopdev)$kernel $kernelcmd ${extra_cmdline} ${extra_passive_cmdline}

--- a/pkg/features/embedded/grub-default-bootargs/etc/cos/bootargs.cfg
+++ b/pkg/features/embedded/grub-default-bootargs/etc/cos/bootargs.cfg
@@ -1,8 +1,8 @@
 # TODO we could sanity check $partlabel is set here so we can error out before even attempting to boot
 set kernel=/boot/vmlinuz
 if [ "${mode}" == "recovery" ]; then
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$recovery_label elemental.image=$mode elemental.oemlabel=COS_OEM security=selinux selinux=0 rd.neednet=1"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$recovery_label elemental.image=${img} elemental.oemlabel=COS_OEM security=selinux selinux=0 rd.neednet=1"
 else
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$state_label elemental.image=$mode elemental.oemlabel=COS_OEM panic=5 security=selinux selinux=0 rd.neednet=1 fsck.mode=force fsck.repair=yes"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$state_label elemental.image=${img} elemental.oemlabel=COS_OEM panic=5 security=selinux selinux=0 rd.neednet=1 fsck.mode=force fsck.repair=yes"
 fi
 set initramfs=/boot/initrd

--- a/pkg/features/embedded/immutable-rootfs/usr/lib/dracut/modules.d/30elemental-immutable-rootfs/elemental-generator.sh
+++ b/pkg/features/embedded/immutable-rootfs/usr/lib/dracut/modules.d/30elemental-immutable-rootfs/elemental-generator.sh
@@ -19,7 +19,7 @@ fi
 cos_img=$(getarg cos-img/filename=)
 elemental_img=$(getarg elemental.image=)
 [ -z "${cos_img}" && -z "${elemental_img}" ] && exit 0
-[ -z "${cos_img}" ] && cos_img="/cOS/${elemental_img}.img"
+[ -z "${cos_img}" ] && cos_img="${elemental_img}"
 
 [ -z "${root}" ] && root=$(getarg root=)
 

--- a/pkg/features/embedded/immutable-rootfs/usr/lib/dracut/modules.d/30elemental-immutable-rootfs/parse-elemental-cmdline.sh
+++ b/pkg/features/embedded/immutable-rootfs/usr/lib/dracut/modules.d/30elemental-immutable-rootfs/parse-elemental-cmdline.sh
@@ -29,7 +29,7 @@ elemental_img=$(getarg elemental.image=)
 [ -z "${cos_img}" && -z "${elemental_img}" ] && return 0
 [ -z "${root}" ] && root=$(getarg root=)
 
-[ -n "${elemental_img}" ] && cos_img="/cOS/${elemental_img}.img"
+[ -n "${elemental_img}" ] && cos_img="${elemental_img}"
 
 cos_root_perm="ro"
 if getargbool 0 rd.cos.debugrw; then

--- a/pkg/mocks/extractor_mock.go
+++ b/pkg/mocks/extractor_mock.go
@@ -18,9 +18,11 @@ package mocks
 
 import v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
 
+const FakeDigest = "fakeDigest"
+
 type FakeImageExtractor struct {
 	Logger     v1.Logger
-	SideEffect func(imageRef, destination, platformRef string, local bool) error
+	SideEffect func(imageRef, destination, platformRef string, local bool) (string, error)
 }
 
 var _ v1.ImageExtractor = FakeImageExtractor{}
@@ -31,12 +33,12 @@ func NewFakeImageExtractor(logger v1.Logger) *FakeImageExtractor {
 	}
 }
 
-func (f FakeImageExtractor) ExtractImage(imageRef, destination, platformRef string, local bool) error {
+func (f FakeImageExtractor) ExtractImage(imageRef, destination, platformRef string, local bool) (string, error) {
 	f.Logger.Debugf("extracting %s to %s in platform %s", imageRef, destination, platformRef)
 	if f.SideEffect != nil {
 		f.Logger.Debugf("running sideeffect")
 		return f.SideEffect(imageRef, destination, platformRef, local)
 	}
 
-	return nil
+	return FakeDigest, nil
 }

--- a/pkg/mocks/utils.go
+++ b/pkg/mocks/utils.go
@@ -1,0 +1,65 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mocks
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+
+	"github.com/rancher/elemental-toolkit/pkg/constants"
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
+	"github.com/rancher/elemental-toolkit/pkg/utils"
+)
+
+// FakeLoopDeviceSnapshotsStatus creates fake snapshots files according to the LoopDevice behavior.
+// Used for unit testing only.
+func FakeLoopDeviceSnapshotsStatus(fs v1.FS, rootDir string, snapsCount int) error {
+	var snapshotFile, snapshotsPrefix string
+	var i int
+	var err error
+
+	snapshotsPrefix = filepath.Join(rootDir, ".snapshots")
+	for i = 1; i <= snapsCount; i++ {
+		err = utils.MkdirAll(fs, filepath.Join(rootDir, ".snapshots", strconv.Itoa(i)), constants.DirPerm)
+		if err != nil {
+			return err
+		}
+		snapshotFile = filepath.Join(snapshotsPrefix, strconv.Itoa(i), "snapshot.img")
+		err = fs.WriteFile(snapshotFile, []byte(fmt.Sprintf("This is snapshot %d", i)), constants.FilePerm)
+		if err != nil {
+			return err
+		}
+	}
+	err = fs.Symlink(filepath.Join(strconv.Itoa(i-1), "snapshot.img"), filepath.Join(snapshotsPrefix, constants.ActiveSnapshot))
+	if err != nil {
+		return err
+	}
+	passivesPath := filepath.Join(snapshotsPrefix, "passives")
+	err = utils.MkdirAll(fs, passivesPath, constants.DirPerm)
+	if err != nil {
+		return err
+	}
+	for i = 1; i <= snapsCount-1; i++ {
+		snapshotFile = filepath.Join("..", strconv.Itoa(i), "snapshot.img")
+		err = fs.Symlink(snapshotFile, filepath.Join(passivesPath, fmt.Sprintf(constants.PassiveSnapshot, i)))
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}

--- a/pkg/snapshotter/loopdevice.go
+++ b/pkg/snapshotter/loopdevice.go
@@ -463,7 +463,7 @@ func (l *LoopDevice) setBootloader() error {
 	}
 	snapsList := strings.Join(passives, " ")
 	fallbackList := strings.Join(fallbacks, " ")
-	envFile := filepath.Join(l.rootDir, constants.GrubOEMEnv)
+	envFile := filepath.Join(constants.EfiDir, constants.GrubOEMEnv)
 
 	envs := map[string]string{
 		constants.GrubFallback:         fallbackList,
@@ -550,9 +550,9 @@ func (l *LoopDevice) cleanLegacyImages() error {
 	var path string
 
 	if l.legacyClean {
-		path = filepath.Join(l.rootDir, legacyActivePath)
+		path = filepath.Join(l.rootDir, legacyPassivePath)
 		if elemental.IsPassiveMode(l.cfg) {
-			path = filepath.Join(l.rootDir, legacyPassivePath)
+			path = filepath.Join(l.rootDir, legacyActivePath)
 		} else if elemental.IsRecoveryMode(l.cfg) {
 			path = filepath.Join(l.rootDir, legacyImagesPath)
 		}

--- a/pkg/snapshotter/loopdevice.go
+++ b/pkg/snapshotter/loopdevice.go
@@ -41,10 +41,6 @@ const (
 	loopDevicePassivePath  = loopDeviceSnapsPath + "/passives"
 )
 
-const legacyImagesPath = "cOS"
-const legacyPassivePath = legacyImagesPath + "/passive.img"
-const legacyActivePath = legacyImagesPath + "/active.img"
-
 var _ v1.Snapshotter = (*LoopDevice)(nil)
 
 type LoopDevice struct {
@@ -87,15 +83,15 @@ func (l *LoopDevice) InitSnapshotter(rootDir string) error {
 	}
 
 	// Check the existence of a legacy deployment
-	if ok, _ := utils.Exists(l.cfg.Fs, filepath.Join(rootDir, legacyImagesPath)); ok {
+	if ok, _ := utils.Exists(l.cfg.Fs, filepath.Join(rootDir, constants.LegacyImagesPath)); ok {
 		l.cfg.Logger.Info("Legacy deployment detected running migration logic")
 		l.legacyClean = true
-		image := filepath.Join(rootDir, legacyActivePath)
+		image := filepath.Join(rootDir, constants.LegacyActivePath)
 
 		// Migrate passive image if running the transaction in passive mode
 		if elemental.IsPassiveMode(l.cfg) {
 			l.cfg.Logger.Debug("Running in passive mode, migrating passive image")
-			image = filepath.Join(rootDir, legacyPassivePath)
+			image = filepath.Join(rootDir, constants.LegacyPassivePath)
 		}
 		err = l.legacyImageToSnapsot(image)
 		if err != nil {
@@ -575,13 +571,13 @@ func (l *LoopDevice) cleanLegacyImages() error {
 
 	if l.legacyClean {
 		// delete passive image
-		path = filepath.Join(l.rootDir, legacyPassivePath)
+		path = filepath.Join(l.rootDir, constants.LegacyPassivePath)
 		if elemental.IsPassiveMode(l.cfg) {
 			// delete active image
-			path = filepath.Join(l.rootDir, legacyActivePath)
+			path = filepath.Join(l.rootDir, constants.LegacyActivePath)
 		} else if l.currentSnapshotID > 0 || elemental.IsRecoveryMode(l.cfg) {
 			// delete passive and active if we are not booting from any of them
-			path = filepath.Join(l.rootDir, legacyImagesPath)
+			path = filepath.Join(l.rootDir, constants.LegacyImagesPath)
 		}
 		if ok, _ := utils.Exists(l.cfg.Fs, path); ok {
 			return l.cfg.Fs.RemoveAll(path)

--- a/pkg/snapshotter/loopdevice_test.go
+++ b/pkg/snapshotter/loopdevice_test.go
@@ -268,7 +268,7 @@ var _ = Describe("LoopDevice", Label("snapshotter", "loopdevice"), func() {
 			Expect(snap.ID).To(Equal(6))
 			Expect(snap.InProgress).To(BeTrue())
 			Expect(lp.CloseTransaction(snap)).To(Succeed())
-			Expect(lp.GetSnapshots()).To(Equal([]int{3, 4, 5, 6}))
+			Expect(lp.GetSnapshots()).To(Equal([]int{5, 6}))
 		})
 
 		It("closes a started transaction and cleans old snapshots up to current active", func() {
@@ -287,8 +287,8 @@ var _ = Describe("LoopDevice", Label("snapshotter", "loopdevice"), func() {
 			Expect(snap.InProgress).To(BeTrue())
 			Expect(lp.CloseTransaction(snap)).To(Succeed())
 
-			// Could not delete 2 as it is in use and stopped cleaning
-			Expect(lp.GetSnapshots()).To(Equal([]int{2, 3, 4, 5, 6}))
+			// Could not delete 2 as it is in use
+			Expect(lp.GetSnapshots()).To(Equal([]int{2, 5, 6}))
 		})
 
 		It("closes and drops a started transaction if snapshot is not in progress", func() {

--- a/pkg/snapshotter/loopdevice_test.go
+++ b/pkg/snapshotter/loopdevice_test.go
@@ -143,6 +143,7 @@ var _ = Describe("LoopDevice", Label("snapshotter", "loopdevice"), func() {
 		Expect(fs.WriteFile(constants.ActiveMode, []byte("1"), constants.FilePerm)).To(Succeed())
 		Expect(utils.MkdirAll(fs, filepath.Join(rootDir, "cOS"), constants.DirPerm)).To(Succeed())
 		Expect(fs.WriteFile(filepath.Join(rootDir, "cOS/active.img"), []byte("active image"), constants.FilePerm)).To(Succeed())
+		Expect(fs.WriteFile(filepath.Join(rootDir, "cOS/passive.img"), []byte("passive image"), constants.FilePerm)).To(Succeed())
 
 		lp, err := snapshotter.NewLoopDeviceSnapshotter(cfg, snapCfg, bootloader)
 		Expect(err).NotTo(HaveOccurred())
@@ -157,7 +158,8 @@ var _ = Describe("LoopDevice", Label("snapshotter", "loopdevice"), func() {
 		Expect(snap.Path).To(Equal(filepath.Join(rootDir, ".snapshots/2/snapshot.img")))
 
 		Expect(lp.CloseTransaction(snap)).To(Succeed())
-		Expect(utils.Exists(fs, filepath.Join(rootDir, "cOS"))).To(BeFalse())
+		Expect(utils.Exists(fs, filepath.Join(rootDir, "cOS/passive.img"))).To(BeFalse())
+		Expect(utils.Exists(fs, filepath.Join(rootDir, "cOS/active.img"))).To(BeTrue())
 	})
 
 	It("fails to start a transaction without being initiated first", func() {

--- a/pkg/types/v1/common.go
+++ b/pkg/types/v1/common.go
@@ -37,6 +37,15 @@ const (
 type ImageSource struct {
 	source  string
 	srcType string
+	digest  string
+}
+
+func (i *ImageSource) SetDigest(digest string) {
+	i.digest = digest
+}
+
+func (i ImageSource) GetDigest() string {
+	return i.digest
 }
 
 func (i ImageSource) Value() string {

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -369,6 +369,12 @@ func (u *UpgradeSpec) Sanitize() error {
 		}
 	}
 
+	if u.BootloaderUpgrade {
+		if u.Partitions.EFI == nil || u.Partitions.EFI.MountPoint == "" {
+			return fmt.Errorf("undefined EFI partition")
+		}
+	}
+
 	// Set default label for non squashfs images
 	if u.RecoverySystem.FS != constants.SquashFs && u.RecoverySystem.Label == "" {
 		u.RecoverySystem.Label = constants.SystemLabel

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -219,6 +219,8 @@ func (i *InstallSpec) Sanitize() error {
 	// Set default label for non squashfs images
 	if i.RecoverySystem.FS != constants.SquashFs && i.RecoverySystem.Label == "" {
 		i.RecoverySystem.Label = constants.SystemLabel
+	} else if i.RecoverySystem.FS == constants.SquashFs {
+		i.RecoverySystem.Label = ""
 	}
 
 	// Check for extra partitions having set its size to 0

--- a/pkg/types/v1/grub.go
+++ b/pkg/types/v1/grub.go
@@ -23,10 +23,7 @@ import (
 func (i InstallSpec) GetGrubLabels() map[string]string {
 	grubEnv := map[string]string{
 		"state_label":    i.Partitions.State.FilesystemLabel,
-		"active_label":   i.Active.Label,
-		"passive_label":  i.Passive.Label,
 		"recovery_label": i.Partitions.Recovery.FilesystemLabel,
-		"system_label":   i.Recovery.Label,
 		"oem_label":      i.Partitions.OEM.FilesystemLabel,
 	}
 
@@ -40,10 +37,7 @@ func (i InstallSpec) GetGrubLabels() map[string]string {
 func (u UpgradeSpec) GetGrubLabels() map[string]string {
 	grubVars := map[string]string{
 		"state_label":    u.Partitions.State.FilesystemLabel,
-		"active_label":   u.Active.Label,
-		"passive_label":  u.Passive.Label,
 		"recovery_label": u.Partitions.Recovery.FilesystemLabel,
-		"system_label":   u.Recovery.Label,
 		"oem_label":      u.Partitions.OEM.FilesystemLabel,
 	}
 
@@ -57,8 +51,6 @@ func (u UpgradeSpec) GetGrubLabels() map[string]string {
 func (r ResetSpec) GetGrubLabels() map[string]string {
 	grubVars := map[string]string{
 		"state_label":    r.Partitions.State.FilesystemLabel,
-		"active_label":   r.Active.Label,
-		"passive_label":  r.Passive.Label,
 		"recovery_label": r.Partitions.Recovery.FilesystemLabel,
 		"oem_label":      r.Partitions.OEM.FilesystemLabel,
 	}
@@ -66,9 +58,7 @@ func (r ResetSpec) GetGrubLabels() map[string]string {
 	if r.State != nil {
 		if recoveryPart, ok := r.State.Partitions[constants.RecoveryPartName]; ok {
 			grubVars["recovery_label"] = recoveryPart.FSLabel
-			if recoveryImg, ok := recoveryPart.Images[constants.RecoveryImgName]; ok {
-				grubVars["system_label"] = recoveryImg.Label
-			}
+			grubVars["system_label"] = recoveryPart.RecoveryImage.Label
 		}
 	}
 
@@ -86,8 +76,5 @@ func (d DiskSpec) GetGrubLabels() map[string]string {
 		"recovery_label":   d.Partitions.Recovery.FilesystemLabel,
 		"state_label":      d.Partitions.State.FilesystemLabel,
 		"persistent_label": d.Partitions.Persistent.FilesystemLabel,
-		"active_label":     d.Active.Label,
-		"passive_label":    d.Passive.Label,
-		"system_label":     d.Recovery.Label,
 	}
 }

--- a/tests/assets/break_upgrade_hook.yaml
+++ b/tests/assets/break_upgrade_hook.yaml
@@ -1,0 +1,5 @@
+name: "Setup cos config"
+stages:
+   after-upgrade-chroot:
+     - commands:
+        - rm -rf /usr/lib/systemd /usr/bin/bash

--- a/tests/common/common.go
+++ b/tests/common/common.go
@@ -18,7 +18,7 @@ package common
 
 import "flag"
 
-const upImg = "ghcr.io/rancher/elemental-toolkit/elemental-green:v1.3.0"
+const upImg = "ghcr.io/rancher/elemental-toolkit/elemental-green:v0.10.7-g3e4a3c56"
 
 var upgradeImg string
 

--- a/tests/fsck/fsck_test.go
+++ b/tests/fsck/fsck_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Elemental booting fallback tests", func() {
+var _ = Describe("Elemental filesystem check tests", func() {
 	var s *sut.SUT
 
 	BeforeEach(func() {

--- a/tests/grubfallback/grubfallback_test.go
+++ b/tests/grubfallback/grubfallback_test.go
@@ -41,36 +41,21 @@ var _ = Describe("Elemental booting fallback tests", func() {
 
 	Context("GRUB cannot mount image", func() {
 		When("COS_ACTIVE image was corrupted", func() {
-			It("fallbacks by booting into passive", func() {
-				Expect(s.BootFrom()).To(Equal(sut.Active))
-
-				_, err := s.Command("mount -o rw,remount /run/initramfs/elemental-state")
-				Expect(err).ToNot(HaveOccurred())
-				_, err = s.Command("rm -rf /run/initramfs/elemental-state/cOS/active.img")
-				Expect(err).ToNot(HaveOccurred())
-
-				s.Reboot()
-
-				Expect(s.BootFrom()).To(Equal(sut.Passive))
-
-				// Here we did fallback from grub. boot assessment didn't kicked in here
-				cmdline, _ := s.Command("sudo cat /proc/cmdline")
-				Expect(cmdline).ToNot(And(ContainSubstring("upgrade_failure")), cmdline)
-			})
-		})
-		When("COS_ACTIVE and COS_PASSIVE images are corrupted", func() {
 			It("fallbacks by booting into recovery", func() {
 				Expect(s.BootFrom()).To(Equal(sut.Active))
 
 				_, err := s.Command("mount -o rw,remount /run/initramfs/elemental-state")
 				Expect(err).ToNot(HaveOccurred())
-				_, err = s.Command("rm -rf /run/initramfs/elemental-state/cOS/active.img")
+				_, err = s.Command("rm -rf /run/initramfs/elemental-state/.snapshots/1/snapshot.img")
 				Expect(err).ToNot(HaveOccurred())
-				_, err = s.Command("rm -rf /run/initramfs/elemental-state/cOS/passive.img")
-				Expect(err).ToNot(HaveOccurred())
+
 				s.Reboot()
 
 				Expect(s.BootFrom()).To(Equal(sut.Recovery))
+
+				// Here we did fallback from grub. boot assessment didn't kicked in here
+				cmdline, _ := s.Command("sudo cat /proc/cmdline")
+				Expect(cmdline).ToNot(And(ContainSubstring("upgrade_failure")), cmdline)
 			})
 		})
 	})

--- a/tests/installer/installer_efi_test.go
+++ b/tests/installer/installer_efi_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Elemental Installer EFI tests", func() {
 					err := s.SendFile("../assets/custom_partitions.yaml", "/etc/elemental/config.d/custom_partitions.yaml", "0770")
 					By("Running the elemental install with a layout file")
 					Expect(err).To(BeNil())
-					out, err := s.Command(s.ElementalCmd("install", "/dev/vda"))
+					out, err := s.Command(s.ElementalCmd("install", "--squash-no-compression", "/dev/vda"))
 					fmt.Printf(out)
 					Expect(err).To(BeNil())
 					Expect(out).To(ContainSubstring("Mounting disk partitions"))

--- a/tests/recovery/recovery_test.go
+++ b/tests/recovery/recovery_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Elemental Recovery upgrade tests", func() {
 
 			By(fmt.Sprintf("upgrading to %s", comm.UpgradeImage()))
 
-			cmd := s.ElementalCmd("upgrade", "--system.uri", comm.UpgradeImage())
+			cmd := s.ElementalCmd("upgrade", "--system", comm.UpgradeImage())
 			By(fmt.Sprintf("running %s", cmd))
 
 			out, err := s.Command(cmd)

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -54,24 +54,6 @@ var _ = Describe("Elemental Smoke tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("can boot into passive", func() {
-			err := s.ChangeBootOnce(sut.Passive)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("rebooting into passive")
-			s.Reboot()
-
-			Expect(s.BootFrom()).To(Equal(sut.Passive))
-			_, err = s.Command("cat /run/cos/recovery_mode")
-			Expect(err).To(HaveOccurred())
-
-			_, err = s.Command("cat /run/cos/live_mode")
-			Expect(err).To(HaveOccurred())
-
-			By("reboot back to active")
-			s.Reboot()
-		})
-
 		It("can boot into recovery", func() {
 			s.ChangeBoot(sut.Recovery)
 			By("rebooting into recovery")
@@ -82,12 +64,11 @@ var _ = Describe("Elemental Smoke tests", func() {
 			out, err := s.Command("cat /run/cos/recovery_mode")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(Equal("1"))
-			_, err = s.Command("cat /run/cos/live_mode")
-			Expect(err).To(HaveOccurred())
 
 			By("switching back to active")
 			s.ChangeBoot(sut.Active)
 			s.Reboot()
+			Expect(s.BootFrom()).To(Equal(sut.Active))
 		})
 
 		It("can read the file from persistent storage", func() {
@@ -97,6 +78,7 @@ var _ = Describe("Elemental Smoke tests", func() {
 		})
 
 		It("fails running elemental reset from COS_ACTIVE", func() {
+			Expect(s.BootFrom()).To(Equal(sut.Active))
 			out, err := s.Command(s.ElementalCmd("reset"))
 			Expect(err).To(HaveOccurred())
 			Expect(out).Should(ContainSubstring("reset can only be called from the recovery system"))

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -43,10 +43,8 @@ var _ = Describe("Elemental Feature tests", func() {
 			originalVersion := s.GetOSRelease("TIMESTAMP")
 
 			By(fmt.Sprintf("and upgrading the to %s", comm.UpgradeImage()))
-			// TODO: make use of verified images and check unsigned images can't be pulled
-			//out, err := s.Command(s.ElementalCmd("upgrade", "--verify", "--system.uri", comm.UpgradeImage()))
-			//Expect(err).To(HaveOccurred())
-			out, err := s.Command(s.ElementalCmd("upgrade", "--system.uri", comm.UpgradeImage()))
+
+			out, err := s.Command(s.ElementalCmd("upgrade", "--system", comm.UpgradeImage()))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).Should(ContainSubstring("Upgrade completed"))
 

--- a/tests/vm/sut.go
+++ b/tests/vm/sut.go
@@ -161,9 +161,9 @@ func (s *SUT) ChangeBootOnce(b string) error {
 
 	switch b {
 	case Active:
-		bootEntry = Cos
+		bootEntry = "active"
 	case Passive:
-		bootEntry = "fallback"
+		bootEntry = "passive_1"
 	case Recovery:
 		bootEntry = "recovery"
 	}
@@ -207,11 +207,11 @@ func (s *SUT) BootFrom() string {
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	switch {
-	case strings.Contains(out, "active.img"), strings.Contains(out, "image=active"):
+	case strings.Contains(out, "active"):
 		return Active
-	case strings.Contains(out, "passive.img"), strings.Contains(out, "image=passive"):
+	case strings.Contains(out, "passive"):
 		return Passive
-	case strings.Contains(out, "recovery.img"), strings.Contains(out, "recovery.squashfs"), strings.Contains(out, "image=recovery"):
+	case strings.Contains(out, "recovery"):
 		return Recovery
 	case strings.Contains(out, "live:CDLABEL"):
 		return LiveCD


### PR DESCRIPTION
This commit adopts snapshotter interface in install, reset and upgrade commands. The change implies changes to the respective specs, grub configuration and dracut modules.

This commit also changes the behavior of recovery system upgrades. Now recovery upgrades are an optional step of a system upgrade. Recovery image can't be upgraded without upgrading the active system.

Finally build-disk command is also changed to be better aligned with upgrade and install procedures. Expandable disks are an unprivileged build and non expandable ones require privileges as they relay on snapshotter.

Fixes #1874
Fixes #1921 
Fixes #1922 