### PR TITLE
Nightly retry pull

### DIFF
--- a/.github/workflows/build_and_test_x86.yaml
+++ b/.github/workflows/build_and_test_x86.yaml
@@ -27,8 +27,6 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha }}"
       - run: |
           git fetch --prune --unshallow
-      - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,10 @@ push-toolkit:
 
 .PHONY: pull-toolkit
 pull-toolkit:
-	$(DOCKER) pull $(TOOLKIT_REPO):$(VERSION)
+	for retry in 1 2 3 ; do \
+		$(DOCKER) pull $(TOOLKIT_REPO):$(VERSION) && exit 0; \
+		sleep 3; \
+	done
 
 .PHONY: build-cli
 build-cli:


### PR DESCRIPTION
Nigthly fails, might be timing related. Retry the pull-toolkit step 3 times if not successful with 3 second sleep between pulls.