### PR TITLE
Bootloader-in-rootfs=true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ build-iso:
 	mkdir -p $(ROOT_DIR)/build
 	$(DOCKER) run --rm -v $(DOCKER_SOCK):$(DOCKER_SOCK) -v $(ROOT_DIR)/build:/build \
 		-v $(ROOT_DIR)/tests/assets/remote_login.yaml:/overlay-iso/iso-config/remote_login.yaml \
-		--entrypoint /usr/bin/elemental $(TOOLKIT_REPO):$(VERSION) --debug build-iso --bootloader-in-rootfs \
+		--entrypoint /usr/bin/elemental $(TOOLKIT_REPO):$(VERSION) --debug build-iso \
 		-n elemental-$(FLAVOR).$(ARCH) --overlay-iso /overlay-iso \
 		--local --platform $(PLATFORM) -o /build $(REPO):$(VERSION)
 

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -141,7 +141,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().String("overlay-iso", "", "Path of the overlayed iso data")
 	c.Flags().String("label", "", "Label of the ISO volume")
 	c.Flags().String("extra-cmdline", "", fmt.Sprintf("Extra kernel cmdline (defaults to '%s')", constants.ISODefaultExtraCmdline))
-	c.Flags().Bool("bootloader-in-rootfs", true, "Fetch ISO bootloader binaries from the rootfs")
+	c.Flags().Bool("bootloader-in-rootfs", false, "Fetch ISO bootloader binaries from the rootfs")
 	c.Flags().Var(firmType, "firmware", "Firmware to install, only 'efi' is currently supported")
 	_ = c.Flags().MarkDeprecated("firmware", "'firmware' is deprecated. only efi firmware is supported.")
 	addPlatformFlags(c)

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -141,7 +141,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().String("overlay-iso", "", "Path of the overlayed iso data")
 	c.Flags().String("label", "", "Label of the ISO volume")
 	c.Flags().String("extra-cmdline", "", fmt.Sprintf("Extra kernel cmdline (defaults to '%s')", constants.ISODefaultExtraCmdline))
-	c.Flags().Bool("bootloader-in-rootfs", false, "Fetch ISO bootloader binaries from the rootfs")
+	c.Flags().Bool("bootloader-in-rootfs", true, "Fetch ISO bootloader binaries from the rootfs")
 	c.Flags().Var(firmType, "firmware", "Firmware to install, only 'efi' is currently supported")
 	_ = c.Flags().MarkDeprecated("firmware", "'firmware' is deprecated. only efi firmware is supported.")
 	addPlatformFlags(c)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -538,12 +538,13 @@ func NewDisk(cfg *types.BuildConfig) *types.DiskSpec {
 
 func NewISO() *types.LiveISO {
 	return &types.LiveISO{
-		Label:        constants.ISOLabel,
-		GrubEntry:    constants.GrubDefEntry,
-		UEFI:         []*types.ImageSource{},
-		Image:        []*types.ImageSource{},
-		Firmware:     types.EFI,
-		ExtraCmdline: constants.ISODefaultExtraCmdline,
+		Label:              constants.ISOLabel,
+		GrubEntry:          constants.GrubDefEntry,
+		UEFI:               []*types.ImageSource{},
+		Image:              []*types.ImageSource{},
+		BootloaderInRootFs: true,
+		Firmware:           types.EFI,
+		ExtraCmdline:       constants.ISODefaultExtraCmdline,
 	}
 }
 


### PR DESCRIPTION
Change the default value of bootloader-in-rootfs flag for build-iso
command to true.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
