### PR TITLE
Add upgrade-recovery subcommand

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -452,6 +452,29 @@ func ReadUpgradeSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.UpgradeSpec, er
 	return upgrade, err
 }
 
+func ReadUpgradeRecoverySpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.UpgradeSpec, error) {
+	upgrade, err := config.NewUpgradeSpec(r.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed initializing upgrade recovery spec: %v", err)
+	}
+	vp := viper.Sub("upgrade-recovery")
+	if vp == nil {
+		vp = viper.New()
+	}
+	// Bind upgrade-recovery cmd flags
+	bindGivenFlags(vp, flags)
+	// Bind upgrade-recovery env vars
+	viperReadEnv(vp, "UPGRADE_RECOVERY", constants.GetUpgradeRecoveryKeyEnvMap())
+
+	err = vp.Unmarshal(upgrade, setDecoder, decodeHook)
+	if err != nil {
+		r.Logger.Warnf("error unmarshalling UpgradeSpec: %s", err)
+	}
+	err = upgrade.SanitizeForRecoveryOnly()
+	r.Logger.Debugf("Loaded upgrade UpgradeSpec: %s", litter.Sdump(upgrade))
+	return upgrade, err
+}
+
 func ReadBuildISO(b *v1.BuildConfig, flags *pflag.FlagSet) (*v1.LiveISO, error) {
 	iso := config.NewISO()
 	vp := viper.Sub("iso")

--- a/cmd/upgrade-recovery.go
+++ b/cmd/upgrade-recovery.go
@@ -1,0 +1,85 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/rancher/elemental-toolkit/cmd/config"
+	"github.com/rancher/elemental-toolkit/pkg/action"
+	elementalError "github.com/rancher/elemental-toolkit/pkg/error"
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
+)
+
+// NewUpgradeCmd returns a new instance of the upgrade subcommand and appends it to
+// the root command. requireRoot is to initiate it with or without the CheckRoot
+// pre-run check. This method is mostly used for testing purposes.
+func NewUpgradeRecoveryCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "upgrade-recovery",
+		Short: "Upgrade the Recovery system",
+		Args:  cobra.ExactArgs(0),
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if addCheckRoot {
+				return CheckRoot()
+			}
+			return nil
+		},
+
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := exec.LookPath("mount")
+			if err != nil {
+				return err
+			}
+			mounter := v1.NewMounter(path)
+
+			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), mounter)
+			if err != nil {
+				cfg.Logger.Errorf("Error reading config: %s\n", err)
+				return elementalError.NewFromError(err, elementalError.ReadingRunConfig)
+			}
+
+			// Set this after parsing of the flags, so it fails on parsing and prints usage properly
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true // Do not propagate errors down the line, we control them
+
+			spec, err := config.ReadUpgradeRecoverySpec(cfg, cmd.Flags())
+			if err != nil {
+				cfg.Logger.Errorf("Invalid upgrade-recovery command setup %v", err)
+				return elementalError.NewFromError(err, elementalError.ReadingSpecConfig)
+			}
+
+			cfg.Logger.Infof("Upgrade Recovery called")
+			upgrade, err := action.NewUpgradeRecoveryAction(cfg, spec, action.WithUpdateInstallState(true))
+			if err != nil {
+				cfg.Logger.Errorf("failed to initialize upgrade-recovery action: %v", err)
+				return err
+			}
+
+			return upgrade.Run()
+		},
+	}
+	root.AddCommand(c)
+	addRecoverySystemFlag(c)
+	return c
+}
+
+// register the subcommand into rootCmd
+var _ = NewUpgradeRecoveryCmd(rootCmd, true)

--- a/cmd/upgrade-recovery.go
+++ b/cmd/upgrade-recovery.go
@@ -60,7 +60,7 @@ func NewUpgradeRecoveryCmd(root *cobra.Command, addCheckRoot bool) *cobra.Comman
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true // Do not propagate errors down the line, we control them
 
-			spec, err := config.ReadUpgradeRecoverySpec(cfg, cmd.Flags())
+			spec, err := config.ReadUpgradeSpec(cfg, cmd.Flags(), true)
 			if err != nil {
 				cfg.Logger.Errorf("Invalid upgrade-recovery command setup %v", err)
 				return elementalError.NewFromError(err, elementalError.ReadingSpecConfig)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -68,7 +68,7 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true // Do not propagate errors down the line, we control them
 
-			spec, err := config.ReadUpgradeSpec(cfg, cmd.Flags())
+			spec, err := config.ReadUpgradeSpec(cfg, cmd.Flags(), false)
 			if err != nil {
 				cfg.Logger.Errorf("Invalid upgrade command setup %v", err)
 				return elementalError.NewFromError(err, elementalError.ReadingSpecConfig)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -85,7 +85,6 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		},
 	}
 	root.AddCommand(c)
