### PR TITLE
Use fake mounter in tests

### DIFF
--- a/pkg/action/init_test.go
+++ b/pkg/action/init_test.go
@@ -46,8 +46,10 @@ var _ = Describe("Init Action", func() {
 	var spec *types.InitSpec
 	var enabledUnits []string
 	var errCmd, initrdFile string
+	var mounter *mocks.FakeMounter
 
 	BeforeEach(func() {
+		mounter = mocks.NewFakeMounter()
 		runner = mocks.NewFakeRunner()
 		memLog = &bytes.Buffer{}
 		logger = types.NewBufferLogger(memLog)
@@ -56,6 +58,7 @@ var _ = Describe("Init Action", func() {
 		cfg = config.NewRunConfig(
 			config.WithFs(fs),
 			config.WithRunner(runner),
+			config.WithMounter(mounter),
 			config.WithLogger(logger),
 		)
 

--- a/pkg/bootloader/grub_test.go
+++ b/pkg/bootloader/grub_test.go
@@ -50,9 +50,11 @@ var _ = Describe("Booloader", Label("bootloader", "grub"), func() {
 	var grubCfg, osRelease []byte
 	var efivars eleefi.Variables
 	var relativeTo string
+	var mounter *mocks.FakeMounter
 
 	BeforeEach(func() {
 		logger = types.NewNullLogger()
+		mounter = mocks.NewFakeMounter()
 		fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{})
 		Expect(err).Should(BeNil())
 		runner = mocks.NewFakeRunner()
@@ -101,6 +103,7 @@ var _ = Describe("Booloader", Label("bootloader", "grub"), func() {
 		cfg = config.NewConfig(
 			config.WithLogger(logger),
 			config.WithRunner(runner),
+			config.WithMounter(mounter),
 			config.WithFs(fs),
 			config.WithPlatform("linux/amd64"),
 		)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 					config.WithSyscall(sysc),
 					config.WithLogger(logger),
 				)
-				Expect(c.Mounter).To(Equal(types.NewMounter(constants.MountBinary)))
+				Expect(c.Mounter).ToNot(BeNil())
 			})
 		})
 		Describe("RunConfig", func() {
@@ -347,7 +347,7 @@ var _ = Describe("Types", Label("types", "config"), func() {
 		})
 		Describe("BuildConfig", Label("build"), func() {
 			It("initiates a new build config", func() {
-				build := config.NewBuildConfig()
+				build := config.NewBuildConfig(config.WithMounter(mounter))
 				Expect(build.Name).To(Equal(constants.BuildImgName))
 			})
 		})

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -49,6 +49,7 @@ func PartitionAndFormatDevice(c types.Config, i *types.InstallSpec) error {
 		partitioner.WithRunner(c.Runner),
 		partitioner.WithFS(c.Fs),
 		partitioner.WithLogger(c.Logger),
+		partitioner.WithMounter(c.Mounter),
 	)
 
 	if !disk.Exists() {

--- a/pkg/partitioner/partitioner_test.go
+++ b/pkg/partitioner/partitioner_test.go
@@ -378,7 +378,7 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 		})
 		AfterEach(func() { cleanup() })
 		It("Creates a default disk", func() {
-			dev = part.NewDisk("/dev/device")
+			dev = part.NewDisk("/dev/device", part.WithMounter(mounter))
 		})
 		Describe("Load data without changes", func() {
 			BeforeEach(func() {
@@ -471,7 +471,7 @@ var _ = Describe("Partitioner", Label("disk", "partition", "partitioner"), func(
 				Expect(runner.CmdsMatch(cmds)).To(BeNil())
 			})
 			It("Does not find device for a given partition number", func() {
-				dev := part.NewDisk("/dev/lp0")
+				dev := part.NewDisk("/dev/lp0", part.WithMounter(mounter))
 				_, err := dev.FindPartitionDevice(4)
 				Expect(err).NotTo(BeNil())
 			})


### PR DESCRIPTION
This PR is just to use the fakemounter interface in some units tests where it was not initiated.

This prevent many dialogs asking for root password to appear when running tests in a desktop env do to the systemd integration of the default mounter.