### PR TITLE
Add "meta-data" to userDataFiles string list Refers #2125

### DIFF
--- a/vendor/github.com/rancher-sandbox/linuxkit/providers/provider_cdrom.go
+++ b/vendor/github.com/rancher-sandbox/linuxkit/providers/provider_cdrom.go
@@ -28,7 +28,7 @@ import (
 // ListCDROMs lists all the cdroms in the system
 func ListCDROMs() []Provider {
 	// UserdataFiles is where to find the user data
-	var userdataFiles = []string{"user-data", "config"}
+	var userdataFiles = []string{"user-data", "meta-data", "config"}
 	cdroms, err := filepath.Glob(cdromDevs)
 	if err != nil {
 		// Glob can only error on invalid pattern


### PR DESCRIPTION
As suggested in the issue I've raised, this allows cloud-init on toolkit built images to pick up cloud config in files named "meta-data" such as the one Harvester provides instance data in.