### PR TITLE
Enable SELinux for tumbleweed and green

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ RUN ARCH=$(uname -m); \
         cosign \
         gptfdisk \
         patterns-microos-selinux \
-        k3s-selinux \
         btrfsprogs \
         lvm2 && \
     zypper cc -a

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN ARCH=$(uname -m); \
         xorriso \
         cosign \
         gptfdisk \
+        patterns-microos-selinux \
+        k3s-selinux \
+        btrfsprogs \
         lvm2 && \
     zypper cc -a
 

--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -61,7 +61,6 @@ RUN ARCH=$(uname -m); \
       podman \
       audit \
       patterns-microos-selinux \
-      k3s-selinux \
       btrfsprogs \
       btrfsmaintenance \
       snapper \

--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -57,9 +57,11 @@ RUN ARCH=$(uname -m); \
       sudo \
       curl \
       sed \
-      patch \
       iproute2 \
       podman \
+      audit \
+      patterns-microos-selinux \
+      k3s-selinux \
       btrfsprogs \
       btrfsmaintenance \
       snapper \
@@ -78,6 +80,9 @@ RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
 
 # Add default network configuration
 ADD 05_network.yaml /system/oem/05_network.yaml
+
+# SELinux in enforce mode
+RUN sed -i "s|SELINUX=.*|SELINUX=enforcing|g" /etc/selinux/config
 
 # Add default snapshotter setup
 ADD snapshotter.yaml /etc/elemental/config.d/snapshotter.yaml

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -41,7 +41,9 @@ func grubCfgTemplate(arch string) string {
 
 	menuentry "%s" --class os --unrestricted {
 		echo Loading kernel...
-		linux ($root)` + constants.ISOKernelPath(arch) + ` cdroot root=live:CDLABEL=%s rd.live.dir=` + constants.ISOLoaderPath(arch) + `  rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 elemental.disable elemental.setup=` + constants.ISOCloudInitPath + `
+		linux ($root)` + constants.ISOKernelPath(arch) + ` cdroot root=live:CDLABEL=%s rd.live.dir=` + constants.ISOLoaderPath(arch) +
+		`  rd.live.squashimg=rootfs.squashfs security=selinux enforcing=0 console=tty1 console=ttyS0 elemental.disable elemental.setup=` +
+		constants.ISOCloudInitPath + `
 		echo Loading initrd...
 		initrd ($root)` + constants.ISOInitrdPath(arch) + `
 	}

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -324,13 +324,6 @@ func (i *InstallAction) refineDeployment() error { //nolint:dupl
 		return elementalError.NewFromError(err, elementalError.InstallGrub)
 	}
 
-	// Relabel SELinux
-	err = elemental.ApplySelinuxLabels(i.cfg.Config, i.spec.Partitions)
-	if err != nil {
-		i.cfg.Logger.Errorf("failed setting SELinux labels: %v", err)
-		return elementalError.NewFromError(err, elementalError.SelinuxRelabel)
-	}
-
 	err = i.installChrootHook(cnst.AfterInstallChrootHook, cnst.WorkingImgDir)
 	if err != nil {
 		i.cfg.Logger.Errorf("failed after-install-chroot hook: %v", err)

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -297,13 +297,6 @@ func (r *ResetAction) refineDeployment() error { //nolint:dupl
 		return elementalError.NewFromError(err, elementalError.InstallGrub)
 	}
 
-	// Relabel SELinux
-	err = elemental.ApplySelinuxLabels(r.cfg.Config, r.spec.Partitions)
-	if err != nil {
-		r.cfg.Logger.Errorf("failed setting SELinux labels: %v", err)
-		return elementalError.NewFromError(err, elementalError.SelinuxRelabel)
-	}
-
 	err = r.resetChrootHook(constants.AfterResetChrootHook, constants.WorkingImgDir)
 	if err != nil {
 		r.cfg.Logger.Errorf("failed after-reset-chroot hook: %v", err)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -361,13 +361,6 @@ func (u *UpgradeAction) refineDeployment() error { //nolint:dupl
 		}
 	}
 
-	// Relabel SELinux
-	err = elemental.ApplySelinuxLabels(u.cfg.Config, u.spec.Partitions)
-	if err != nil {
-		u.cfg.Logger.Errorf("failed setting SELinux labels: %v", err)
-		return elementalError.NewFromError(err, elementalError.SelinuxRelabel)
-	}
-
 	err = u.upgradeChrootHook(constants.AfterUpgradeChrootHook, constants.WorkingImgDir)
 	if err != nil {
 		u.Error("Error running hook after-upgrade-chroot: %s", err)

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -885,8 +885,8 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			relabelCmd = []string{
-				"setfiles", "-c", policyFile, "-e", "/dev", "-e", "/proc", "-e", "/sys",
-				"-F", constants.SELinuxTargetedContextFile, "/",
+				"setfiles", "-e", "/dev", "-e", "/proc", "-e", "/sys",
+				"-i", "-F", constants.SELinuxTargetedContextFile, "/",
 			}
 		})
 		It("does nothing if the context file is not found", func() {
@@ -929,7 +929,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			relabelCmd = []string{
-				"setfiles", "-c", policyFile, "-F", "-r", "/root", contextFile, "/root",
+				"setfiles", "-i", "-F", "-r", "/root", contextFile, "/root",
 			}
 
 			Expect(elemental.SelinuxRelabel(*config, "/root")).To(BeNil())

--- a/pkg/features/embedded/cloud-config-defaults/system/oem/10_selinux.yaml
+++ b/pkg/features/embedded/cloud-config-defaults/system/oem/10_selinux.yaml
@@ -8,10 +8,16 @@
 name: "SELinux"
 stages:
    initramfs:
-     - name: "Relabelling"
+     - name: "SELinux labels for targeted policy"
        commands:
        - | 
-         if grep -q "selinux=1" /proc/cmdline; then
-           load_policy -i
-           restorecon -R -i -v /etc /root /opt /srv /var /home /usr/local /oem
+         if grep -qw selinux /sys/kernel/security/lsm; then
+           # Some extended attributes are lost on copy-up bsc#1210690. Workaround visit children first, then parents
+           mkdir -p /run/systemd/relabel-extra.d/
+           for path in /etc /srv /var /oem /home /root /opt; do
+             if [ -d "${path}" ]; then
+               find ${path} -depth -exec /sbin/setfiles -F -v "/etc/selinux/targeted/contexts/files/file_contexts" \{\} +
+               echo "${path}" >> /run/systemd/relabel-extra.d/layout.relabel
+             fi
+           done
          fi

--- a/pkg/features/embedded/cloud-config-defaults/system/oem/10_selinux.yaml
+++ b/pkg/features/embedded/cloud-config-defaults/system/oem/10_selinux.yaml
@@ -18,7 +18,7 @@ stages:
            mkdir -p /run/systemd/relabel-extra.d/
            for path in /etc /srv /var /oem /home /root /opt; do
              if [ -d "${path}" ]; then
-               find ${path} -depth -exec /sbin/setfiles -F -v "${contexts}" \{\} +
+               find ${path} -depth -exec /sbin/setfiles -i -F -v "${contexts}" \{\} +
                echo "${path}" >> /run/systemd/relabel-extra.d/layout.relabel
              fi
            done

--- a/pkg/features/embedded/cloud-config-defaults/system/oem/10_selinux.yaml
+++ b/pkg/features/embedded/cloud-config-defaults/system/oem/10_selinux.yaml
@@ -11,12 +11,14 @@ stages:
      - name: "SELinux labels for targeted policy"
        commands:
        - | 
-         if grep -qw selinux /sys/kernel/security/lsm; then
-           # Some extended attributes are lost on copy-up bsc#1210690. Workaround visit children first, then parents
+         contexts="/etc/selinux/targeted/contexts/files/file_contexts"
+         if grep -qw selinux /sys/kernel/security/lsm && [ -e "${contexts}" ]; then
+           # Some extended attributes are lost on copy-up bsc#1210690.
+           # Workaround visit children first, then parents
            mkdir -p /run/systemd/relabel-extra.d/
            for path in /etc /srv /var /oem /home /root /opt; do
              if [ -d "${path}" ]; then
-               find ${path} -depth -exec /sbin/setfiles -F -v "/etc/selinux/targeted/contexts/files/file_contexts" \{\} +
+               find ${path} -depth -exec /sbin/setfiles -F -v "${contexts}" \{\} +
                echo "${path}" >> /run/systemd/relabel-extra.d/layout.relabel
              fi
            done

--- a/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
+++ b/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
@@ -15,12 +15,12 @@ if [ -n "${img}" ]; then
 fi
 
 if [ "${mode}" == "recovery" ]; then
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} security=selinux selinux=0 rd.neednet=1"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} security=selinux selinux=1 enforcing=0 rd.neednet=1"
 else
   if [ "${snapshotter}" == "btrfs" ]; then
     set snap_arg="elemental.snapshotter=btrfs"
   fi
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} panic=5 security=selinux selinux=0 rd.neednet=1 fsck.mode=force fsck.repair=yes"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} panic=5 security=selinux selinux=1 rd.neednet=1 fsck.mode=force fsck.repair=yes"
 fi
 
 set kernel=/boot/vmlinuz

--- a/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
+++ b/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
@@ -15,7 +15,7 @@ if [ -n "${img}" ]; then
 fi
 
 if [ "${mode}" == "recovery" ]; then
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} security=selinux selinux=0 rd.neednet=1"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} security=selinux enforcing=0 rd.neednet=1"
 else
   if [ "${snapshotter}" == "btrfs" ]; then
     set snap_arg="elemental.snapshotter=btrfs"

