### PR TITLE
Use backup legacy grub.cfg location

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -182,6 +182,7 @@ const (
 	LegacyPassivePath = LegacyImagesPath + "/passive.img"
 	LegacyActivePath  = LegacyImagesPath + "/active.img"
 	LegacyStateDir    = "/run/initramfs/cos-state"
+	LegacyGrubCfgPath = "/etc/cos"
 )
 
 // GetDefaultSystemEcludes returns a list of transient paths


### PR DESCRIPTION
During build-disk, if the new /etc/elemental/grub.cfg config is not found, revert to using /etc/cos/grub.cfg for backwards compatibility.