### PR TITLE
Move mount config file to /run/elemental

### DIFF
--- a/pkg/features/embedded/cloud-config-defaults/system/oem/00_layout.yaml
+++ b/pkg/features/embedded/cloud-config-defaults/system/oem/00_layout.yaml
@@ -11,7 +11,7 @@ stages:
     - if: '[ ! -f "/run/elemental/recovery_mode" ]'
       name: "Layout configuration"
       files:
-        - path: /etc/elemental/config.d/layout.yaml
+        - path: /run/elemental/config.d/layout.yaml
           content: |
             mount:
               ephemeral:

--- a/pkg/features/embedded/elemental-rootfs/etc/systemd/system/elemental-rootfs.service
+++ b/pkg/features/embedded/elemental-rootfs/etc/systemd/system/elemental-rootfs.service
@@ -13,7 +13,7 @@ Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=-/run/cos/cos-layout.env
 EnvironmentFile=-/run/elemental/mount-layout.env
-ExecStart=/usr/bin/elemental mount --debug
+ExecStart=/usr/bin/elemental --config-dir /run/elemental mount --debug
 
 [Install]
 WantedBy=initrd-fs.target


### PR DESCRIPTION
This makes possible to see the mount config file in  `initramfs` stage or even after switching root. Makes no functional difference but it can be handy specially for debugging.