### PR TITLE
Ensure SELinux relabelling can be disabled in configfile

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -253,7 +253,7 @@ func ReadInitSpec(r *types.RunConfig, flags *pflag.FlagSet) (*types.InitSpec, er
 }
 
 func ReadMountSpec(r *types.RunConfig, flags *pflag.FlagSet) (*types.MountSpec, error) {
-	mount := config.NewMountSpec()
+	mount := config.NewMountSpec(r.Config)
 
 	vp := viper.Sub("mount")
 	if vp == nil {
@@ -286,15 +286,6 @@ func ReadMountSpec(r *types.RunConfig, flags *pflag.FlagSet) (*types.MountSpec, 
 }
 
 func applyKernelCmdline(r *types.RunConfig, mount *types.MountSpec) error {
-	lsm, err := r.Config.Fs.ReadFile("/sys/kernel/security/lsm")
-	if err != nil {
-		r.Logger.Errorf("Error reading /sys/kernel/security/lsm: %s", err.Error())
-		return err
-	}
-	if strings.Contains(string(lsm), "selinux") {
-		mount.SelinuxRelabel = true
-	}
-
 	cmdline, err := r.Config.Fs.ReadFile("/proc/cmdline")
 	if err != nil {
 		r.Logger.Errorf("Error reading /proc/cmdline: %s", err.Error())

--- a/cmd/config/fixtures/simple/config.yaml
+++ b/cmd/config/fixtures/simple/config.yaml
@@ -18,3 +18,6 @@ snapshotter:
   config:
     fs: xfs
     size: 2000
+
+mount:
+  selinux-relabel: false


### PR DESCRIPTION
With this PR the mount command checks if SELinux is enabled in the Kernel to enable or disable relabeling before loading the config files. This way whatever is defined in config files will prevail over the runtime check. This allows to disable relabeling on systems using SELinux.