### PR TITLE
Add extra-cmdline flag to build-iso command

### DIFF
--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -140,7 +140,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().String("overlay-uefi", "", "Path of the overlayed uefi data")
 	c.Flags().String("overlay-iso", "", "Path of the overlayed iso data")
 	c.Flags().String("label", "", "Label of the ISO volume")
-	c.Flags().String("extra-cmdline", constants.ISODefaultExtraCmdline, "Extra kernel cmdline")
+	c.Flags().String("extra-cmdline", "", fmt.Sprintf("Extra kernel cmdline (defaults to '%s')", constants.ISODefaultExtraCmdline))
 	c.Flags().Bool("bootloader-in-rootfs", false, "Fetch ISO bootloader binaries from the rootfs")
 	c.Flags().Var(firmType, "firmware", "Firmware to install, only 'efi' is currently supported")
 	_ = c.Flags().MarkDeprecated("firmware", "'firmware' is deprecated. only efi firmware is supported.")

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/rancher/elemental-toolkit/v2/cmd/config"
 	"github.com/rancher/elemental-toolkit/v2/pkg/action"
+	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
 	elementalError "github.com/rancher/elemental-toolkit/v2/pkg/error"
 	"github.com/rancher/elemental-toolkit/v2/pkg/types"
 	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
@@ -139,6 +140,7 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().String("overlay-uefi", "", "Path of the overlayed uefi data")
 	c.Flags().String("overlay-iso", "", "Path of the overlayed iso data")
 	c.Flags().String("label", "", "Label of the ISO volume")
+	c.Flags().String("extra-cmdline", constants.ISODefaultExtraCmdline, "Extra kernel cmdline")
 	c.Flags().Bool("bootloader-in-rootfs", false, "Fetch ISO bootloader binaries from the rootfs")
 	c.Flags().Var(firmType, "firmware", "Firmware to install, only 'efi' is currently supported")
 	_ = c.Flags().MarkDeprecated("firmware", "'firmware' is deprecated. only efi firmware is supported.")

--- a/pkg/action/build-iso.go
+++ b/pkg/action/build-iso.go
@@ -33,7 +33,7 @@ const (
 	isoBootCatalog = "/boot/boot.catalog"
 )
 
-func grubCfgTemplate(arch string) string {
+func grubCfgTemplate(arch, cmdline string) string {
 	return `search --no-floppy --file --set=root ` + constants.ISOKernelPath(arch) + `
 	set default=0
 	set timeout=5
@@ -42,7 +42,7 @@ func grubCfgTemplate(arch string) string {
 	menuentry "%s" --class os --unrestricted {
 		echo Loading kernel...
 		linux ($root)` + constants.ISOKernelPath(arch) + ` cdroot root=live:CDLABEL=%s rd.live.dir=` + constants.ISOLoaderPath(arch) +
-		`  rd.live.squashimg=rootfs.squashfs security=selinux enforcing=0 console=tty1 console=ttyS0 elemental.disable elemental.setup=` +
+		`  rd.live.squashimg=rootfs.squashfs ` + cmdline + ` elemental.disable elemental.setup=` +
 		constants.ISOCloudInitPath + `
 		echo Loading initrd...
 		initrd ($root)` + constants.ISOInitrdPath(arch) + `
@@ -222,7 +222,7 @@ func (b *BuildISOAction) renderGrubTemplate(rootDir string) error {
 	// Write grub.cfg file
 	return b.cfg.Fs.WriteFile(
 		filepath.Join(rootDir, constants.FallbackEFIPath, constants.GrubCfg),
-		[]byte(fmt.Sprintf(grubCfgTemplate(b.cfg.Platform.Arch), b.spec.GrubEntry, b.spec.Label)),
+		[]byte(fmt.Sprintf(grubCfgTemplate(b.cfg.Platform.Arch, b.spec.ExtraCmdline), b.spec.GrubEntry, b.spec.Label)),
 		constants.FilePerm,
 	)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -538,11 +538,12 @@ func NewDisk(cfg *types.BuildConfig) *types.DiskSpec {
 
 func NewISO() *types.LiveISO {
 	return &types.LiveISO{
-		Label:     constants.ISOLabel,
-		GrubEntry: constants.GrubDefEntry,
-		UEFI:      []*types.ImageSource{},
-		Image:     []*types.ImageSource{},
-		Firmware:  types.EFI,
+		Label:        constants.ISOLabel,
+		GrubEntry:    constants.GrubDefEntry,
+		UEFI:         []*types.ImageSource{},
+		Image:        []*types.ImageSource{},
+		Firmware:     types.EFI,
+		ExtraCmdline: constants.ISODefaultExtraCmdline,
 	}
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -148,10 +148,11 @@ const (
 	SELinuxRelabelDir          = "/run/systemd/relabel-extra.d"
 	SELinuxRelabelFile         = "elemental.relabel"
 
-	ISORootFile      = "rootfs.squashfs"
-	ISOEFIImg        = "uefi.img"
-	ISOLabel         = "COS_LIVE"
-	ISOCloudInitPath = LiveDir + "/iso-config"
+	ISORootFile            = "rootfs.squashfs"
+	ISOEFIImg              = "uefi.img"
+	ISOLabel               = "COS_LIVE"
+	ISOCloudInitPath       = LiveDir + "/iso-config"
+	ISODefaultExtraCmdline = "security=selinux enforcing=0 console=tty1 console=ttyS0"
 
 	MountLayoutPath = "/run/elemental/mount-layout.env"
 

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -689,6 +689,7 @@ type LiveISO struct {
 	GrubEntry          string         `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
 	BootloaderInRootFs bool           `yaml:"bootloader-in-rootfs" mapstructure:"bootloader-in-rootfs"`
 	Firmware           string         `yaml:"firmware,omitempty" mapstructure:"firmware"`
+	ExtraCmdline       string         `yaml:"extra-cmdline,omitempty" mapstructure:"extra-cmdline"`
 }
 
 // Sanitize checks the consistency of the struct, returns error


### PR DESCRIPTION
The extra-cmdline can be used to customize the kernel commandline used
for the ISO.

Some arbitrary flags were moved to the extra-cmdline in order to support
overriding security and consoles.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
