### PR TITLE
fix broken link in docs

### DIFF
--- a/docs/content/en/docs/Creating derivatives/build_iso.md
+++ b/docs/content/en/docs/Creating derivatives/build_iso.md
@@ -34,7 +34,7 @@ date: true
 
 ## What's next?
 
-- Check out on how to [build an image](build_disk) from the ISO we have just created
+- Check out on how to [build an image](../build_disk) from the ISO we have just created
 
 ## Syntax
 


### PR DESCRIPTION
This fixes a broken link here: https://rancher.github.io/elemental-toolkit/docs/creating-derivatives/build_iso/#whats-next