### PR TITLE
Disable codecov/codecov-action

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -41,7 +41,3 @@ jobs:
           echo "mode: atomic" > coverage.out
           grep -v "mode: atomic" coverage.txt >> coverage.out
           grep -v "mode: atomic" coverage_root.txt >> coverage.out
-      - name: Codecov
-        uses: codecov/codecov-action@v3.1.1
-        with:
-          file: ./coverage.out


### PR DESCRIPTION
The codecov action is not allowed in the rancher namespace and needs a
token to run correctly, disabling for now.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
