### PR TITLE
Extract recovery kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ build-iso:
 	mkdir -p $(ROOT_DIR)/build
 	$(DOCKER) run --rm -v $(DOCKER_SOCK):$(DOCKER_SOCK) -v $(ROOT_DIR)/build:/build \
 		--entrypoint /usr/bin/elemental $(TOOLKIT_REPO):$(VERSION) --debug build-iso --bootloader-in-rootfs -n elemental-$(FLAVOR).$(ARCH) \
-		--local --platform $(PLATFORM) --squash-no-compression -o /build $(REPO):$(VERSION)
+		--local --platform $(PLATFORM) -o /build $(REPO):$(VERSION)
 
 .PHONY: build-disk
 build-disk:
@@ -99,7 +99,7 @@ build-disk:
 	$(DOCKER) run --rm -v $(DOCKER_SOCK):$(DOCKER_SOCK) -v $(ROOT_DIR)/build:/build \
 		--entrypoint /usr/bin/elemental \
 		$(TOOLKIT_REPO):$(VERSION) --debug build-disk --platform $(PLATFORM) --expandable -n elemental-$(FLAVOR).$(ARCH) --local \
-		--squash-no-compression -o /build --system $(REPO):$(VERSION)
+		-o /build --system $(REPO):$(VERSION)
 	qemu-img convert -O qcow2 $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).raw $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).qcow2
 	qemu-img resize $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).qcow2 $(DISKSIZE) 
 

--- a/cmd/upgrade-recovery.go
+++ b/cmd/upgrade-recovery.go
@@ -78,6 +78,8 @@ func NewUpgradeRecoveryCmd(root *cobra.Command, addCheckRoot bool) *cobra.Comman
 	}
 	root.AddCommand(c)
 	addRecoverySystemFlag(c)
