### PR TITLE
gomod package manager does not support 'vendor' key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    vendor: true
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot is currently showing this error

`The property '#/updates/0/' contains additional properties ["vendor"] outside of the schema when none are allowed`

Moreover according to [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#vendor) we should not use the `vendor` key for `gomod` package manager