-	c.Flags().Bool("recovery-only", false, "Upgrade recovery image only")
 	c.Flags().Bool("recovery", false, "Upgrade recovery image too")
 	c.Flags().Bool("bootloader", false, "Reinstall bootloader during the upgrade")
 	addSharedInstallUpgradeFlags(c)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -85,6 +85,7 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		},
 	}
 	root.AddCommand(c)
+	c.Flags().Bool("recovery-only", false, "Upgrade recovery image only")
 	c.Flags().Bool("recovery", false, "Upgrade recovery image too")
 	c.Flags().Bool("bootloader", false, "Reinstall bootloader during the upgrade")
 	addSharedInstallUpgradeFlags(c)

--- a/docs/content/en/docs/Customizing/upgrades.md
+++ b/docs/content/en/docs/Customizing/upgrades.md
@@ -35,3 +35,18 @@ upgrade:
 ```
 
 The `system` and `recovery-system` objects define the OS image used for the main active system and the recovery system respectively. They both are fined by a `<image-spec>`.
+
+## Upgrading Recovery only
+
+The `elemental upgrade-recovery` command can be used to upgrade the Recovery system only.  
+The `upgrade` configuration can be used seamlessly between `upgrade` and `upgrade-recovery`, but for the latter only the `recovery-system` field applies:  
+
+```yaml
+# configuration used for the 'ugrade-recovery' command
+upgrade:
+  recovery-system:
+    fs: squashfs
+    uri: oci:recovery/cos
+```
+
+It is also possible to invoke it directly with: `elemental upgrade-recovery --recovery-system.uri oci:recovery/cos`

--- a/pkg/action/upgrade-recovery.go
+++ b/pkg/action/upgrade-recovery.go
@@ -131,15 +131,8 @@ func (u *UpgradeRecoveryAction) upgradeInstallStateYaml() error {
 		u.spec.State.Partitions[constants.RecoveryPartName] = recoveryPart
 	}
 
-	// Hack to ensure we are not using / or /.snapshots mountpoints. Btrfs based deployments
-	// mount state partition into multiple locations
-	statePath := filepath.Join(u.spec.Partitions.State.MountPoint, constants.InstallStateFile)
-	if u.spec.Partitions.State.MountPoint == "/" || u.spec.Partitions.State.MountPoint == "/.snapshots" {
-		statePath = filepath.Join(constants.RunningStateDir, constants.InstallStateFile)
-	}
-
 	return u.cfg.WriteInstallState(
-		u.spec.State, statePath,
+		u.spec.State, filepath.Join(u.spec.Partitions.State.MountPoint, constants.InstallStateFile),
 		filepath.Join(u.spec.Partitions.Recovery.MountPoint, constants.InstallStateFile),
 	)
 }

--- a/pkg/action/upgrade-recovery.go
+++ b/pkg/action/upgrade-recovery.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -27,6 +28,8 @@ import (
 	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
 	"github.com/rancher/elemental-toolkit/pkg/utils"
 )
+
+var ErrUpgradeRecoveryFromRecovery = errors.New("Can not upgrade recovery from recovery partition")
 
 // UpgradeRecoveryAction represents the struct that will run the recovery upgrade from start to finish
 type UpgradeRecoveryAction struct {
@@ -79,7 +82,7 @@ func (u UpgradeRecoveryAction) Error(s string, args ...interface{}) {
 
 func (u *UpgradeRecoveryAction) mountRWPartitions(cleanup *utils.CleanStack) error {
 	if elemental.IsRecoveryMode(u.cfg.Config) {
-		return fmt.Errorf("Can not upgrade recovery from recovery partition")
+		return ErrUpgradeRecoveryFromRecovery
 	}
 
 	if u.updateInstallState {

--- a/pkg/action/upgrade-recovery.go
+++ b/pkg/action/upgrade-recovery.go
@@ -174,10 +174,12 @@ func (u *UpgradeRecoveryAction) Run() (err error) {
 	}
 
 	// Update state.yaml file on recovery and state partitions
-	err = u.upgradeInstallStateYaml()
-	if err != nil {
-		u.Error("failed upgrading installation metadata")
-		return err
+	if u.updateInstallState {
+		err = u.upgradeInstallStateYaml()
+		if err != nil {
+			u.Error("failed upgrading installation metadata")
+			return err
+		}
 	}
 
 	u.Info("Recovery upgrade completed")

--- a/pkg/action/upgrade-recovery.go
+++ b/pkg/action/upgrade-recovery.go
@@ -1,0 +1,110 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/rancher/elemental-toolkit/pkg/constants"
+	"github.com/rancher/elemental-toolkit/pkg/elemental"
+	elementalError "github.com/rancher/elemental-toolkit/pkg/error"
+	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
+	"github.com/rancher/elemental-toolkit/pkg/utils"
+)
+
+// UpgradeRecoveryAction represents the struct that will run the upgrade from start to finish
+type UpgradeRecoveryAction struct {
+	cfg  *v1.RunConfig
+	spec *v1.UpgradeSpec
+}
+
+func NewUpgradeRecoveryAction(config *v1.RunConfig, spec *v1.UpgradeSpec) *UpgradeRecoveryAction {
+	return &UpgradeRecoveryAction{cfg: config, spec: spec}
+}
+
+func (u UpgradeRecoveryAction) Info(s string, args ...interface{}) {
+	u.cfg.Logger.Infof(s, args...)
+}
+
+func (u UpgradeRecoveryAction) Debug(s string, args ...interface{}) {
+	u.cfg.Logger.Debugf(s, args...)
+}
+
+func (u UpgradeRecoveryAction) Error(s string, args ...interface{}) {
+	u.cfg.Logger.Errorf(s, args...)
+}
+
+func (u *UpgradeRecoveryAction) mountRWPartitions(cleanup *utils.CleanStack) error {
+	if elemental.IsRecoveryMode(u.cfg.Config) {
+		return fmt.Errorf("Can not upgrade recovery from recovery partition")
+	}
+
+	umount, err := elemental.MountRWPartition(u.cfg.Config, u.spec.Partitions.Recovery)
+	if err != nil {
+		return elementalError.NewFromError(err, elementalError.MountRecoveryPartition)
+	}
+	cleanup.Push(umount)
+
+	return nil
+}
+
+func (u *UpgradeRecoveryAction) Run() (err error) {
+	cleanup := utils.NewCleanStack()
+	defer func() {
+		err = cleanup.Cleanup(err)
+	}()
+
+	// Mount required partitions as RW
+	err = u.mountRWPartitions(cleanup)
+	if err != nil {
+		return err
+	}
+
+	// Upgrade recovery
+	if u.spec.RecoveryUpgrade {
+		err = elemental.DeployImage(u.cfg.Config, &u.spec.RecoverySystem)
+		if err != nil {
+			u.cfg.Logger.Error("failed deploying recovery image")
+			return elementalError.NewFromError(err, elementalError.DeployImage)
+		}
+		recoveryFile := filepath.Join(u.spec.Partitions.Recovery.MountPoint, constants.RecoveryImgFile)
+		transitionFile := filepath.Join(u.spec.Partitions.Recovery.MountPoint, constants.TransitionImgFile)
+		if ok, _ := utils.Exists(u.cfg.Fs, recoveryFile); ok {
+			err = u.cfg.Fs.Remove(recoveryFile)
+			if err != nil {
+				u.Error("failed removing old recovery image")
+				return err
+			}
+		}
+		err = u.cfg.Fs.Rename(transitionFile, recoveryFile)
+		if err != nil {
+			u.Error("failed renaming transition recovery image")
+			return err
+		}
+	}
+
+	u.Info("Recovery upgrade completed")
+
+	// Do not reboot/poweroff on cleanup errors
+	err = cleanup.Cleanup(err)
+	if err != nil {
+		return elementalError.NewFromError(err, elementalError.Cleanup)
+	}
+
+	return nil
+}

--- a/pkg/action/upgrade-recovery_test.go
+++ b/pkg/action/upgrade-recovery_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/rancher/elemental-toolkit/pkg/utils"
 )
 
-var _ = Describe("Runtime Actions", func() {
+var _ = Describe("Upgrade Recovery Actions", func() {
 	var config *v1.RunConfig
 	var runner *v1mock.FakeRunner
 	var fs vfs.FS
@@ -49,7 +49,6 @@ var _ = Describe("Runtime Actions", func() {
 	var cleanup func()
 	var memLog *bytes.Buffer
 	var ghwTest v1mock.GhwMock
-	var bootloader *v1mock.FakeBootloader
 
 	BeforeEach(func() {
 		runner = v1mock.NewFakeRunner()
@@ -58,7 +57,6 @@ var _ = Describe("Runtime Actions", func() {
 		client = &v1mock.FakeHTTPClient{}
 		memLog = &bytes.Buffer{}
 		logger = v1.NewBufferLogger(memLog)
-		bootloader = &v1mock.FakeBootloader{}
 		extractor = v1mock.NewFakeImageExtractor(logger)
 		var err error
 		fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{})
@@ -80,9 +78,9 @@ var _ = Describe("Runtime Actions", func() {
 
 	AfterEach(func() { cleanup() })
 
-	Describe("Upgrade Action", Label("upgrade"), func() {
+	Describe("UpgradeRecovery Action", Label("upgrade-recovery"), func() {
 		var spec *v1.UpgradeSpec
-		var upgrade *action.UpgradeAction
+		var upgradeRecovery *action.UpgradeRecoveryAction
 		var memLog *bytes.Buffer
 
 		BeforeEach(func() {
@@ -159,139 +157,22 @@ var _ = Describe("Runtime Actions", func() {
 			AfterEach(func() {
 
 			})
-			It("Fails if some hook fails and strict is set", func() {
+			It("Fails if updateInstallState and State partition is not present", func() {
+				spec.Partitions.State = nil
+				upgradeRecovery, err = action.NewUpgradeRecoveryAction(config, spec, action.WithUpdateInstallState(true))
+				Expect(err).To(HaveOccurred())
+			})
+			It("Fails if updateInstallState and current state can not be loaded", func() {
+				spec.State = nil
+				upgradeRecovery, err = action.NewUpgradeRecoveryAction(config, spec, action.WithUpdateInstallState(true))
+				Expect(err).To(HaveOccurred())
+			})
+			It("Fails if Recovery partition is not present", func() {
 				config.Strict = true
 				cloudInit.Error = true
-				upgrade, err = action.NewUpgradeAction(config, spec, action.WithUpgradeBootloader(bootloader))
-				Expect(err).NotTo(HaveOccurred())
-				err := upgrade.Run()
+				spec.Partitions.Recovery = nil
+				upgradeRecovery, err = action.NewUpgradeRecoveryAction(config, spec)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("cloud init"))
-			})
-			It("Fails setting the grub labels", func() {
-				bootloader.ErrorSetPersistentVariables = true
-				upgrade, err = action.NewUpgradeAction(config, spec, action.WithUpgradeBootloader(bootloader))
-				Expect(err).NotTo(HaveOccurred())
-				err := upgrade.Run()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("setting persistent variables"))
-			})
-			It("Fails setting the grub default entry", func() {
-				bootloader.ErrorSetDefaultEntry = true
-				upgrade, err = action.NewUpgradeAction(config, spec, action.WithUpgradeBootloader(bootloader))
-				Expect(err).NotTo(HaveOccurred())
-				err := upgrade.Run()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("setting default entry"))
-			})
-			It("Successfully upgrades from docker image", func() {
-				Expect(v1mock.FakeLoopDeviceSnapshotsStatus(fs, constants.RunningStateDir, 2)).To(Succeed())
-				// Create installState with previous install state
-				statePath := filepath.Join(constants.RunningStateDir, constants.InstallStateFile)
-				installState := &v1.InstallState{
-					Partitions: map[string]*v1.PartitionState{
-						constants.StatePartName: {
-							FSLabel: "COS_STATE",
-							Snapshots: map[int]*v1.SystemState{
-								2: {
-									Source: v1.NewDockerSrc("some/image:v2"),
-									Digest: "somehash2",
-									Active: true,
-								},
-								1: {
-									Source: v1.NewDockerSrc("some/image:v1"),
-									Digest: "somehash",
-								},
-							},
-						},
-					},
-				}
-				err = config.WriteInstallState(installState, statePath, statePath)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				// Limit maximum snapshots to 2
-				config.Snapshotter.MaxSnaps = 2
-
-				// Create a new spec to load state yaml
-				spec, err = conf.NewUpgradeSpec(config.Config)
-
-				spec.System = v1.NewDockerSrc("alpine")
-				upgrade, err = action.NewUpgradeAction(config, spec)
-				Expect(err).NotTo(HaveOccurred())
-				err := upgrade.Run()
-				Expect(err).ToNot(HaveOccurred())
-
-				// Check that the rebrand worked with our os-release value
-				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
-
-				// Writes filesystem labels to GRUB oem env file
-				grubOEMEnv := filepath.Join(spec.Partitions.EFI.MountPoint, constants.GrubOEMEnv)
-				Expect(runner.IncludesCmds(
-					[][]string{{"grub2-editenv", grubOEMEnv, "set", "passive_snaps=2"}},
-				)).To(Succeed())
-
-				// Expect snapshot 2 and 3 to be there and 1 deleted
-				ok, _ := utils.Exists(fs, filepath.Join(constants.RunningStateDir, ".snapshots/3/snapshot.img"))
-				Expect(ok).To(BeTrue())
-				ok, _ = utils.Exists(fs, filepath.Join(constants.RunningStateDir, ".snapshots/2/snapshot.img"))
-				Expect(ok).To(BeTrue())
-				ok, _ = utils.Exists(fs, filepath.Join(constants.RunningStateDir, ".snapshots/1/snapshot.img"))
-				Expect(ok).To(BeFalse())
-
-				// An upgraded state yaml file should exist
-				state, err := config.LoadInstallState()
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(state.Partitions[constants.StatePartName].Snapshots[3].Active).
-					To(BeTrue())
-				Expect(state.Partitions[constants.StatePartName].Snapshots[2].Active).
-					To(BeFalse())
-				Expect(state.Partitions[constants.StatePartName].Snapshots[3].Digest).
-					To(Equal(v1mock.FakeDigest))
-				Expect(state.Partitions[constants.StatePartName].Snapshots[3].Source.String()).
-					To(Equal("oci://alpine:latest"))
-				Expect(state.Partitions[constants.StatePartName].Snapshots[2].Source.String()).
-					To(Equal("oci://some/image:v2"))
-				// Snapshot 1 was deleted
-				Expect(state.Partitions[constants.StatePartName].Snapshots[1]).
-					To(BeNil())
-			})
-			It("Successfully reboots after upgrade from docker image", func() {
-				Expect(v1mock.FakeLoopDeviceSnapshotsStatus(fs, constants.RunningStateDir, 1)).To(Succeed())
-				spec.System = v1.NewDockerSrc("alpine")
-				config.Reboot = true
-				upgrade, err = action.NewUpgradeAction(config, spec)
-				Expect(err).NotTo(HaveOccurred())
-				err := upgrade.Run()
-				Expect(err).ToNot(HaveOccurred())
-
-				// Check that the rebrand worked with our os-release value
-				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
-
-				// Expect snapshot 2 to be there
-				ok, _ := utils.Exists(fs, filepath.Join(constants.RunningStateDir, ".snapshots/2/snapshot.img"))
-				Expect(ok).To(BeTrue())
-
-				// Expect reboot executed
-				Expect(runner.IncludesCmds([][]string{{"reboot", "-f"}})).To(BeNil())
-			})
-			It("Successfully powers off after upgrade from docker image", func() {
-				Expect(v1mock.FakeLoopDeviceSnapshotsStatus(fs, constants.RunningStateDir, 1)).To(Succeed())
-				spec.System = v1.NewDockerSrc("alpine")
-				config.PowerOff = true
-				upgrade, err = action.NewUpgradeAction(config, spec)
-				Expect(err).NotTo(HaveOccurred())
-				err := upgrade.Run()
-				Expect(err).ToNot(HaveOccurred())
-
-				// Check that the rebrand worked with our os-release value
-				Expect(memLog).To(ContainSubstring("default_menu_entry=TESTOS"))
-
-				// Expect snapshot 2 to be there
-				ok, _ := utils.Exists(fs, filepath.Join(constants.RunningStateDir, ".snapshots/2/snapshot.img"))
-				Expect(ok).To(BeTrue())
-
-				// Expect poweroff executed
-				Expect(runner.IncludesCmds([][]string{{"poweroff", "-f"}})).To(BeNil())
 			})
 			It("Successfully upgrades recovery from docker image", Label("docker"), func() {
 				recoveryImgPath := filepath.Join(constants.LiveDir, constants.RecoveryImgFile)
@@ -306,9 +187,9 @@ var _ = Describe("Runtime Actions", func() {
 				f, _ := fs.ReadFile(recoveryImgPath)
 				Expect(f).To(ContainSubstring("recovery"))
 
-				upgrade, err = action.NewUpgradeAction(config, spec)
+				upgradeRecovery, err = action.NewUpgradeRecoveryAction(config, spec, action.WithUpdateInstallState(true))
 				Expect(err).NotTo(HaveOccurred())
-				err = upgrade.Run()
+				err = upgradeRecovery.Run()
 				Expect(err).ToNot(HaveOccurred())
 
 				// This should be the new image
@@ -323,6 +204,38 @@ var _ = Describe("Runtime Actions", func() {
 				// Transition squash should not exist
 				info, err = fs.Stat(spec.RecoverySystem.File)
 				Expect(err).To(HaveOccurred())
+
+				// Create a new spec to load state yaml
+				spec, err = conf.NewUpgradeSpec(config.Config)
+				Expect(err).NotTo(HaveOccurred())
+				// Just a small test to ensure we touched the state file
+				Expect(spec.State.Date).ToNot(BeEmpty(), "post-upgrade state should contain a date")
+			})
+			It("Successfully skips updateInstallState", Label("docker"), func() {
+				recoveryImgPath := filepath.Join(constants.LiveDir, constants.RecoveryImgFile)
+				spec := PrepareTestRecoveryImage(config, recoveryImgPath, fs, runner)
+
+				// This should be the old image
+				info, err := fs.Stat(recoveryImgPath)
+				Expect(err).ToNot(HaveOccurred())
+				// Image size should be empty
+				Expect(info.Size()).To(BeNumerically(">", 0))
+				Expect(info.IsDir()).To(BeFalse())
+				f, _ := fs.ReadFile(recoveryImgPath)
+				Expect(f).To(ContainSubstring("recovery"))
+
+				spec.Partitions.State = nil
+				spec.State = nil
+				upgradeRecovery, err = action.NewUpgradeRecoveryAction(config, spec, action.WithUpdateInstallState(false))
+				Expect(err).NotTo(HaveOccurred())
+				err = upgradeRecovery.Run()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create a new spec to load state yaml
+				spec, err = conf.NewUpgradeSpec(config.Config)
+				Expect(err).NotTo(HaveOccurred())
+				// Just a small test to ensure we touched the state file
+				Expect(spec.State.Date).To(BeEmpty(), "install state files should have not been touched")
 			})
 		})
 		Describe(fmt.Sprintf("Booting from %s", constants.RecoveryLabel), Label("recovery_label"), func() {
@@ -332,10 +245,49 @@ var _ = Describe("Runtime Actions", func() {
 			It("Fails to upgrade recovery", func() {
 				spec, err := conf.NewUpgradeSpec(config.Config)
 				Expect(err).NotTo(HaveOccurred())
-				spec.RecoveryUpgrade = true
-				_, err = action.NewUpgradeAction(config, spec)
+				_, err = action.NewUpgradeRecoveryAction(config, spec)
 				Expect(err).Should(Equal(action.ErrUpgradeRecoveryFromRecovery))
 			})
 		})
 	})
 })
+
+func PrepareTestRecoveryImage(config *v1.RunConfig, recoveryImgPath string, fs vfs.FS, runner *v1mock.FakeRunner) *v1.UpgradeSpec {
+	GinkgoHelper()
+	// Create installState with squashed recovery
+	statePath := filepath.Join(constants.RunningStateDir, constants.InstallStateFile)
+	installState := &v1.InstallState{
+		Partitions: map[string]*v1.PartitionState{
+			constants.RecoveryPartName: {
+				FSLabel: constants.RecoveryLabel,
+				RecoveryImage: &v1.SystemState{
+					Label:  constants.SystemLabel,
+					FS:     constants.SquashFs,
+					Source: v1.NewDirSrc("/some/dir"),
+				},
+			},
+		},
+	}
+	Expect(config.WriteInstallState(installState, statePath, statePath)).ShouldNot(HaveOccurred())
+
+	Expect(fs.WriteFile(recoveryImgPath, []byte("recovery"), constants.FilePerm)).ShouldNot(HaveOccurred())
+
+	spec, err := conf.NewUpgradeSpec(config.Config)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	spec.System = v1.NewDockerSrc("alpine")
+	spec.RecoveryUpgrade = true
+	spec.RecoverySystem.Source = spec.System
+	spec.RecoverySystem.Size = 16
+
+	runner.SideEffect = func(command string, args ...string) ([]byte, error) {
+		if command == "mksquashfs" && args[1] == spec.RecoverySystem.File {
+			// create the transition img for squash to fake it
+			_, _ = fs.Create(spec.RecoverySystem.File)
+		}
+		return []byte{}, nil
+	}
+	config.Runner = runner
+
+	return spec
+}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -211,11 +211,19 @@ func (u *UpgradeAction) mountRWPartitions(cleanup *utils.CleanStack) error {
 	}
 	cleanup.Push(umount)
 
-	umount, err = elemental.MountRWPartition(u.cfg.Config, u.spec.Partitions.State)
-	if err != nil {
-		return elementalError.NewFromError(err, elementalError.MountStatePartition)
+	if !elemental.IsRecoveryMode(u.cfg.Config) {
+		umount, err = elemental.MountRWPartition(u.cfg.Config, u.spec.Partitions.Recovery)
+		if err != nil {
+			return elementalError.NewFromError(err, elementalError.MountRecoveryPartition)
+		}
+		cleanup.Push(umount)
+	} else {
+		umount, err = elemental.MountRWPartition(u.cfg.Config, u.spec.Partitions.State)
+		if err != nil {
+			return elementalError.NewFromError(err, elementalError.MountStatePartition)
+		}
+		cleanup.Push(umount)
 	}
-	cleanup.Push(umount)
 
 	if u.spec.Partitions.Persistent != nil {
 		umount, err = elemental.MountRWPartition(u.cfg.Config, u.spec.Partitions.Persistent)
@@ -224,12 +232,6 @@ func (u *UpgradeAction) mountRWPartitions(cleanup *utils.CleanStack) error {
 		}
 		cleanup.Push(umount)
 	}
-
-	umount, err = elemental.MountRWPartition(u.cfg.Config, u.spec.Partitions.Recovery)
-	if err != nil {
-		return elementalError.NewFromError(err, elementalError.MountRecoveryPartition)
-	}
-	cleanup.Push(umount)
 
 	return nil
 }

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -242,6 +242,7 @@ func (u *UpgradeAction) Run() (err error) {
 
 	// Only upgrade recovery
 	if u.spec.RecoveryOnlyUpgrade {
+		u.cfg.Logger.Info("Upgrading Recovery only")
 		upgradeRecoveryAction := NewUpgradeRecoveryAction(u.cfg, u.spec)
 		if err := upgradeRecoveryAction.Run(); err != nil {
 			u.Error("Upgrading Recovery: %s", err)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -82,7 +82,7 @@ func NewUpgradeAction(config *v1.RunConfig, spec *v1.UpgradeSpec, opts ...Upgrad
 
 	if u.spec.RecoveryUpgrade && elemental.IsRecoveryMode(config.Config) {
 		config.Logger.Errorf("Upgrading recovery image from the recovery system itself is not supported")
-		return nil, fmt.Errorf("not supported")
+		return nil, ErrUpgradeRecoveryFromRecovery
 	}
 
 	return u, nil

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -225,6 +225,12 @@ func (u *UpgradeAction) mountRWPartitions(cleanup *utils.CleanStack) error {
 		cleanup.Push(umount)
 	}
 
+	umount, err = elemental.MountRWPartition(u.cfg.Config, u.spec.Partitions.Recovery)
+	if err != nil {
+		return elementalError.NewFromError(err, elementalError.MountRecoveryPartition)
+	}
+	cleanup.Push(umount)
+
 	return nil
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -333,15 +333,9 @@ func GetResetKeyEnvMap() map[string]string {
 // GetUpgradeKeyEnvMap returns environment variable bindings to UpgradeSpec data
 func GetUpgradeKeyEnvMap() map[string]string {
 	return map[string]string{
-<<<<<<< HEAD
 		"recovery":            "RECOVERY",
 		"system":              "SYSTEM",
 		"recovery-system.uri": "RECOVERY_SYSTEM",
-=======
-		"recovery":        "RECOVERY",
-		"system":          "SYSTEM",
-		"recovery-system": "RECOVERY_SYSTEM",
->>>>>>> 49451b499 (Implement to upgrade-recovery separate command)
 	}
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -333,9 +333,22 @@ func GetResetKeyEnvMap() map[string]string {
 // GetUpgradeKeyEnvMap returns environment variable bindings to UpgradeSpec data
 func GetUpgradeKeyEnvMap() map[string]string {
 	return map[string]string{
+<<<<<<< HEAD
 		"recovery":            "RECOVERY",
 		"system":              "SYSTEM",
 		"recovery-system.uri": "RECOVERY_SYSTEM",
+=======
+		"recovery":        "RECOVERY",
+		"system":          "SYSTEM",
+		"recovery-system": "RECOVERY_SYSTEM",
+>>>>>>> 49451b499 (Implement to upgrade-recovery separate command)
+	}
+}
+
+// GetUpgradeRecoveryKeyEnvMap returns environment variable bindings to UpgradeSpec data
+func GetUpgradeRecoveryKeyEnvMap() map[string]string {
+	return map[string]string{
+		"recovery-system": "RECOVERY_SYSTEM",
 	}
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -339,13 +339,6 @@ func GetUpgradeKeyEnvMap() map[string]string {
 	}
 }
 
-// GetUpgradeRecoveryKeyEnvMap returns environment variable bindings to UpgradeSpec data
-func GetUpgradeRecoveryKeyEnvMap() map[string]string {
-	return map[string]string{
-		"recovery-system.uri": "RECOVERY_SYSTEM",
-	}
-}
-
 // GetBuildKeyEnvMap returns environment variable bindings to BuildConfig data
 func GetBuildKeyEnvMap() map[string]string {
 	return map[string]string{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -342,7 +342,7 @@ func GetUpgradeKeyEnvMap() map[string]string {
 // GetUpgradeRecoveryKeyEnvMap returns environment variable bindings to UpgradeSpec data
 func GetUpgradeRecoveryKeyEnvMap() map[string]string {
 	return map[string]string{
-		"recovery-system": "RECOVERY_SYSTEM",
+		"recovery-system.uri": "RECOVERY_SYSTEM",
 	}
 }
 

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -193,6 +193,7 @@ func IsRWMountPoint(c v1.Config, mountPoint string) (bool, error) {
 func MountRWPartition(c v1.Config, part *v1.Partition) (umount func() error, err error) {
 	if mnt, _ := IsMounted(c, part); mnt {
 		if ok, _ := IsRWMountPoint(c, part.MountPoint); ok {
+			c.Logger.Debugf("Already RW mounted: %s at %s", part.Name, part.MountPoint)
 			return func() error { return nil }, nil
 		}
 		err = MountPartition(c, part, "remount", "rw")

--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -259,5 +259,8 @@ const MountEFIPartition = 86
 // Error mounting Persistent partition
 const MountPersistentPartition = 87
 
+// Error upgrading Recovery partition
+const UpgradeRecovery = 88
+
 // Unknown error
 const Unknown int = 255

--- a/pkg/snapshotter/btrfs.go
+++ b/pkg/snapshotter/btrfs.go
@@ -439,7 +439,7 @@ func (b *Btrfs) SnapshotToImageSource(snap *v1.Snapshot) (*v1.ImageSource, error
 func (b *Btrfs) getSubvolumes(rootDir string) (btrfsSubvolList, error) {
 	out, err := b.cfg.Runner.Run("btrfs", "subvolume", "list", "--sort=path", rootDir)
 	if err != nil {
-		b.cfg.Logger.Errorf("falied listing btrfs subvolumes: %s", err.Error())
+		b.cfg.Logger.Errorf("failed listing btrfs subvolumes: %s", err.Error())
 		return nil, err
 	}
 	return b.parseVolumes(strings.TrimSpace(string(out))), nil
@@ -448,7 +448,7 @@ func (b *Btrfs) getSubvolumes(rootDir string) (btrfsSubvolList, error) {
 func (b *Btrfs) getActiveSnapshot() (int, error) {
 	out, err := b.cfg.Runner.Run("btrfs", "subvolume", "get-default", b.rootDir)
 	if err != nil {
-		b.cfg.Logger.Errorf("falied listing btrfs subvolumes: %s", err.Error())
+		b.cfg.Logger.Errorf("failed listing btrfs subvolumes: %s", err.Error())
 		return 0, err
 	}
 	re := regexp.MustCompile(snapshotPathRegex)

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -359,13 +359,14 @@ func (r *ResetSpec) Sanitize() error {
 }
 
 type UpgradeSpec struct {
-	RecoveryUpgrade   bool         `yaml:"recovery,omitempty" mapstructure:"recovery"`
-	System            *ImageSource `yaml:"system,omitempty" mapstructure:"system"`
-	RecoverySystem    Image        `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
-	GrubDefEntry      string       `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
-	BootloaderUpgrade bool         `yaml:"bootloader,omitempty" mapstructure:"bootloader"`
-	Partitions        ElementalPartitions
-	State             *InstallState
+	RecoveryOnlyUpgrade bool         `yaml:"recovery-only,omitempty" mapstructure:"recovery"`
+	RecoveryUpgrade     bool         `yaml:"recovery,omitempty" mapstructure:"recovery"`
+	System              *ImageSource `yaml:"system,omitempty" mapstructure:"system"`
+	RecoverySystem      Image        `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
+	GrubDefEntry        string       `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
+	BootloaderUpgrade   bool         `yaml:"bootloader,omitempty" mapstructure:"bootloader"`
+	Partitions          ElementalPartitions
+	State               *InstallState
 }
 
 // Sanitize checks the consistency of the struct, returns error

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -379,7 +379,7 @@ func (u *UpgradeSpec) Sanitize() error {
 		return fmt.Errorf("undefined upgrade source")
 	}
 
-	if u.RecoveryUpgrade {
+	if u.RecoveryUpgrade || u.RecoveryOnlyUpgrade {
 		if u.Partitions.Recovery == nil || u.Partitions.Recovery.MountPoint == "" {
 			return fmt.Errorf("undefined recovery partition")
 		}

--- a/pkg/types/v1/config.go
+++ b/pkg/types/v1/config.go
@@ -359,7 +359,7 @@ func (r *ResetSpec) Sanitize() error {
 }
 
 type UpgradeSpec struct {
-	RecoveryOnlyUpgrade bool         `yaml:"recovery-only,omitempty" mapstructure:"recovery"`
+	RecoveryOnlyUpgrade bool         `yaml:"recovery-only,omitempty" mapstructure:"recovery-only"`
 	RecoveryUpgrade     bool         `yaml:"recovery,omitempty" mapstructure:"recovery"`
 	System              *ImageSource `yaml:"system,omitempty" mapstructure:"system"`
 	RecoverySystem      Image        `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`


### PR DESCRIPTION
> A different take of https://github.com/rancher/elemental-toolkit/pull/1966
> 
> This PR does not actually introduce a new `upgrade-recovery` subcommand, but instead just adds a `--recovery-only` `upgrade` subcommand argument.

Scratch the above.
This is now something in the middle.

`elemental upgrade-recovery --recovery-system.uri <imgRef>` is the final choice.  

`elemental upgrade --recovery` can still be used as usual to upgrade both recovery and system at the same time.

The `upgrade-recovery` subcommand shares the `UpgradeSpec` with `upgrade` to reuse the same configuration/initialization logic, but filters it at a command level.
Only `--recovery-system` probably makes sense here, most of other flags should be disabled.