### PR TITLE
Wait for relevant elemental init stages

### DIFF
--- a/pkg/features/embedded/boot-assessment/etc/systemd/system/elemental-boot-assessment.service
+++ b/pkg/features/embedded/boot-assessment/etc/systemd/system/elemental-boot-assessment.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Elemental system configuration
-After=network-online.target systemd-logind.service
-Wants=network-online.target systemd-logind.service
+After=network-online.target systemd-logind.service elemental-setup-network.service elemental-setup-boot.service
+Wants=network-online.target systemd-logind.service elemental-setup-network.service elemental-setup-boot.service
 ConditionKernelCommandLine=elemental.health_check
 ConditionPathExists=!/run/elemental/recovery_mode
 


### PR DESCRIPTION
This commit ensures the boot assessment checkers wait for the network and boot stages of yip. This makes sure the checkers are executed once cloud-init based config files are processed.