--- a/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
+++ b/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
@@ -15,12 +15,12 @@ if [ -n "${img}" ]; then
 fi
 
 if [ "${mode}" == "recovery" ]; then
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} security=selinux selinux=1 enforcing=0 rd.neednet=1"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} security=selinux selinux=0 rd.neednet=1"
 else
   if [ "${snapshotter}" == "btrfs" ]; then
     set snap_arg="elemental.snapshotter=btrfs"
   fi
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} panic=5 security=selinux selinux=1 rd.neednet=1 fsck.mode=force fsck.repair=yes"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} panic=5 security=selinux rd.neednet=1 fsck.mode=force fsck.repair=yes"
 fi
 
 set kernel=/boot/vmlinuz

--- a/pkg/snapshotter/btrfs_test.go
+++ b/pkg/snapshotter/btrfs_test.go
@@ -46,6 +46,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 	var snapCfg types.SnapshotterConfig
 	var rootDir, efiDir string
 	var statePart *types.Partition
+	var syscall *mocks.FakeSyscall
 
 	BeforeEach(func() {
 		rootDir = "/some/root"
@@ -57,6 +58,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 		efiDir = constants.EfiDir
 		runner = mocks.NewFakeRunner()
 		mounter = mocks.NewFakeMounter()
+		syscall = &mocks.FakeSyscall{}
 		bootloader = &mocks.FakeBootloader{}
 		memLog = bytes.NewBuffer(nil)
 		logger = types.NewBufferLogger(memLog)
@@ -71,6 +73,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 			conf.WithRunner(runner),
 			conf.WithLogger(logger),
 			conf.WithMounter(mounter),
+			conf.WithSyscall(syscall),
 			conf.WithPlatform("linux/amd64"),
 		)
 		snapCfg = types.SnapshotterConfig{

--- a/pkg/snapshotter/loopdevice_test.go
+++ b/pkg/snapshotter/loopdevice_test.go
@@ -44,6 +44,7 @@ var _ = Describe("LoopDevice", Label("snapshotter", "loopdevice"), func() {
 	var snapCfg types.SnapshotterConfig
 	var rootDir, efiDir string
 	var statePart *types.Partition
+	var syscall *mocks.FakeSyscall
 
 	BeforeEach(func() {
 		rootDir = "/some/root"
@@ -55,6 +56,7 @@ var _ = Describe("LoopDevice", Label("snapshotter", "loopdevice"), func() {
 		efiDir = constants.EfiDir
 		runner = mocks.NewFakeRunner()
 		mounter = mocks.NewFakeMounter()
+		syscall = &mocks.FakeSyscall{}
 		bootloader = &mocks.FakeBootloader{}
 		memLog = bytes.NewBuffer(nil)
 		logger = types.NewBufferLogger(memLog)
@@ -69,6 +71,7 @@ var _ = Describe("LoopDevice", Label("snapshotter", "loopdevice"), func() {
 			conf.WithRunner(runner),
 			conf.WithLogger(logger),
 			conf.WithMounter(mounter),
+			conf.WithSyscall(syscall),
 			conf.WithPlatform("linux/amd64"),
 		)
 		snapCfg = types.NewLoopDevice()

--- a/pkg/utils/chroot.go
+++ b/pkg/utils/chroot.go
@@ -50,6 +50,9 @@ func NewChroot(path string, config *types.Config) *Chroot {
 // ChrootedCallback runs the given callback in a chroot environment
 func ChrootedCallback(cfg *types.Config, path string, bindMounts map[string]string, callback func() error) error {
 	chroot := NewChroot(path, cfg)
+	if bindMounts == nil {
+		bindMounts = map[string]string{}
+	}
 	chroot.SetExtraMounts(bindMounts)
 	return chroot.RunCallback(callback)
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -156,7 +156,7 @@ func CreateDirStructure(fs types.FS, target string) error {
 // SyncData rsync's source folder contents to a target folder content,
 // both are expected to exist before hand.
 func SyncData(log types.Logger, runner types.Runner, fs types.FS, source string, target string, excludes ...string) error {
-	flags := []string{"--progress", "--partial", "--human-readable", "--archive", "--xattrs", "--acls"}
+	flags := []string{"--progress", "--partial", "--human-readable", "--archive", "--xattrs", "--acls", "--filter=-x security.selinux"}
 	for _, e := range excludes {
 		flags = append(flags, fmt.Sprintf("--exclude=%s", e))
 	}
@@ -167,7 +167,7 @@ func SyncData(log types.Logger, runner types.Runner, fs types.FS, source string,
 // MirrorData rsync's source folder contents to a target folder content, in contrast, to SyncData this
 // method includes the --delete flag which forces the deletion of files in target that are missing in source.
 func MirrorData(log types.Logger, runner types.Runner, fs types.FS, source string, target string, excludes ...string) error {
-	flags := []string{"--progress", "--partial", "--human-readable", "--archive", "--xattrs", "--acls", "--delete"}
+	flags := []string{"--progress", "--partial", "--human-readable", "--archive", "--xattrs", "--acls", "--delete", "--filter=-x security.selinux"}
 	for _, e := range excludes {
 		flags = append(flags, fmt.Sprintf("--exclude=%s", e))
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -97,11 +97,11 @@ var _ = Describe("Utils", Label("utils"), func() {
 		})
 		Describe("ChrootedCallback method", func() {
 			It("runs a callback in a chroot", func() {
-				err := utils.ChrootedCallback(config, "/somepath", map[string]string{}, func() error {
+				err := utils.ChrootedCallback(config, "/somepath", nil, func() error {
 					return nil
 				})
 				Expect(err).ShouldNot(HaveOccurred())
-				err = utils.ChrootedCallback(config, "/somepath", map[string]string{}, func() error {
+				err = utils.ChrootedCallback(config, "/somepath", nil, func() error {
 					return fmt.Errorf("callback error")
 				})
 				Expect(err).Should(HaveOccurred())


### PR DESCRIPTION
This PR uses SELinux in enforce mode for the active/passive systems and in permissive mode for recovery and ISO systems.

The elemental labelling code changed slightly,  basically the change is that now it is also executed as part of the close transaction step once the new root is already rsynced. In addition it also tries to label from the outer system any eventual mountpoint that was labeled in a chroot env (`/dev`, `/proc`, `/sys`, etc.).

Current unsolved issues:

* In github actions the host has SELinux enabled and relabeling the new root within a container turns to fail (see build disk and build iso logs in GH)... as a consequence the disk and iso images are not properly labeled, hence they are not really usabled in enforce mode. This does not happen in a host without the `container-selinux` policy module. This has impact on our capability to build ISOs and Disks inside a k8s cluster using unprivileged pods.

* Running upgrades from the recovery system (`elemental upgrade` command) is not functional if the target is in btrfs. There seams to be an issue with selinux labels when mounting the `.snapshots` subvolume preventing snapper to properly operate. One option would be to rethink the btrfs snapshotter env in recovery mode, instead of mounting `.snapshots` in `<some/root>/.snapshots` just use `/.snapshots` so any eventual relabel is done with the appropriate path.

Fixes #2054

Signed-off-by: David Cassany <dcassany@suse.com>
