### PR TITLE
Use go 1.22

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -9,6 +9,8 @@ on:
       - .github/**
       - Makefile
       - tests/**
+      - go.mod
+      - go.sum
   push:
     branches:
       - main

--- a/.obs/specfile/elemental-toolkit.spec
+++ b/.obs/specfile/elemental-toolkit.spec
@@ -40,7 +40,7 @@ Requires:       util-linux
 Requires:       gptfdisk
 
 %if 0%{?suse_version}
-BuildRequires:  golang(API) >= 1.18
+BuildRequires:  golang(API) >= 1.22
 BuildRequires:  golang-packaging
 %{go_provides}
 %else

--- a/.obs/specfile/elemental-toolkit.spec
+++ b/.obs/specfile/elemental-toolkit.spec
@@ -49,7 +49,7 @@ BuildRequires:  golang-packaging
 %global commit     d1ae3f9a425de2618f9058f3b37583ef3ce52c7d
 %gometa
 %if (0%{?centos_version} == 800) || (0%{?rhel_version} == 800)
-BuildRequires:  go1.20
+BuildRequires:  go1.22
 %else
 BuildRequires:  compiler(go-compiler)
 %endif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_OS_IMAGE=registry.opensuse.org/opensuse/leap
 ARG BASE_OS_VERSION=15.5
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.22
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine as elemental-bin
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check out our [getting-started](https://rancher.github.io/elemental-toolkit/docs
 
 ## License
 
-Copyright (c) 2020-2023 [SUSE, LLC](http://suse.com)
+Copyright (c) 2020-2024 [SUSE, LLC](http://suse.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/elemental-toolkit
 
-go 1.21
+go 1.22
 
 require (
 	github.com/bramvdbogaerde/go-scp v1.2.1


### PR DESCRIPTION
Also includes an update to the README for the correct copyright year.