### PR TITLE
[v1.1.x] Move recovery hostname to cloud-config-defaults

### DIFF
--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -40,7 +40,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		Use:   "build-disk image",
 		Short: "Build a disk image using the given image (experimental and subject to change)",
 		Args:  cobra.MaximumNArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if addCheckRoot {
 				return CheckRoot()
 			}

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -43,7 +43,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			"    * <sourceType> - might be [\"dir\", \"file\", \"oci\", \"docker\", \"channel\"], as default is \"docker\"\n" +
 			"    * <sourceName> - is path to file or directory, image name with tag version or channel name",
 		Args: cobra.MaximumNArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if addCheckRoot {
 				return CheckRoot()
 			}

--- a/cmd/cloud-init.go
+++ b/cmd/cloud-init.go
@@ -35,7 +35,7 @@ func NewCloudInitCmd(root *cobra.Command) *cobra.Command {
 		Use:   "cloud-init",
 		Short: "Run cloud-init",
 		Args:  cobra.MinimumNArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlags(cmd.Flags())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -184,7 +184,7 @@ func ReadConfigRun(configDir string, flags *pflag.FlagSet, mounter mount.Interfa
 	cfgExtra := filepath.Join(configDir, "config.d")
 	if exists, _ := utils.Exists(cfg.Fs, cfgExtra); exists {
 		viper.AddConfigPath(cfgExtra)
-		err := filepath.WalkDir(cfgExtra, func(path string, d fs.DirEntry, err error) error {
+		err := filepath.WalkDir(cfgExtra, func(_ string, d fs.DirEntry, _ error) error {
 			if !d.IsDir() && filepath.Ext(d.Name()) == ".yaml" {
 				viper.SetConfigType("yaml")
 				viper.SetConfigName(strings.TrimSuffix(d.Name(), ".yaml"))

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -37,7 +37,7 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		Use:   "install DEVICE",
 		Short: "Elemental installer",
 		Args:  cobra.MaximumNArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if addCheckRoot {
 				return CheckRoot()
 			}

--- a/cmd/pull-image.go
+++ b/cmd/pull-image.go
@@ -33,7 +33,7 @@ func NewPullImageCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		Use:   "pull-image IMAGE DESTINATION",
 		Short: "Pull remote image to local file",
 		Args:  cobra.ExactArgs(2),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if addCheckRoot {
 				return CheckRoot()
 			}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -33,13 +33,13 @@ func NewResetCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		Use:   "reset",
 		Short: "Reset OS",
 		Args:  cobra.ExactArgs(0),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if addCheckRoot {
 				return CheckRoot()
 			}
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			path, err := exec.LookPath("mount")
 			if err != nil {
 				return err

--- a/cmd/run-stage.go
+++ b/cmd/run-stage.go
@@ -31,7 +31,7 @@ func NewRunStage(root *cobra.Command) *cobra.Command {
 		Use:   "run-stage STAGE",
 		Short: "Run stage from cloud-init",
 		Args:  cobra.MinimumNArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(_ *cobra.Command, _ []string) {
 
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -36,14 +36,14 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 		Use:   "upgrade",
 		Short: "Upgrade the system",
 		Args:  cobra.ExactArgs(0),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if addCheckRoot {
 				return CheckRoot()
 			}
 			return nil
 		},
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			path, err := exec.LookPath("mount")
 			if err != nil {
 				return err

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -29,7 +29,7 @@ func NewVersionCmd(root *cobra.Command) *cobra.Command {
 		Use:   "version",
 		Args:  cobra.ExactArgs(0),
 		Short: "Print the version",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			v := version.Get()
 			commit := v.GitCommit
 			if len(commit) > 7 {

--- a/pkg/features/embedded/cloud-config-defaults/system/oem/03_branding.yaml
+++ b/pkg/features/embedded/cloud-config-defaults/system/oem/03_branding.yaml
@@ -26,4 +26,8 @@ stages:
           permissions: 0644
           owner: 0
           group: 0
+   boot:
+    - name: "Recovery"
+      if: '[ -f "/run/cos/recovery_mode" ]'
+      hostname: "recovery"
 

--- a/pkg/features/embedded/cloud-config-essentials/system/oem/06_recovery.yaml
+++ b/pkg/features/embedded/cloud-config-essentials/system/oem/06_recovery.yaml
@@ -10,7 +10,6 @@ stages:
    boot:
      - name: "Recovery"
        if: '[ -f "/run/cos/recovery_mode" ]'
-       hostname: "recovery"
        commands:
        - |
             source /etc/os-release


### PR DESCRIPTION
Setting recovery hostname is mostly a nice-to-have and can be destructive so move it to cloud-config-defaults feature.

This is a backport to v1.1.x to solve recovery hostname issue in rancher/elemental