### PR TITLE
Update v2 linker args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ ARG TARGETARCH
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go generate ./...
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     -ldflags "-w -s \
-    -X github.com/rancher/elemental-toolkit/internal/version.version=${ELEMENTAL_VERSION} \
-    -X github.com/rancher/elemental-toolkit/internal/version.gitCommit=${ELEMENTAL_COMMIT}" \
+    -X github.com/rancher/elemental-toolkit/v2/internal/version.version=${ELEMENTAL_VERSION} \
+    -X github.com/rancher/elemental-toolkit/v2/internal/version.gitCommit=${ELEMENTAL_COMMIT}" \
     -o /usr/bin/elemental
 
 FROM ${BASE_OS_IMAGE}:${BASE_OS_VERSION} AS elemental-toolkit

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ VERSION?=$(GIT_TAG)-g$(GIT_COMMIT_SHORT)
 
 PKG:=./cmd ./pkg/...
 LDFLAGS:=-w -s
-LDFLAGS+=-X "github.com/rancher/elemental-toolkit/internal/version.version=$(GIT_TAG)"
-LDFLAGS+=-X "github.com/rancher/elemental-toolkit/internal/version.gitCommit=$(GIT_COMMIT)"
+LDFLAGS+=-X "github.com/rancher/elemental-toolkit/v2/internal/version.version=$(GIT_TAG)"
+LDFLAGS+=-X "github.com/rancher/elemental-toolkit/v2/internal/version.gitCommit=$(GIT_COMMIT)"
 
 # For RISC-V 64bit support
 ifeq ($(PLATFORM),linux/riscv64)


### PR DESCRIPTION
This makes the 'elemental version' command work as expected again.