### PR TITLE
Fix the fix

### DIFF
--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -550,7 +550,8 @@ func DeployRecoverySystem(cfg types.Config, img *types.Image, bootDir string) er
 		"initrd":  initrd,
 	} {
 		// if kernel/initrd is actually named "vmlinuz"/"initrd" we just skip the symlink part.
-		if kernel == name || initrd == name {
+		if filepath.Base(kernel) == name || filepath.Base(initrd) == name {
+			cfg.Logger.Debugf("File already exists, skipping: %s", name)
 			continue
 		}
 


### PR DESCRIPTION
The previous fix does not compare filenames, only a path to a filename which will always be false.

This commit corrects the comparison and adds a log when skipping.