+	addPowerFlags(c)
+	addSquashFsCompressionFlags(c)
 	return c
 }
 

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Build Actions", func() {
 			Expect(buildDisk.BuildDiskRun()).To(Succeed())
 
 			Expect(runner.MatchMilestones([][]string{
-				{"mkfs.ext2", "-L", "COS_SYSTEM", "/tmp/test/build/recovery/recovery.img"},
+				{"mksquashfs", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/recovery.img"},
 				{"mkfs.ext4", "-L", "COS_STATE"},
 				{"losetup", "--show", "-f", "/tmp/test/build/state.part"},
 				{"mkfs.vfat", "-n", "COS_GRUB"},
@@ -247,7 +247,7 @@ var _ = Describe("Build Actions", func() {
 			Expect(buildDisk.BuildDiskRun()).To(Succeed())
 
 			Expect(runner.MatchMilestones([][]string{
-				{"mkfs.ext2", "-L", "COS_SYSTEM", "-d", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/recovery.img"},
+				{"mksquashfs", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/recovery.img"},
 				{"mkfs.vfat", "-n", "COS_GRUB"},
 				{"mkfs.ext4", "-L", "COS_OEM"},
 				{"mkfs.ext4", "-L", "COS_RECOVERY"},
@@ -266,7 +266,7 @@ var _ = Describe("Build Actions", func() {
 			Expect(buildDisk.BuildDiskRun()).NotTo(Succeed())
 
 			Expect(runner.MatchMilestones([][]string{
-				{"mkfs.ext2", "-L", "COS_SYSTEM", "-d", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/recovery.img"},
+				{"mksquashfs", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/recovery.img"},
 			})).To(Succeed())
 
 			// failed before preparing partitions images

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -162,7 +162,6 @@ var _ = Describe("Install action tests", func() {
 			Expect(utils.MkdirAll(fs, "/run/elemental/recovery/recovery.imgTree/boot", constants.DirPerm)).To(Succeed())
 			Expect(utils.MkdirAll(fs, "/run/elemental/recovery/recovery.imgTree/lib/modules/6.7", constants.DirPerm)).To(Succeed())
 			_, err = fs.Create("/run/elemental/recovery/recovery.imgTree/boot/vmlinuz-6.7")
-			_, err = fs.Create("/run/elemental/recovery/recovery.imgTree/boot/vmlinuz-6.7")
 			Expect(err).To(Succeed())
 			_, err = fs.Create("/run/elemental/recovery/recovery.imgTree/boot/elemental.initrd-6.7")
 			Expect(err).To(Succeed())

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -146,6 +146,7 @@ var _ = Describe("Install action tests", func() {
 					return []byte{}, nil
 				}
 			}
+
 			// Need to create the IsoBaseTree, like if we are booting from iso
 			Expect(utils.MkdirAll(fs, constants.ISOBaseTree, constants.DirPerm)).To(Succeed())
 
@@ -155,9 +156,18 @@ var _ = Describe("Install action tests", func() {
 			loopCfg.Size = 16
 			Expect(spec.System.Value()).To(Equal(constants.ISOBaseTree))
 			Expect(spec.System.IsDir()).To(BeTrue())
-			Expect(spec.RecoverySystem.Source.Value()).To(Equal(constants.ISOBaseTree))
-			//spec.System = types.NewDockerSrc("fake/image:tag")
 
+			// Create minimal recovery system source
+			spec.RecoverySystem.Source = types.NewDirSrc("/run/elemental/recovery/recovery.imgTree")
+			Expect(utils.MkdirAll(fs, "/run/elemental/recovery/recovery.imgTree/boot", constants.DirPerm)).To(Succeed())
+			Expect(utils.MkdirAll(fs, "/run/elemental/recovery/recovery.imgTree/lib/modules/6.7", constants.DirPerm)).To(Succeed())
+			_, err = fs.Create("/run/elemental/recovery/recovery.imgTree/boot/vmlinuz-6.7")
+			_, err = fs.Create("/run/elemental/recovery/recovery.imgTree/boot/vmlinuz-6.7")
+			Expect(err).To(Succeed())
+			_, err = fs.Create("/run/elemental/recovery/recovery.imgTree/boot/elemental.initrd-6.7")
+			Expect(err).To(Succeed())
+
+			// Write grub config
 			grubCfg := filepath.Join(constants.WorkingImgDir, constants.GrubCfgPath, constants.GrubCfg)
 			Expect(utils.MkdirAll(fs, filepath.Dir(grubCfg), constants.DirPerm)).To(Succeed())
 			_, err = fs.Create(grubCfg)

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -295,7 +295,7 @@ var _ = Describe("Runtime Actions", func() {
 			})
 			It("Successfully upgrades recovery from docker image", Label("docker"), func() {
 				recoveryImgPath := filepath.Join(constants.LiveDir, constants.RecoveryImgFile)
-				spec := PrepareTestRecoveryImage(config, recoveryImgPath, fs, runner)
+				spec := PrepareTestRecoveryImage(config, constants.LiveDir, fs, runner)
 
 				// This should be the old image
 				info, err := fs.Stat(recoveryImgPath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -193,8 +193,7 @@ func NewInstallSpec(cfg types.Config) *types.InstallSpec {
 	}
 
 	recoverySystem.Source = system
-	recoverySystem.FS = constants.LinuxImgFs
-	recoverySystem.Label = constants.SystemLabel
+	recoverySystem.FS = constants.SquashFs
 	recoverySystem.File = filepath.Join(constants.RecoveryDir, constants.RecoveryImgFile)
 	recoverySystem.MountPoint = constants.TransitionDir
 
@@ -516,8 +515,7 @@ func NewDisk(cfg *types.BuildConfig) *types.DiskSpec {
 
 	recoveryImg.Size = constants.ImgSize
 	recoveryImg.File = filepath.Join(workdir, constants.RecoveryPartName, constants.RecoveryImgFile)
-	recoveryImg.FS = constants.LinuxImgFs
-	recoveryImg.Label = constants.SystemLabel
+	recoveryImg.FS = constants.SquashFs
 	recoveryImg.Source = types.NewEmptySrc()
 	recoveryImg.MountPoint = filepath.Join(
 		workdir, strings.TrimSuffix(

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -82,6 +82,7 @@ const (
 	EfiImgArm64            = "bootaa64.efi"
 	EfiImgRiscv64          = "bootriscv64.efi"
 	GrubCfg                = "grub.cfg"
+	BootargsCfg            = "bootargs.cfg"
 	GrubCfgPath            = "/etc/elemental"
 	GrubOEMEnv             = "grub_oem_env"
 	GrubEnv                = "grubenv"

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -520,7 +520,7 @@ func DeployRecoverySystem(cfg types.Config, img *types.Image, bootDir string) er
 	for _, file := range []string{
 		kernel,
 		initrd,
-		"/etc/elemental/bootargs.conf",
+		filepath.Join(transientTree, cnst.GrubCfgPath, cnst.BootargsCfg),
 	} {
 		if exist, _ := utils.Exists(cfg.Fs, file); exist {
 			cfg.Logger.Debugf("Copying file %s to root tree", file)

--- a/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
+++ b/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
@@ -110,8 +110,7 @@ menuentry "${display_name} recovery" --id recovery {
     set img=/cOS/recovery.img
   fi
 
-  set_loopdevice ${img}
-  source_bootargs
-  linux (${volume})${kernel} ${kernelcmd} ${extra_cmdline} ${extra_recovery_cmdline}
-  initrd (${volume})${initramfs}
+  source (${root})/boot/bootargs.cfg
+  linux (${root})${kernel} ${kernelcmd} ${extra_cmdline} ${extra_recovery_cmdline}
+  initrd (${root})${initramfs}
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -448,7 +448,7 @@ func FindFile(vfs types.FS, rootDir string, patterns ...string) (string, error) 
 		}
 	}
 	if found == "" {
-		return "", fmt.Errorf("failed to find binary matching %v", patterns)
+		return "", fmt.Errorf("failed to find binary matching %v in %v", patterns, rootDir)
 	}
 	return found, nil
 }


### PR DESCRIPTION
This PR refactors the deployment of the recovery-system in our different code-branches according to the [ADR](https://github.com/rancher/elemental-toolkit/wiki/ADRs#0001-extract-recovery-kernel).

 - [x] build-iso
 - [x] build-disk
 - [x] install
 - [x] upgrade-recovery

Fixes #1864 #1930 