### PR TITLE
Disable boot entry if efivars is read-only

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -61,7 +61,10 @@ func NewInstallAction(cfg *types.RunConfig, spec *types.InstallSpec, opts ...Ins
 	}
 
 	if i.bootloader == nil {
-		i.bootloader = bootloader.NewGrub(&cfg.Config, bootloader.WithGrubDisableBootEntry(i.spec.DisableBootEntry))
+		i.bootloader = bootloader.NewGrub(&cfg.Config,
+			bootloader.WithGrubDisableBootEntry(i.spec.DisableBootEntry),
+			bootloader.WithGrubAutoDisableBootEntry(),
+		)
 	}
 
 	if i.snapshotter == nil {

--- a/pkg/action/reset.go
+++ b/pkg/action/reset.go
@@ -84,7 +84,9 @@ func NewResetAction(cfg *types.RunConfig, spec *types.ResetSpec, opts ...ResetAc
 
 	if r.bootloader == nil {
 		r.bootloader = bootloader.NewGrub(
-			&cfg.Config, bootloader.WithGrubDisableBootEntry(r.spec.DisableBootEntry),
+			&cfg.Config,
+			bootloader.WithGrubDisableBootEntry(r.spec.DisableBootEntry),
+			bootloader.WithGrubAutoDisableBootEntry(),
 			bootloader.WithGrubClearBootEntry(false),
 		)
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -63,6 +63,7 @@ const (
 	Tmpfs              = "tmpfs"
 	Autofs             = "auto"
 	Block              = "block"
+	EfivarsMountPath   = "/sys/firmware/efi/efivars"
 
 	// Maxium number of nested symlinks to resolve
 	MaxLinkDepth = 4

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -177,8 +177,8 @@ func IsMounted(c types.Config, part *types.Partition) (bool, error) {
 	return !notMnt, nil
 }
 
-func IsRWMountPoint(c types.Config, mountPoint string) (bool, error) {
-	cmdOut, err := c.Runner.Run("findmnt", "-fno", "OPTIONS", mountPoint)
+func IsRWMountPoint(r types.Runner, mountPoint string) (bool, error) {
+	cmdOut, err := r.Run("findmnt", "-fno", "OPTIONS", mountPoint)
 	if err != nil {
 		return false, err
 	}
@@ -193,7 +193,7 @@ func IsRWMountPoint(c types.Config, mountPoint string) (bool, error) {
 // MountRWPartition mounts, or remounts if needed, a partition with RW permissions
 func MountRWPartition(c types.Config, part *types.Partition) (umount func() error, err error) {
 	if mnt, _ := IsMounted(c, part); mnt {
-		if ok, _ := IsRWMountPoint(c, part.MountPoint); ok {
+		if ok, _ := IsRWMountPoint(c.Runner, part.MountPoint); ok {
 			c.Logger.Debugf("Already RW mounted: %s at %s", part.Name, part.MountPoint)
 			return func() error { return nil }, nil
 		}

--- a/pkg/snapshotter/loopdevice.go
+++ b/pkg/snapshotter/loopdevice.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
 	"github.com/rancher/elemental-toolkit/v2/pkg/elemental"
 
@@ -91,7 +92,7 @@ func (l *LoopDevice) InitSnapshotter(state *types.Partition, efiDir string) erro
 		l.legacyClean = true
 
 		// Legacy deployments might not include RW mounts for state partitions
-		if ok, _ := elemental.IsRWMountPoint(l.cfg, l.rootDir); !ok {
+		if ok, _ := elemental.IsRWMountPoint(l.cfg.Runner, l.rootDir); !ok {
 			err = l.cfg.Mounter.Mount("", l.rootDir, "auto", []string{"remount", "rw"})
 			if err != nil {
 				l.cfg.Logger.Errorf("Failed remounting root as RW: %v", err)


### PR DESCRIPTION
On some systems the efivars is mounted read-only if the firmware does not support writing (such as RPI).

This commit turns off writing boot entries to efivars if the efivars filesystem is mounted read-only.