### PR TITLE
Bind mount /oem in elemental-setup-initramfs

### DIFF
--- a/pkg/features/embedded/elemental-setup/usr/lib/systemd/system/elemental-setup-initramfs.service
+++ b/pkg/features/embedded/elemental-setup/usr/lib/systemd/system/elemental-setup-initramfs.service
@@ -8,6 +8,7 @@ Before=initrd.target
 [Service]
 RootDirectory=/sysroot
 BindPaths=/proc /sys /dev /run /tmp
+BindPaths=-/oem
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/elemental run-stage initramfs


### PR DESCRIPTION
Bind /oem into /sysroot/oem when running elemental-setup-initramfs to enable running initramfs stages from config files in oem partition.