### PR TITLE
add symlink for missing binary on ubuntu 22.04+

### DIFF
--- a/examples/orange/Dockerfile
+++ b/examples/orange/Dockerfile
@@ -52,6 +52,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   podman \
   xz-utils
 
+# Symlink grub2-editenv
+RUN ln -sf /usr/bin/grub-editenv /usr/bin/grub2-editenv
+
 # Create non FHS paths
 RUN mkdir -p /oem /system
 


### PR DESCRIPTION
grub2-editenv does not exist on ubuntu 22.04+ - it is just called grub-editenv

Currently it fails like so:

```
ERRO[2024-04-17T22:54:28-04:00] sh: 1: grub2-editenv: not found
 : failed to run grub2-editenv /oem/grubenv set boot_assessment_check=yes: exit status 127
ERRO[2024-04-17T22:54:28-04:00] sh: 1: grub2-editenv: not found
 : failed to run grub2-editenv /oem/grubenv unset last_boot_attempt: exit status 127
ERRO[2024-04-17T22:54:28-04:00] 2 errors occurred:
        * failed to run grub2-editenv /oem/grubenv set boot_assessment_check=yes: exit status 127
        * failed to run grub2-editenv /oem/grubenv unset last_boot_attempt: exit status 127
```

The symlink fixes the issue