### PR TITLE
Use nightly tag for ghcr.io nightly builds

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -26,7 +26,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build toolkit
         run: |
-          make DOCKER_ARGS=--push build
+          make DOCKER_ARGS=--push VERSION=nightly build
 
   build-matrix:
     strategy:


### PR DESCRIPTION
> This should always replace the `latest` elemental-cli image when building from main.
> 
> This change is desirable so users can reliably pull the `latest` tag and not have to follow the commit tags that on the other hand seem excessive.
> 
> Instead of building an image per commit, we can think about re-instating GitHub releases and build images based on git tags.

Scratch the above, since these commit tags are needed for the PR tests on OBS.
Next best thing is to add a `nightly` tag.
