### PR TITLE
Add back the BindPath for /oem

### DIFF
--- a/pkg/features/embedded/elemental-setup/usr/lib/systemd/system/elemental-setup-initramfs.service
+++ b/pkg/features/embedded/elemental-setup/usr/lib/systemd/system/elemental-setup-initramfs.service
@@ -8,6 +8,7 @@ Before=initrd.target
 [Service]
 RootDirectory=/sysroot
 BindPaths=/proc /sys /dev /run /tmp
+BindPaths=-/oem
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/elemental run-stage initramfs


### PR DESCRIPTION
Without this, the registration breaks (initramfs stages put in /oem are not read and executed).

Edit: also, /oem should be unmounted because of the Conflicts declaration in the oem-generator...