### PR TITLE
Do not rebuild OS Images nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,11 +27,3 @@ jobs:
       - name: Build toolkit
         run: |
           make DOCKER_ARGS=--push VERSION=nightly build
-
-  build-matrix:
-    strategy:
-      matrix:
-        flavor: ['green', 'blue', 'orange']
-    uses: ./.github/workflows/build_and_test_x86.yaml
-    with:
-      flavor: ${{ matrix.flavor }}


### PR DESCRIPTION
This part of the job fails due to missing `write` packages permission. 
Instead of fixing it, I think it can be removed since we don't care about rebuilding the OS images every night.