### PR TITLE
Include elemental partitions in mount command

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -254,7 +254,11 @@ func ReadInitSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.InitSpec, error) {
 }
 
 func ReadMountSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.MountSpec, error) {
-	mount := config.NewMountSpec()
+	mount, err := config.NewMountSpec(r.Config)
+	if err != nil {
+		r.Logger.Errorf("Failed preparing mount configuration: %s", err)
+		return nil, err
+	}
 	vp := viper.Sub("mount")
 	if vp == nil {
 		vp = viper.New()
@@ -264,7 +268,7 @@ func ReadMountSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.MountSpec, error)
 	// Bind mount env vars
 	viperReadEnv(vp, "MOUNT", constants.GetMountKeyEnvMap())
 
-	err := vp.Unmarshal(mount, setDecoder, decodeHook)
+	err = vp.Unmarshal(mount, setDecoder, decodeHook)
 	if err != nil {
 		r.Logger.Warnf("error unmarshalling MountSpec: %s", err)
 		return mount, err

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -467,6 +467,34 @@ var _ = Describe("Config", Label("config"), func() {
 			})
 		})
 		Describe("Read MountSpec", Label("mount"), func() {
+			var ghwTest v1mock.GhwMock
+			BeforeEach(func() {
+				mainDisk := block.Disk{
+					Name: "device",
+					Partitions: []*block.Partition{
+						{
+							Name:            "device2",
+							FilesystemLabel: "COS_STATE",
+							Type:            "ext4",
+							MountPoint:      constants.RunningStateDir,
+						},
+						{
+							Name:            "device3",
+							FilesystemLabel: "COS_RECOVERY",
+							Type:            "ext4",
+							MountPoint:      constants.RunningStateDir,
+						},
+					},
+				}
+				ghwTest = v1mock.GhwMock{}
+				ghwTest.AddDisk(mainDisk)
+				ghwTest.CreateDevices()
+			})
+
+			AfterEach(func() {
+				ghwTest.Clean()
+			})
+
 			It("inits a mount spec according to given configs", func() {
 				err := os.Setenv("ELEMENTAL_MOUNT_SYSROOT", "/newroot")
 				spec, err := ReadMountSpec(cfg, nil)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -168,7 +168,7 @@ func (i InstallAction) Run() (err error) {
 		return err
 	}
 
-	err = elemental.MountPartitions(i.cfg.Config, i.spec.Partitions.PartitionsByMountPoint(false))
+	err = elemental.MountPartitions(i.cfg.Config, i.spec.Partitions.PartitionsByMountPoint(false), "rw")
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.MountPartitions)
 	}

--- a/pkg/action/mount_test.go
+++ b/pkg/action/mount_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rancher/elemental-toolkit/pkg/action"
 	"github.com/rancher/elemental-toolkit/pkg/config"
 	"github.com/rancher/elemental-toolkit/pkg/constants"
+	"github.com/rancher/elemental-toolkit/pkg/elemental"
 	v1mock "github.com/rancher/elemental-toolkit/pkg/mocks"
 	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
 	"github.com/rancher/elemental-toolkit/pkg/utils"
@@ -78,14 +79,76 @@ var _ = Describe("Mount Action", func() {
 				Ephemeral: v1.EphemeralMounts{
 					Size: "30%",
 				},
+				Persistent: v1.PersistentMounts{
+					Mode:  constants.BindMode,
+					Paths: []string{"/some/path"},
+				},
+				Partitions: v1.ElementalPartitions{
+					Persistent: &v1.Partition{
+						Path:       "/some/device",
+						MountPoint: "/mnt",
+					},
+				},
 			}
+			Expect(elemental.MountPartition(cfg.Config, spec.Partitions.Persistent)).To(Succeed())
 			utils.MkdirAll(fs, filepath.Join(spec.Sysroot, "/etc"), constants.DirPerm)
 			err := action.WriteFstab(cfg, spec)
 			Expect(err).To(BeNil())
 
 			fstab, err := cfg.Config.Fs.ReadFile(filepath.Join(spec.Sysroot, "/etc/fstab"))
 			Expect(err).To(BeNil())
-			Expect(string(fstab)).To(Equal("/dev/loop0\t/\text2\tro,relatime\t0\t0\ntmpfs\t/run/elemental/overlay\ttmpfs\tdefaults,size=30%\t0\t0\n"))
+			expectedFstab := "/dev/loop0\t/\text2\tro,relatime\t0\t0\n"
+			expectedFstab += "tmpfs\t/run/elemental/overlay\ttmpfs\tdefaults,size=30%\t0\t0\n"
+			expectedFstab += "/some/device\t/mnt\tauto\tdefaults\t0\t0\n"
+			expectedFstab += "/run/elemental/persistent/.state/some-path.bind\t/some/path\tnone\tdefaults,bind\t0\t0\n"
+			Expect(string(fstab)).To(Equal(expectedFstab))
+		})
+
+		It("Writes a simple fstab with overlay mode", func() {
+			spec := &v1.MountSpec{
+				WriteFstab: true,
+				Ephemeral: v1.EphemeralMounts{
+					Size: "30%",
+				},
+				Persistent: v1.PersistentMounts{
+					Mode:  constants.OverlayMode,
+					Paths: []string{"/some/path"},
+				},
+				Partitions: v1.ElementalPartitions{
+					Persistent: &v1.Partition{
+						Path:       "/some/device",
+						MountPoint: "/mnt",
+					},
+				},
+			}
+			Expect(elemental.MountPartition(cfg.Config, spec.Partitions.Persistent)).To(Succeed())
+			utils.MkdirAll(fs, filepath.Join(spec.Sysroot, "/etc"), constants.DirPerm)
+			err := action.WriteFstab(cfg, spec)
+			Expect(err).To(BeNil())
+
+			fstab, err := cfg.Config.Fs.ReadFile(filepath.Join(spec.Sysroot, "/etc/fstab"))
+			Expect(err).To(BeNil())
+			expectedFstab := "/dev/loop0\t/\text2\tro,relatime\t0\t0\n"
+			expectedFstab += "tmpfs\t/run/elemental/overlay\ttmpfs\tdefaults,size=30%\t0\t0\n"
+			expectedFstab += "/some/device\t/mnt\tauto\tdefaults\t0\t0\n"
+			expectedFstab += "overlay\t/some/path\toverlay\t"
+			expectedFstab += "defaults,lowerdir=/some/path,upperdir=/run/elemental/persistent/.state/some-path.overlay/upper,workdir=/run/elemental/persistent/.state/some-path.overlay/work,x-systemd.requires-mounts-for=/run/elemental/persistent\t0\t0\n"
+			Expect(string(fstab)).To(Equal(expectedFstab))
+		})
+
+		It("Does not write fstab if not requested", func() {
+			spec := &v1.MountSpec{
+				WriteFstab: false,
+				Ephemeral: v1.EphemeralMounts{
+					Size: "30%",
+				},
+			}
+			utils.MkdirAll(fs, filepath.Join(spec.Sysroot, "/etc"), constants.DirPerm)
+			err := action.WriteFstab(cfg, spec)
+			Expect(err).To(BeNil())
+
+			ok, _ := utils.Exists(fs, filepath.Join(spec.Sysroot, "/etc/fstab"))
+			Expect(ok).To(BeFalse())
 		})
 	})
 })

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -175,7 +175,7 @@ func (r ResetAction) Run() (err error) {
 		}
 	}
 	// Mount configured partitions
