### PR TITLE
Snapshottable recovery system

### DIFF
--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -125,7 +125,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			}
 
 			buildISO := action.NewBuildISOAction(cfg, spec)
-			return buildISO.ISORun()
+			return buildISO.Run()
 		},
 	}
 

--- a/pkg/action/build-disk.go
+++ b/pkg/action/build-disk.go
@@ -237,16 +237,9 @@ func (b *BuildDiskAction) BuildDiskRun() (err error) { //nolint:gocyclo
 		return elementalError.NewFromError(err, elementalError.HookAfterDisk)
 	}
 
-	// Create recovery image
-	bootDir := filepath.Join(b.roots[constants.RecoveryPartName], "boot")
-	if err = utils.MkdirAll(b.cfg.Fs, bootDir, constants.DirPerm); err != nil {
-		b.cfg.Logger.Errorf("failed creating recovery boot dir: %v", err)
-		return err
-	}
-
 	tmpSrc := b.spec.RecoverySystem.Source
 	b.spec.RecoverySystem.Source = types.NewDirSrc(recRoot)
-	err = elemental.DeployRecoverySystem(b.cfg.Config, &b.spec.RecoverySystem, bootDir)
+	err = elemental.DeployRecoverySystem(b.cfg.Config, &b.spec.RecoverySystem)
 	if err != nil {
 		b.cfg.Logger.Errorf("failed deploying recovery system: %v", err)
 		return err

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -41,7 +41,7 @@ func grubCfgTemplate(arch string) string {
 
 	menuentry "%s" --class os --unrestricted {
 		echo Loading kernel...
-		linux ($root)` + constants.ISOKernelPath(arch) + ` cdroot root=live:CDLABEL=%s rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 elemental.disable elemental.setup=` + constants.ISOCloudInitPath + `
+		linux ($root)` + constants.ISOKernelPath(arch) + ` cdroot root=live:CDLABEL=%s rd.live.dir=` + constants.ISOLoaderPath(arch) + `  rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 elemental.disable elemental.setup=` + constants.ISOCloudInitPath + `
 		echo Loading initrd...
 		initrd ($root)` + constants.ISOInitrdPath(arch) + `
 	}
@@ -78,8 +78,8 @@ func NewBuildISOAction(cfg *types.BuildConfig, spec *types.LiveISO, opts ...Buil
 	return b
 }
 
-// BuildISORun will install the system from a given configuration
-func (b *BuildISOAction) ISORun() error {
+// Run will install the system from a given configuration
+func (b *BuildISOAction) Run() error {
 	cleanup := utils.NewCleanStack()
 	var err error
 	defer func() { err = cleanup.Cleanup(err) }()
@@ -170,11 +170,11 @@ func (b *BuildISOAction) ISORun() error {
 
 	image := &types.Image{
 		Source: types.NewDirSrc(rootDir),
-		File:   filepath.Join(isoDir, constants.ISORootFile),
+		File:   filepath.Join(bootDir, constants.ISORootFile),
 		FS:     constants.SquashFs,
 	}
 
-	err = elemental.DeployRecoverySystem(b.cfg.Config, image, bootDir)
+	err = elemental.DeployRecoverySystem(b.cfg.Config, image)
 	if err != nil {
 		b.cfg.Logger.Errorf("Failed preparing ISO's root tree: %v", err)
 		return err

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Build Actions", func() {
 			}
 
 			buildISO := action.NewBuildISOAction(cfg, iso, action.WithLiveBootloader(bootloader))
-			err := buildISO.ISORun()
+			err := buildISO.Run()
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -138,7 +138,7 @@ var _ = Describe("Build Actions", func() {
 			iso.RootFS = append(iso.RootFS, rootSrc)
 
 			buildISO := action.NewBuildISOAction(cfg, iso, action.WithLiveBootloader(bootloader))
-			err := buildISO.ISORun()
+			err := buildISO.Run()
 			Expect(err).Should(HaveOccurred())
 		})
 		It("Fails on prepare ISO", func() {
@@ -148,7 +148,7 @@ var _ = Describe("Build Actions", func() {
 			iso.RootFS = append(iso.RootFS, rootSrc)
 
 			buildISO := action.NewBuildISOAction(cfg, iso, action.WithLiveBootloader(bootloader))
-			err := buildISO.ISORun()
+			err := buildISO.Run()
 
 			Expect(err).Should(HaveOccurred())
 		})
@@ -161,14 +161,14 @@ var _ = Describe("Build Actions", func() {
 
 			By("fails without kernel")
 			buildISO := action.NewBuildISOAction(cfg, iso, action.WithLiveBootloader(bootloader))
-			err = buildISO.ISORun()
+			err = buildISO.Run()
 			Expect(err).Should(HaveOccurred())
 
 			By("fails without initrd")
 			_, err = fs.Create("/local/dir/boot/vmlinuz")
 			Expect(err).ShouldNot(HaveOccurred())
 			buildISO = action.NewBuildISOAction(cfg, iso, action.WithLiveBootloader(bootloader))
-			err = buildISO.ISORun()
+			err = buildISO.Run()
 			Expect(err).Should(HaveOccurred())
 		})
 		It("Fails installing uefi sources", func() {
@@ -178,7 +178,7 @@ var _ = Describe("Build Actions", func() {
 			iso.UEFI = []*types.ImageSource{uefiSrc}
 
 			buildISO := action.NewBuildISOAction(cfg, iso)
-			err := buildISO.ISORun()
+			err := buildISO.Run()
 			Expect(err).Should(HaveOccurred())
 		})
 		It("Fails on ISO filesystem creation", func() {
@@ -193,7 +193,7 @@ var _ = Describe("Build Actions", func() {
 			}
 
 			buildISO := action.NewBuildISOAction(cfg, iso, action.WithLiveBootloader(bootloader))
-			err := buildISO.ISORun()
+			err := buildISO.Run()
 
 			Expect(err).Should(HaveOccurred())
 		})
@@ -228,7 +228,7 @@ var _ = Describe("Build Actions", func() {
 			Expect(buildDisk.BuildDiskRun()).To(Succeed())
 
 			Expect(runner.MatchMilestones([][]string{
-				{"mksquashfs", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/recovery.img"},
+				{"mksquashfs", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/boot/recovery.img"},
 				{"mkfs.ext4", "-L", "COS_STATE"},
 				{"losetup", "--show", "-f", "/tmp/test/build/state.part"},
 				{"mkfs.vfat", "-n", "COS_GRUB"},
@@ -255,7 +255,7 @@ var _ = Describe("Build Actions", func() {
 			Expect(buildDisk.BuildDiskRun()).To(Succeed())
 
 			Expect(runner.MatchMilestones([][]string{
-				{"mksquashfs", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/recovery.img"},
+				{"mksquashfs", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/boot/recovery.img"},
 				{"mkfs.vfat", "-n", "COS_GRUB"},
 				{"mkfs.ext4", "-L", "COS_OEM"},
 				{"mkfs.ext4", "-L", "COS_RECOVERY"},
@@ -274,7 +274,7 @@ var _ = Describe("Build Actions", func() {
 			Expect(buildDisk.BuildDiskRun()).NotTo(Succeed())
 
 			Expect(runner.MatchMilestones([][]string{
-				{"mksquashfs", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/recovery.img"},
+				{"mksquashfs", "/tmp/test/build/recovery.img.root", "/tmp/test/build/recovery/boot/recovery.img"},
 			})).To(Succeed())
 
 			// failed before preparing partitions images

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -249,7 +249,7 @@ func (i InstallAction) Run() (err error) {
 		}
 		recoverySystem.Source.SetDigest(i.spec.System.GetDigest())
 	}
-	err = elemental.DeployRecoverySystem(i.cfg.Config, &recoverySystem, recoveryBootDir)
+	err = elemental.DeployRecoverySystem(i.cfg.Config, &recoverySystem)
 	if err != nil {
 		i.cfg.Logger.Errorf("Failed deploying recovery image: %v", err)
 		return elementalError.NewFromError(err, elementalError.DeployImage)

--- a/pkg/action/upgrade-recovery_test.go
+++ b/pkg/action/upgrade-recovery_test.go
@@ -253,7 +253,6 @@ var _ = Describe("Upgrade Recovery Actions", func() {
 })
 
 func PrepareTestRecoveryImage(config *types.RunConfig, recoveryPath string, fs vfs.FS, runner *mocks.FakeRunner) *types.UpgradeSpec {
-	GinkgoHelper()
 	// Create installState with squashed recovery
 	statePath := filepath.Join(constants.RunningStateDir, constants.InstallStateFile)
 	installState := &types.InstallState{
@@ -292,7 +291,8 @@ func PrepareTestRecoveryImage(config *types.RunConfig, recoveryPath string, fs v
 	runner.SideEffect = func(command string, args ...string) ([]byte, error) {
 		if command == "mksquashfs" && args[1] == spec.RecoverySystem.File {
 			// create the transition img for squash to fake it
-			_, _ = fs.Create(spec.RecoverySystem.File)
+			_, err = fs.Create(spec.RecoverySystem.File)
+			Expect(err).To(Succeed())
 		}
 		return []byte{}, nil
 	}

--- a/pkg/action/upgrade-recovery_test.go
+++ b/pkg/action/upgrade-recovery_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Upgrade Recovery Actions", func() {
 				Expect(err).To(HaveOccurred())
 			})
 			It("Successfully upgrades recovery from docker image", Label("docker"), func() {
-				recoveryImgPath := filepath.Join(constants.LiveDir, constants.RecoveryImgFile)
+				recoveryImgPath := filepath.Join(constants.LiveDir, constants.BootDir, constants.RecoveryImgFile)
 				spec := PrepareTestRecoveryImage(config, constants.LiveDir, fs, runner)
 
 				// This should be the old image
@@ -212,7 +212,7 @@ var _ = Describe("Upgrade Recovery Actions", func() {
 				Expect(spec.State.Date).ToNot(BeEmpty(), "post-upgrade state should contain a date")
 			})
 			It("Successfully skips updateInstallState", Label("docker"), func() {
-				recoveryImgPath := filepath.Join(constants.LiveDir, constants.RecoveryImgFile)
+				recoveryImgPath := filepath.Join(constants.LiveDir, constants.BootDir, constants.RecoveryImgFile)
 				spec := PrepareTestRecoveryImage(config, constants.LiveDir, fs, runner)
 
 				// This should be the old image
@@ -270,22 +270,23 @@ func PrepareTestRecoveryImage(config *types.RunConfig, recoveryPath string, fs v
 	}
 	Expect(config.WriteInstallState(installState, statePath, statePath)).ShouldNot(HaveOccurred())
 
-	recoveryImgPath := filepath.Join(recoveryPath, constants.RecoveryImgFile)
-	Expect(fs.WriteFile(recoveryImgPath, []byte("recovery"), constants.FilePerm)).ShouldNot(HaveOccurred())
-
-	transitionDir := filepath.Join(recoveryPath, "transition.imgTree")
-	Expect(utils.MkdirAll(fs, filepath.Join(transitionDir, "lib/modules/6.6"), constants.DirPerm)).ShouldNot(HaveOccurred())
-	bootDir := filepath.Join(transitionDir, "boot")
-	Expect(utils.MkdirAll(fs, bootDir, constants.DirPerm)).ShouldNot(HaveOccurred())
-	Expect(fs.WriteFile(filepath.Join(bootDir, "vmlinuz-6.6"), []byte("kernel"), constants.FilePerm)).ShouldNot(HaveOccurred())
-	Expect(fs.WriteFile(filepath.Join(bootDir, "elemental.initrd-6.6"), []byte("initrd"), constants.FilePerm)).ShouldNot(HaveOccurred())
+	for _, rootDir := range []string{"/some/dir", recoveryPath} {
+		bootDir := filepath.Join(rootDir, "boot")
+		Expect(utils.MkdirAll(fs, bootDir, constants.DirPerm)).ShouldNot(HaveOccurred())
+		recoveryImgPath := filepath.Join(bootDir, constants.RecoveryImgFile)
+		Expect(fs.WriteFile(recoveryImgPath, []byte("recovery"), constants.FilePerm)).ShouldNot(HaveOccurred())
+		Expect(utils.MkdirAll(fs, filepath.Join(rootDir, "lib/modules/6.6"), constants.DirPerm)).ShouldNot(HaveOccurred())
+		Expect(utils.MkdirAll(fs, bootDir, constants.DirPerm)).ShouldNot(HaveOccurred())
+		Expect(fs.WriteFile(filepath.Join(bootDir, "vmlinuz-6.6"), []byte("kernel"), constants.FilePerm)).ShouldNot(HaveOccurred())
+		Expect(fs.WriteFile(filepath.Join(bootDir, "elemental.initrd-6.6"), []byte("initrd"), constants.FilePerm)).ShouldNot(HaveOccurred())
+	}
 
 	spec, err := conf.NewUpgradeSpec(config.Config)
 	Expect(err).ShouldNot(HaveOccurred())
 
 	spec.System = types.NewDockerSrc("alpine")
 	spec.RecoveryUpgrade = true
-	spec.RecoverySystem.Source = spec.System
+	spec.RecoverySystem.Source = types.NewDirSrc("/some/dir")
 	spec.RecoverySystem.Size = 16
 
 	runner.SideEffect = func(command string, args ...string) ([]byte, error) {

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -300,8 +300,6 @@ var _ = Describe("Runtime Actions", func() {
 				// This should be the old image
 				info, err := fs.Stat(recoveryImgPath)
 				Expect(err).ToNot(HaveOccurred())
-				// Image size should be empty
-				Expect(info.Size()).To(BeNumerically(">", 0))
 				Expect(info.IsDir()).To(BeFalse())
 				f, _ := fs.ReadFile(recoveryImgPath)
 				Expect(f).To(ContainSubstring("recovery"))
@@ -314,11 +312,9 @@ var _ = Describe("Runtime Actions", func() {
 				// This should be the new image
 				info, err = fs.Stat(recoveryImgPath)
 				Expect(err).ToNot(HaveOccurred())
-				// Image size should be empty
-				Expect(info.Size()).To(BeNumerically("==", 0))
 				Expect(info.IsDir()).To(BeFalse())
 				f, _ = fs.ReadFile(recoveryImgPath)
-				Expect(f).ToNot(ContainSubstring("recovery"))
+				Expect(f).To(BeEmpty())
 
 				// Transition squash should not exist
 				info, err = fs.Stat(spec.RecoverySystem.File)

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -294,7 +294,7 @@ var _ = Describe("Runtime Actions", func() {
 				Expect(runner.IncludesCmds([][]string{{"poweroff", "-f"}})).To(BeNil())
 			})
 			It("Successfully upgrades recovery from docker image", Label("docker"), func() {
-				recoveryImgPath := filepath.Join(constants.LiveDir, constants.RecoveryImgFile)
+				recoveryImgPath := filepath.Join(constants.LiveDir, constants.BootDir, constants.RecoveryImgFile)
 				spec := PrepareTestRecoveryImage(config, constants.LiveDir, fs, runner)
 
 				// This should be the old image

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -334,7 +334,7 @@ func NewUpgradeSpec(cfg types.Config) (*types.UpgradeSpec, error) {
 		}
 
 		recovery = types.Image{
-			File:       filepath.Join(ep.Recovery.MountPoint, constants.BootDir, constants.TransitionImgFile),
+			File:       filepath.Join(ep.Recovery.MountPoint, constants.BootTransitionDir, constants.RecoveryImgFile),
 			Size:       constants.ImgSize,
 			Label:      rState.Label,
 			FS:         rState.FS,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -194,7 +194,7 @@ func NewInstallSpec(cfg types.Config) *types.InstallSpec {
 
 	recoverySystem.Source = system
 	recoverySystem.FS = constants.SquashFs
-	recoverySystem.File = filepath.Join(constants.RecoveryDir, constants.RecoveryImgFile)
+	recoverySystem.File = filepath.Join(constants.RecoveryDir, constants.BootDir, constants.RecoveryImgFile)
 	recoverySystem.MountPoint = constants.TransitionDir
 
 	return &types.InstallSpec{
@@ -334,7 +334,7 @@ func NewUpgradeSpec(cfg types.Config) (*types.UpgradeSpec, error) {
 		}
 
 		recovery = types.Image{
-			File:       filepath.Join(ep.Recovery.MountPoint, constants.TransitionImgFile),
+			File:       filepath.Join(ep.Recovery.MountPoint, constants.BootDir, constants.TransitionImgFile),
 			Size:       constants.ImgSize,
 			Label:      rState.Label,
 			FS:         rState.FS,
@@ -440,10 +440,13 @@ func NewResetSpec(cfg types.Config) (*types.ResetSpec, error) {
 		cfg.Logger.Warnf("no Persistent partition found")
 	}
 
-	recoveryImg := filepath.Join(constants.RunningStateDir, constants.RecoveryImgFile)
+	recoveryImg := filepath.Join(constants.RunningStateDir, constants.BootDir, constants.RecoveryImgFile)
+	oldRecoveryImg := filepath.Join(constants.RunningStateDir, constants.RecoveryImgFile)
 
 	if exists, _ := utils.Exists(cfg.Fs, recoveryImg); exists {
 		imgSource = types.NewFileSrc(recoveryImg)
+	} else if exists, _ := utils.Exists(cfg.Fs, oldRecoveryImg); exists {
+		imgSource = types.NewFileSrc(oldRecoveryImg)
 	} else {
 		imgSource = types.NewEmptySrc()
 	}
@@ -514,7 +517,7 @@ func NewDisk(cfg *types.BuildConfig) *types.DiskSpec {
 	workdir = filepath.Join(cfg.OutDir, constants.DiskWorkDir)
 
 	recoveryImg.Size = constants.ImgSize
-	recoveryImg.File = filepath.Join(workdir, constants.RecoveryPartName, constants.RecoveryImgFile)
+	recoveryImg.File = filepath.Join(workdir, constants.RecoveryPartName, constants.BootDir, constants.RecoveryImgFile)
 	recoveryImg.FS = constants.SquashFs
 	recoveryImg.Source = types.NewEmptySrc()
 	recoveryImg.MountPoint = filepath.Join(

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -119,7 +119,10 @@ const (
 	PassiveImgName    = "passive"
 	RecoveryImgName   = "recovery"
 	RecoveryImgFile   = "recovery.img"
-	TransitionImgFile = "transition.img"
+	TransitionImgFile = BootTransitionDir + "/" + RecoveryImgFile
+	BootTransitionDir = "boot-transition"
+	BootDir           = "boot"
+	OldBootDir        = "boot-old"
 
 	// Yip stages evaluated on reset/upgrade/install/build-disk actions
 	AfterInstallChrootHook = "after-install-chroot"
@@ -362,7 +365,7 @@ func GetDiskKeyEnvMap() map[string]string {
 	return map[string]string{}
 }
 
-// GetBootPath returns path use to store the boot files
+// ISOLoaderPath returns path use to store the boot files
 func ISOLoaderPath(arch string) string {
 	return filepath.Join("/boot", arch, "loader")
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -119,7 +119,6 @@ const (
 	PassiveImgName    = "passive"
 	RecoveryImgName   = "recovery"
 	RecoveryImgFile   = "recovery.img"
-	TransitionImgFile = BootTransitionDir + "/" + RecoveryImgFile
 	BootTransitionDir = "boot-transition"
 	BootDir           = "boot"
 	OldBootDir        = "boot-old"

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -1031,8 +1031,6 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 	Describe("DeployRecoverySystem", Label("recovery"), func() {
 		BeforeEach(func() {
 			extractor.SideEffect = func(_, destination, platform string, _ bool) (string, error) {
-				Expect(destination).To(Equal("/recovery/recovery.imgTree"))
-
 				bootDir := filepath.Join(destination, "boot")
 				logger.Debugf("Creating %s", bootDir)
 				err := utils.MkdirAll(fs, bootDir, constants.DirPerm)
@@ -1059,11 +1057,11 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			Expect(fs.Mkdir("/recovery/boot", constants.DirPerm)).To(Succeed())
 
 			img := &types.Image{
-				File:   filepath.Join("/recovery", constants.RecoveryImgFile),
+				File:   filepath.Join("/recovery", constants.BootDir, constants.RecoveryImgFile),
 				Source: types.NewDockerSrc("elemental:latest"),
 				FS:     constants.SquashFs,
 			}
-			err := elemental.DeployRecoverySystem(*config, img, "/recovery/boot")
+			err := elemental.DeployRecoverySystem(*config, img)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			info, err := fs.Stat("/recovery/boot/vmlinuz")

--- a/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
+++ b/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
@@ -111,7 +111,7 @@ menuentry "${display_name} recovery" --id recovery {
   search --no-floppy --label --set=root ${recovery_label}
 
   # Check the presence of the image and fallback to legacy path if not present
-  set img=/recovery.img
+  set img=/boot/recovery.img
   if [ -f "${img}" ]; then
     source (${root})/boot/bootargs.cfg
     linux (${root})${kernel} ${kernelcmd} ${extra_cmdline} ${extra_recovery_cmdline}

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -92,6 +92,17 @@ func Exists(fs types.FS, path string, noFollow ...bool) (bool, error) {
 	return false, err
 }
 
+// RemoveAll removes the specified path.
+// It silently drop NotExists errors.
+func RemoveAll(fs types.FS, path string) error {
+	err := fs.RemoveAll(path)
+	if !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}
+
 // IsDir check if the path is a dir
 func IsDir(fs types.FS, path string) (bool, error) {
 	fi, err := fs.Stat(path)


### PR DESCRIPTION
Deploy the entire recovery system to the same folder (kernel, initrd and rootfs).

During upgrade deploy to a transitional folder and then switch it with the current recovery system and then delete the old one.

This makes sure we clean up old recovery systems and don't risk mixing systems during upgrade.

Fixes #2021 