### PR TITLE
Do not migrate legacy images if snapshots are already present

### DIFF
--- a/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
+++ b/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
@@ -63,8 +63,8 @@ function set_volume {
     set btrfs_relative_path="y"
     set volume="${root}"
     if [ -n "${1}" ]; then
-      set img=${1}
-      btrfs-mount-subvol ($root) / @/.snapshots/${1}/snapshot
+      set img=@/.snapshots/${1}/snapshot
+      btrfs-mount-subvol ($root) / ${img}
     fi
   elif [ -z "${1}" ]; then
     set_loopdevice /.snapshots/active

--- a/pkg/snapshotter/loopdevice.go
+++ b/pkg/snapshotter/loopdevice.go
@@ -543,6 +543,10 @@ func (l *LoopDevice) legacyImageToSnapsot(image string) error {
 			l.cfg.Logger.Errorf("failed setting the snaphsot ID for legacy images: %v", err)
 			return err
 		}
+		if id > 1 {
+			l.cfg.Logger.Debugf("Skipping legacy image migration, there are already snapshots in the system")
+			return nil
+		}
 		l.cfg.Logger.Debugf("Migrating image %s to snapshot %d", image, id)
 
 		snapPath := filepath.Join(l.rootDir, loopDeviceSnapsPath, strconv.FormatInt(int64(id), 10))

--- a/pkg/snapshotter/loopdevice.go
+++ b/pkg/snapshotter/loopdevice.go
@@ -544,7 +544,7 @@ func (l *LoopDevice) legacyImageToSnapsot(image string) error {
 			return err
 		}
 		if id > 1 {
-			l.cfg.Logger.Debugf("Skipping legacy image migration, there are already snapshots in the system")
+			l.cfg.Logger.Debugf("Skipping legacy image migration, some snapshot already found in the system")
 			return nil
 		}
 		l.cfg.Logger.Debugf("Migrating image %s to snapshot %d", image, id)


### PR DESCRIPTION
This commit prevents executing the legacy images migration logic if snapshotter already finds available snapshots. This mostly means the migration was already executed and legacy images had already a chance to be converted into snapshots.