### PR TITLE
Add autologin feature

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,7 +36,7 @@ func InitCmd(root *cobra.Command) *cobra.Command {
 		Long: "Init a container image with elemental configuration\n\n" +
 			"FEATURES - should be provided as a comma-separated list of features to install.\n" +
 			"    Available features: " + strings.Join(features.All, ",") + "\n" +
-			"    Defaults to all",
+			"    Defaults to " + strings.Join(features.Default, ","),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.ReadConfigRun(viper.GetString("config-dir"), cmd.Flags(), types.NewDummyMounter())
@@ -52,8 +52,8 @@ func InitCmd(root *cobra.Command) *cobra.Command {
 				return elementalError.NewFromError(err, elementalError.ReadingSpecConfig)
 			}
 
-			if len(args) == 0 || args[0] == "all" {
-				spec.Features = features.All
+			if len(args) == 0 {
+				spec.Features = features.Default
 			} else {
 				spec.Features = strings.Split(args[0], ",")
 			}

--- a/pkg/features/embedded/autologin/system/oem/05_autologin.yaml
+++ b/pkg/features/embedded/autologin/system/oem/05_autologin.yaml
@@ -1,0 +1,17 @@
+name: "Root autologin"
+stages:
+  initramfs:
+    - name: "Autologin"
+      files:
+      - path: /etc/systemd/system/serial-getty@ttyS0.service.d/override.conf
+        content: |
+          [Service]
+          ExecStart=
+          ExecStart=-/sbin/agetty --autologin root --noclear %I $TERM
+        permissions: 0644
+      - path: /etc/systemd/system/getty@tty1.service.d/override.conf
+        content: |
+          [Service]
+          ExecStart=
+          ExecStart=-/sbin/agetty --autologin root --noclear %I $TERM
+        permissions: 0644

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -53,10 +53,23 @@ const (
 	FeatureCloudConfigDefaults   = "cloud-config-defaults"
 	FeatureCloudConfigEssentials = "cloud-config-essentials"
 	FeatureBootAssessment        = "boot-assessment"
+	FeatureAutologin             = "autologin"
 )
 
 var (
 	All = []string{
+		FeatureElementalRootfs,
+		FeatureElementalSysroot,
+		FeatureGrubConfig,
+		FeatureGrubDefaultBootargs,
+		FeatureElementalSetup,
+		FeatureDracutConfig,
+		FeatureCloudConfigDefaults,
+		FeatureCloudConfigEssentials,
+		FeatureBootAssessment,
+	}
+
+	Default = []string{
 		FeatureElementalRootfs,
 		FeatureElementalSysroot,
 		FeatureGrubConfig,
@@ -156,6 +169,8 @@ func Get(names []string) ([]*Feature, error) {
 				systemd.NewUnit("elemental-boot-assessment.service"),
 			}
 			features = append(features, New(name, units))
+		case FeatureAutologin:
+			features = append(features, New(name, nil))
 		default:
 			notFound = append(notFound, name)
 		}


### PR DESCRIPTION
Automatically login as root on the booted system.

This can be useful to debug issues when cloud-config is not applied, locking users out of the system.