### PR TITLE
Make squashfs defaults more consistent

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -19,7 +19,6 @@ package constants
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
 const (
@@ -265,20 +264,12 @@ func GetCloudInitPaths() []string {
 	return []string{"/system/oem", "/oem/", "/usr/local/cloud-config/"}
 }
 
-// GetDefaultSquashfsOptions returns the default options to use when creating a squashfs
-func GetDefaultSquashfsOptions() []string {
-	return []string{"-b", "1024k"}
+func GetSquashfsNoCompressionOptions() []string {
+	return []string{"-no-compression"}
 }
 
 func GetDefaultSquashfsCompressionOptions() []string {
-	options := []string{"-comp", "xz", "-Xbcj"}
-	// Set the filter based on arch for best compression results
-	if runtime.GOARCH == "arm64" {
-		options = append(options, "arm")
-	} else {
-		options = append(options, "x86")
-	}
-	return options
+	return []string{"-b", "1024k"}
 }
 
 // GetRunKeyEnvMap returns environment variable bindings to RunConfig data

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -363,8 +363,7 @@ func CreateImageFromTree(c types.Config, img *types.Image, rootDir string, prelo
 			return err
 		}
 
-		squashOptions := append(cnst.GetDefaultSquashfsOptions(), c.SquashFsCompressionConfig...)
-		err = utils.CreateSquashFS(c.Runner, c.Logger, rootDir, img.File, squashOptions)
+		err = utils.CreateSquashFS(c.Runner, c.Logger, rootDir, img.File, c.SquashFsCompressionConfig)
 		if err != nil {
 			c.Logger.Errorf("failed creating squashfs image for %s: %v", img.File, err)
 			return err

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -147,7 +147,7 @@ func (c *Config) Sanitize() error {
 	// By default on NewConfig the SquashFsCompressionConfig is set to the default values, and then override
 	// on config unmarshall.
 	if c.SquashFsNoCompression {
-		c.SquashFsCompressionConfig = []string{}
+		c.SquashFsCompressionConfig = constants.GetSquashfsNoCompressionOptions()
 	}
 
 	if c.Arch != "" {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -911,9 +911,9 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("runs with options if given", func() {
-			err := utils.CreateSquashFS(runner, logger, "source", "dest", constants.GetDefaultSquashfsOptions())
+			err := utils.CreateSquashFS(runner, logger, "source", "dest", constants.GetDefaultSquashfsCompressionOptions())
 			cmd := []string{"mksquashfs", "source", "dest"}
-			cmd = append(cmd, constants.GetDefaultSquashfsOptions()...)
+			cmd = append(cmd, constants.GetDefaultSquashfsCompressionOptions()...)
 			Expect(runner.IncludesCmds([][]string{
 				cmd,
 			})).To(BeNil())


### PR DESCRIPTION
This PR makes ensures squashfs compression can be disabled and leaves the default compression to what used to be the case for `squash-no-compression: true`. Default compression then defaults to default mksquashfs compression (gzip) with a block of 1024k.