### PR TITLE
Remove empty mount paths

### DIFF
--- a/pkg/action/mount.go
+++ b/pkg/action/mount.go
@@ -25,21 +25,24 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
 	"github.com/rancher/elemental-toolkit/v2/pkg/types"
 	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
 )
 
-const overlaySuffix = ".overlay"
-const labelPref = "LABEL="
-const partLabelPref = "PARTLABEL="
-const uuidPref = "UUID="
-const devPref = "/dev/"
-const diskBy = "/dev/disk/by-"
-const diskByLabel = diskBy + "label"
-const diskByPartLabel = diskBy + "partlabel"
-const diskByUUID = diskBy + "uuid"
-const runPath = "/run"
+const (
+	overlaySuffix   = ".overlay"
+	labelPref       = "LABEL="
+	partLabelPref   = "PARTLABEL="
+	uuidPref        = "UUID="
+	devPref         = "/dev/"
+	diskBy          = "/dev/disk/by-"
+	diskByLabel     = diskBy + "label"
+	diskByPartLabel = diskBy + "partlabel"
+	diskByUUID      = diskBy + "uuid"
+	runPath         = "/run"
+)
 
 func RunMount(cfg *types.RunConfig, spec *types.MountSpec) error {
 	var fstabData string

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 
@@ -300,6 +301,11 @@ func (spec *MountSpec) Sanitize() error {
 	const separator = string(os.PathSeparator)
 
 	if spec.Persistent.Paths != nil {
+		// Remove empty paths
+		spec.Persistent.Paths = slices.DeleteFunc(spec.Persistent.Paths, func(s string) bool {
+			return s == ""
+		})
+
 		sort.Slice(spec.Persistent.Paths, func(i, j int) bool {
 			return strings.Count(spec.Persistent.Paths[i], separator) < strings.Count(spec.Persistent.Paths[j], separator)
 		})
@@ -313,6 +319,11 @@ func (spec *MountSpec) Sanitize() error {
 	}
 
 	if spec.Ephemeral.Paths != nil {
+		// Remove empty paths
+		spec.Ephemeral.Paths = slices.DeleteFunc(spec.Ephemeral.Paths, func(s string) bool {
+			return s == ""
+		})
+
 		sort.Slice(spec.Ephemeral.Paths, func(i, j int) bool {
 			return strings.Count(spec.Ephemeral.Paths[i], separator) < strings.Count(spec.Ephemeral.Paths[j], separator)
 		})

--- a/pkg/types/config_test.go
+++ b/pkg/types/config_test.go
@@ -532,4 +532,23 @@ var _ = Describe("Types", Label("types", "config"), func() {
 			Expect(spec.Sanitize()).Should(HaveOccurred())
 		})
 	})
+	Describe("MountSpec", func() {
+		It("sanitizes empty paths", func() {
+			spec := types.MountSpec{
+				Ephemeral: types.EphemeralMounts{
+					Type:  constants.Tmpfs,
+					Paths: []string{"/var", "", "/etc"},
+				},
+				Persistent: types.PersistentMounts{
+					Mode:  constants.OverlayMode,
+					Paths: []string{"/etc/rancher", "", "/root"},
+				},
+			}
+
+			Expect(spec.Sanitize()).To(Succeed())
+
+			Expect(spec.Ephemeral.Paths).To(Equal([]string{"/var", "/etc"}))
+			Expect(spec.Persistent.Paths).To(Equal([]string{"/root", "/etc/rancher"}))
+		})
+	})
 })


### PR DESCRIPTION
When running mount command with a layout file that contains spaces, those spaces will be converted to empty paths.

This commit removes those paths in the Sanitize method for the MountSpec.

Fixes #2035 