### PR TITLE
Skip symlink if kernel already exists

### DIFF
--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -549,6 +549,11 @@ func DeployRecoverySystem(cfg types.Config, img *types.Image, bootDir string) er
 		"linux":   kernel,
 		"initrd":  initrd,
 	} {
+		// if kernel/initrd is actually named "vmlinuz"/"initrd" we just skip the symlink part.
+		if kernel == name || initrd == name {
+			continue
+		}
+
 		source := filepath.Join(bootDir, name)
 		if exist, _ := utils.Exists(cfg.Fs, source, true); exist {
 			cfg.Logger.Debugf("Removing old symlink %s", source)


### PR DESCRIPTION
If kernel or initrd is named the default vmlinuz/initrd we skip the symlinking since the booting will work anyways.