### PR TITLE
Keep previous behavior for persistent binded paths

### DIFF
--- a/pkg/action/mount.go
+++ b/pkg/action/mount.go
@@ -225,17 +225,14 @@ func MountBindPath(cfg *v1.RunConfig, sysroot, overlayDir, path string) error {
 	pathName := strings.ReplaceAll(trimmed, "/", "-") + ".bind"
 	stateDir := fmt.Sprintf("%s/%s", overlayDir, pathName)
 
-	// Only sync data once, otherwise it could modify persistent data from a previous boot
-	if ok, _ := utils.Exists(cfg.Fs, stateDir); !ok {
-		if err := utils.MkdirAll(cfg.Fs, stateDir, constants.DirPerm); err != nil {
-			cfg.Logger.Errorf("Error creating upperdir %s: %s", stateDir, err.Error())
-			return err
-		}
+	if err := utils.MkdirAll(cfg.Fs, stateDir, constants.DirPerm); err != nil {
+		cfg.Logger.Errorf("Error creating upperdir %s: %s", stateDir, err.Error())
+		return err
+	}
 
-		if err := utils.SyncData(cfg.Logger, cfg.Runner, cfg.Fs, base, stateDir); err != nil {
-			cfg.Logger.Errorf("Error shuffling data: %s", err.Error())
-			return err
-		}
+	if err := utils.SyncData(cfg.Logger, cfg.Runner, cfg.Fs, base, stateDir); err != nil {
+		cfg.Logger.Errorf("Error shuffling data: %s", err.Error())
+		return err
 	}
 
 	if err := cfg.Mounter.Mount(stateDir, base, "none", []string{"defaults", "bind"}); err != nil {

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -497,7 +497,7 @@ func DumpSource(c v1.Config, target string, imgSrc *v1.ImageSource) error { // n
 		imgSrc.SetDigest(digest)
 	} else if imgSrc.IsDir() {
 		excludes := cnst.GetDefaultSystemExcludes()
-		err = utils.SyncData(c.Logger, c.Runner, c.Fs, imgSrc.Value(), target, excludes...)
+		err = utils.MirrorData(c.Logger, c.Runner, c.Fs, imgSrc.Value(), target, excludes...)
 		if err != nil {
 			return err
 		}
@@ -512,7 +512,7 @@ func DumpSource(c v1.Config, target string, imgSrc *v1.ImageSource) error { // n
 			return err
 		}
 		defer UnmountFileSystemImage(c, img) // nolint:errcheck
-		err = utils.SyncData(c.Logger, c.Runner, c.Fs, cnst.ImgSrcDir, target)
+		err = utils.MirrorData(c.Logger, c.Runner, c.Fs, cnst.ImgSrcDir, target)
 		if err != nil {
 			return err
 		}

--- a/pkg/snapshotter/btrfs.go
+++ b/pkg/snapshotter/btrfs.go
@@ -299,7 +299,7 @@ func (b *Btrfs) CloseTransaction(snapshot *v1.Snapshot) (err error) {
 	}
 
 	if !b.installing {
-		err = utils.SyncData(b.cfg.Logger, b.cfg.Runner, b.cfg.Fs, snapshot.WorkDir, snapshot.Path)
+		err = utils.MirrorData(b.cfg.Logger, b.cfg.Runner, b.cfg.Fs, snapshot.WorkDir, snapshot.Path)
 		if err != nil {
 			b.cfg.Logger.Errorf("failed syncing working directory with snapshot directory")
 			return err


### PR DESCRIPTION
With this patch the current (stable release) behavior of binded persistent paths is kept.

This commit adds a new rsync wrapper method (`MirrorData`) which includes the `--delete` flag. Named mirror because it actually causes the target and source to have the same exact data causing the deletion of any file already present in _target_ that is not present in _source_. This is the behavior we want when dumping the image root-tree to a new snapshot.

Current behavior updates at early boot all files in a given path from the image to the persisted path. This includes a couple of non obvious behaviors:

* Reverts changes done in files that were originally part of the image on every boot.
* Files included in path configured as persistent that are present in image A but not present in image B and kept in the persistent storage when upgrading from A to B.

Fixes #1982 