### PR TITLE
Remove BindMount for /oem in initramfs stage

### DIFF
--- a/pkg/features/embedded/elemental-setup/usr/lib/systemd/system/elemental-setup-initramfs.service
+++ b/pkg/features/embedded/elemental-setup/usr/lib/systemd/system/elemental-setup-initramfs.service
@@ -8,7 +8,6 @@ Before=initrd.target
 [Service]
 RootDirectory=/sysroot
 BindPaths=/proc /sys /dev /run /tmp
-BindPaths=-/oem
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/elemental run-stage initramfs


### PR DESCRIPTION
Since we now mount /oem in the mount command this is superfluous and might cause other oddities.