### PR TITLE
[CI] Increase time between pull retries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ push-toolkit:
 pull-toolkit:
 	for retry in 1 2 3 4 5 ; do \
 		$(DOCKER) pull $(TOOLKIT_REPO):$(VERSION) && exit 0; \
-		sleep 5; \
+		sleep 30; \
 	done
 
 .PHONY: build-cli


### PR DESCRIPTION
There seams to be an issue with the nightly builds, looks like a sync issue between the build-toolkit and build-os jobs. Just seen few times in [nightly workflow](https://github.com/rancher/elemental-toolkit/actions/runs/9458768312/job/26054804761) which uses the same exact logic as the PR workflow.

Increasing the time between retries will not harm and hopefully give it a chance to ghcr.io to sync. With the change retries will span up to 2min before giving up.