-	err = elemental.MountPartitions(r.cfg.Config, r.spec.Partitions.PartitionsByMountPoint(false, r.spec.Partitions.Recovery))
+	err = elemental.MountPartitions(r.cfg.Config, r.spec.Partitions.PartitionsByMountPoint(false, r.spec.Partitions.Recovery), "rw")
 	if err != nil {
 		return elementalError.NewFromError(err, elementalError.MountPartitions)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -228,6 +228,8 @@ func NewMountSpec(cfg v1.Config) (*v1.MountSpec, error) {
 	if err != nil {
 		cfg.Logger.Warnf("failed reading installation state: %s", err.Error())
 	}
+
+	// Lists detected partitions on current system including mountpoint if mounted
 	parts, err := utils.GetAllPartitions()
 	if err != nil {
 		return nil, fmt.Errorf("could not read host partitions")
@@ -241,11 +243,15 @@ func NewMountSpec(cfg v1.Config) (*v1.MountSpec, error) {
 	}
 	if ep.OEM != nil && ep.OEM.MountPoint == "" {
 		ep.OEM.MountPoint = constants.OEMDir
-		ep.OEM.Flags = []string{"rw", "defaults"}
 	}
 	if ep.Persistent != nil && ep.Persistent.MountPoint == "" {
 		ep.Persistent.MountPoint = constants.PersistentDir
-		ep.Persistent.Flags = []string{"rw", "defaults"}
+	}
+	if ep.Recovery != nil {
+		ep.Recovery.Flags = []string{"ro", "defaults"}
+	}
+	if ep.State != nil {
+		ep.State.Flags = []string{"ro", "defaults"}
 	}
 	if (ep.Recovery == nil || ep.Recovery.MountPoint == "") &&
 		(ep.State == nil || ep.State.MountPoint == "") {

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -108,13 +108,18 @@ func createPartitions(c v1.Config, disk *partitioner.Disk, parts v1.PartitionLis
 
 // MountPartitions mounts configured partitions. Partitions with an unset mountpoint are not mounted.
 // Note umounts must be handled by caller logic.
-func MountPartitions(c v1.Config, parts v1.PartitionList) error {
+func MountPartitions(c v1.Config, parts v1.PartitionList, overwriteFlags ...string) error {
 	c.Logger.Infof("Mounting disk partitions")
 	var err error
+	var flags []string
 
 	for _, part := range parts {
 		if part.MountPoint != "" {
-			err = MountPartition(c, part, "rw")
+			flags = part.Flags
+			if len(overwriteFlags) > 0 {
+				flags = overwriteFlags
+			}
+			err = MountPartition(c, part, flags...)
 			if err != nil {
 				_ = UnmountPartitions(c, parts)
 				return err

--- a/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-rootfs.service
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/systemd/system/elemental-rootfs.service
@@ -4,6 +4,8 @@ DefaultDependencies=no
 After=initrd-root-fs.target
 Requires=initrd-root-fs.target
 Before=initrd-fs.target
+ConditionKernelCommandLine=!rd.cos.disable
+ConditionKernelCommandLine=!elemental.disable
 Conflicts=initrd-switch-root.target
 
 [Service]

--- a/pkg/features/embedded/elemental-sysroot/usr/lib/dracut/modules.d/20elemental-sysroot/sysroot-generator.sh
+++ b/pkg/features/embedded/elemental-sysroot/usr/lib/dracut/modules.d/20elemental-sysroot/sysroot-generator.sh
@@ -8,6 +8,9 @@ root_part_mnt="/run/initramfs/elemental-state"
 if getargbool 0 elemental.disable; then
     exit 0
 fi
+if getargbool 0 rd.cos.disable; then
+    exit 0
+fi
 
 # Omit any immutable rootfs module logic if no image path provided
 cos_img=$(getarg cos-img/filename=)

--- a/pkg/features/embedded/grub-default-bootargs/etc/cos/bootargs.cfg
+++ b/pkg/features/embedded/grub-default-bootargs/etc/cos/bootargs.cfg
@@ -1,8 +1,8 @@
 # TODO we could sanity check $partlabel is set here so we can error out before even attempting to boot
 set kernel=/boot/vmlinuz
 if [ "${mode}" == "recovery" ]; then
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$recovery_label elemental.image=$mode elemental.oemlabel=COS_OEM rd.cos.mount=LABEL=$oem_label:/oem security=selinux selinux=0 rd.neednet=1"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$recovery_label elemental.image=$mode elemental.oemlabel=COS_OEM security=selinux selinux=0 rd.neednet=1"
 else
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$state_label elemental.image=$mode elemental.oemlabel=COS_OEM panic=5 security=selinux selinux=0 rd.neednet=1 rd.cos.mount=LABEL=$oem_label:/oem fsck.mode=force fsck.repair=yes"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$state_label elemental.image=$mode elemental.oemlabel=COS_OEM panic=5 security=selinux selinux=0 rd.neednet=1 fsck.mode=force fsck.repair=yes"
 fi
 set initramfs=/boot/initrd

--- a/pkg/mocks/mounter_mock.go
+++ b/pkg/mocks/mounter_mock.go
@@ -57,6 +57,7 @@ func (e FakeMounter) Unmount(target string) error {
 
 func (e FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	mnts, _ := e.List()
+
 	for _, mnt := range mnts {
 		if file == mnt.Path {
 			return false, nil

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -298,9 +298,6 @@ func (spec *MountSpec) Sanitize() error {
 
 	if spec.Mode == constants.RecoveryImgName {
 		spec.Partitions.Persistent = nil
-		spec.Partitions.Recovery.MountPoint = constants.RunningStateDir
-	} else {
-		spec.Partitions.State.MountPoint = constants.RunningStateDir
 	}
 
 	return nil


### PR DESCRIPTION
This PR essentially adds an additional step in mount command to mount elemental partitions before hand (OEM, Persistent, EFI, etc.). Elemental partitions should already mounted and prepare at initramfs stage and even before the persistent paths are set (otherwise instead of being defined in a persistent area they are on `/run`'s tmpfs).