### PR TITLE
Backwards compatible recovery boot configuration

### DIFF
--- a/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
+++ b/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
@@ -112,11 +112,16 @@ menuentry "${display_name} recovery" --id recovery {
 
   # Check the presence of the image and fallback to legacy path if not present
   set img=/recovery.img
-  if [ ! -f "${img}" ]; then
+  if [ -f "${img}" ]; then
+    source (${root})/boot/bootargs.cfg
+    linux (${root})${kernel} ${kernelcmd} ${extra_cmdline} ${extra_recovery_cmdline}
+    initrd (${root})${initramfs}
+  else
+    # Boot using legacy recovery system, everything is included in the loopback image.
     set img=/cOS/recovery.img
+    set_loopdevice ${img}
+    source_bootargs
+    linux (${volume})${kernel} ${kernelcmd} ${extra_cmdline} ${extra_recovery_cmdline}
+    initrd (${volume})${initramfs}
   fi
-
-  source (${root})/boot/bootargs.cfg
-  linux (${root})${kernel} ${kernelcmd} ${extra_cmdline} ${extra_recovery_cmdline}
-  initrd (${root})${initramfs}
 }


### PR DESCRIPTION
The recovery system has been changed to extract the kernel/initrd and bootargs.cfg in order to not rely on loopback devices.

This commit adds backwards compatibility to the grub configuration in case we have upgraded the bootloader but not the recovery system on a host.