### PR TITLE
Add Volumes in Mount spec

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -124,6 +124,17 @@ upgrade:
 mount:
   sysroot: /sysroot # Path to mount system to
   write-fstab: true # Write fstab into sysroot/etc/fstab
+  volumes:
+    - mountpoint: /run/elemental/persistent
+      device: PARTLABEL=persistent
+      options: ["defaults"]
+      persisent: true
+    - mountpoint: /run/elemental/efi
+      device: PARTLABEL=efi
+      options: ["ro", "defaults"]
+    - mountpoint: /oem
+      device: LABEL=COS_OEM
+      options: ["defaults"]
   ephemeral:
     type: tmpfs # tmpfs|block
     device: /dev/sda6 # Block device used to store overlay. Used when type is set to block

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -124,11 +124,7 @@ upgrade:
 mount:
   sysroot: /sysroot # Path to mount system to
   write-fstab: true # Write fstab into sysroot/etc/fstab
-  volumes:
-    - mountpoint: /run/elemental/persistent
-      device: PARTLABEL=persistent
-      options: ["defaults"]
-      persisent: true
+  extra-volumes:
     - mountpoint: /run/elemental/efi
       device: PARTLABEL=efi
       options: ["ro", "defaults"]
@@ -145,6 +141,10 @@ mount:
       - /srv
   persistent:
     mode: overlay # overlay|bind
+    volume:
+      mountpoint: /run/elemental/persistent
+      device: PARTLABEL=persistent
+      options: ["defaults"]
     paths:
       - /etc/systemd
       - /etc/ssh

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -226,11 +226,6 @@ func NewMountSpec() *v1.MountSpec {
 		WriteFstab: true,
 		Volumes: []*v1.VolumeMount{
 			{
-				Mountpoint: constants.PersistentDir,
-				Device:     fmt.Sprintf("PARTLABEL=%s", constants.PersistentPartName),
-				Options:    []string{"rw", "defaults"},
-				Persistent: true,
-			}, {
 				Mountpoint: constants.OEMPath,
 				Device:     fmt.Sprintf("PARTLABEL=%s", constants.OEMPartName),
 				Options:    []string{"rw", "defaults"},
@@ -248,6 +243,11 @@ func NewMountSpec() *v1.MountSpec {
 		Persistent: v1.PersistentMounts{
 			Mode:  constants.OverlayMode,
 			Paths: []string{"/etc/systemd", "/etc/ssh", "/home", "/opt", "/root", "/var/log"},
+			Volume: v1.VolumeMount{
+				Mountpoint: constants.PersistentDir,
+				Device:     fmt.Sprintf("PARTLABEL=%s", constants.PersistentPartName),
+				Options:    []string{"rw", "defaults"},
+			},
 		},
 	}
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -26,8 +26,8 @@ const (
 	BiosPartName       = "bios"
 	EfiLabel           = "COS_GRUB"
 	EfiPartName        = "efi"
-	ActiveLabel        = "COS_ACTIVE"
-	PassiveLabel       = "COS_PASSIVE"
+	ActiveLabel        = "COS_ACTIVE"  // TODO deleteme
+	PassiveLabel       = "COS_PASSIVE" // TODO deleteme
 	SystemLabel        = "COS_SYSTEM"
 	RecoveryLabel      = "COS_RECOVERY"
 	RecoveryPartName   = "recovery"
@@ -92,16 +92,17 @@ const (
 	ElementalBootloaderBin = "/usr/lib/elemental/bootloader"
 
 	// Mountpoints of images and partitions
+	RunElementalDir    = "/run/elemental"
 	RecoveryDir        = "/run/elemental/recovery"
 	StateDir           = "/run/elemental/state"
 	OEMDir             = "/run/elemental/oem"
 	PersistentDir      = "/run/elemental/persistent"
-	PersistentStateDir = "/run/elemental/persistent/.state"
 	TransitionDir      = "/run/elemental/transition"
 	EfiDir             = "/run/elemental/efi"
 	ImgSrcDir          = "/run/elemental/imgsrc"
 	WorkingImgDir      = "/run/elemental/workingtree"
 	OverlayDir         = "/run/elemental/overlay"
+	PersistentStateDir = ".state"
 	RunningStateDir    = "/run/initramfs/elemental-state" // TODO: converge this constant with StateDir/RecoveryDir when moving to elemental-rootfs as default rootfs feature.
 
 	// Running mode sentinel files


### PR DESCRIPTION
This commit allows to set specific additional mount points for block devices in mount command. They can be set by label, partlabel, uuid and device path.

In addition this commit also introduces some logic to precompute initial fstab lines for sysroot and
other mounts done in previous stages.