### PR TITLE
Add branding for live CD

### DIFF
--- a/pkg/features/embedded/cloud-config-defaults/system/oem/03_branding.yaml
+++ b/pkg/features/embedded/cloud-config-defaults/system/oem/03_branding.yaml
@@ -23,7 +23,6 @@ stages:
             Welcome to \S !
             IP address \4
             Login with user: root, password: elemental
-            Start the installer with "elemental install <device>" to install it in the local system
           permissions: 0644
           owner: 0
           group: 0
@@ -48,7 +47,7 @@ stages:
           group: 0
      - name: "Branding recovery"
        if: '[ -f "/run/elemental/recovery_mode" ]'
-       hostname: "elemental"
+       hostname: "recovery"
        files:
         - path: /etc/issue
           content: |
@@ -65,8 +64,22 @@ stages:
           permissions: 0644
           owner: 0
           group: 0
-   boot:
-    - name: "Recovery"
-      if: '[ -f "/run/elemental/recovery_mode" ]'
-      hostname: "recovery"
+     - name: "Branding live CD"
+       if: '[ -f "/run/elemental/live_mode" ]'
+       hostname: "installer"
+       files:
+        - path: /etc/issue
+          content: |
+            .-----.
+            | .-. |
+            | |.| |
+            | `-' |
+            `-----'
 
+            Welcome to \S Live CD!
+            IP address \4
+            Login with user: root, password: elemental
+            Install the system with "elemental install".
+          permissions: 0644
+          owner: 0
+          group: 0


### PR DESCRIPTION
The other modes are covered in 03_branding.yaml, but not the live_mode.

This commit adds a short motd and hostname when booting from live CD.