### PR TITLE
Allow insecure registries

### DIFF
--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -86,7 +86,12 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				cfg.Logger.Errorf("failed to initialize build disk action: %v", err)
 				return err
 			}
-			return builder.BuildDiskRun()
+
+			err = builder.BuildDiskRun()
+			if err != nil {
+				cfg.Logger.Errorf("build-disk command failed: %v", err)
+			}
+			return err
 		},
 	}
 	root.AddCommand(c)

--- a/cmd/build-iso.go
+++ b/cmd/build-iso.go
@@ -126,7 +126,12 @@ func NewBuildISO(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 			}
 
 			buildISO := action.NewBuildISOAction(cfg, spec)
-			return buildISO.Run()
+			err = buildISO.Run()
+			if err != nil {
+				cfg.Logger.Errorf("build-iso command failed: %v", err)
+			}
+
+			return err
 		},
 	}
 

--- a/cmd/cloud-init.go
+++ b/cmd/cloud-init.go
@@ -62,6 +62,10 @@ func NewCloudInitCmd(root *cobra.Command) *cobra.Command {
 			}
 
 			err = cfg.CloudInitRunner.Run(stage, args...)
+			if err != nil {
+				cfg.Logger.Errorf("cloud-init command failed: %v")
+			}
+
 			return elementalError.NewFromError(err, elementalError.CloudInitRunStage)
 		},
 	}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -81,7 +81,7 @@ func addLocalImageFlag(cmd *cobra.Command) {
 
 // addVerifyRegistryFlag add local image flag shared between install, pull-image, upgrade
 func addTLSVerifyFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool("tls-verify", false, "Require HTTPS and verify certificates of registries (default: true)")
+	cmd.Flags().Bool("tls-verify", true, "Require HTTPS and verify certificates of registries (default: true)")
 }
 
 func adaptDockerImageAndDirectoryFlagsToSystem(flags *pflag.FlagSet) {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -58,6 +58,7 @@ func addResetFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("verify", false, "Enable mtree checksum verification (requires images manifests generated with mtree separately)")
 	cmd.Flags().Bool("strict", false, "Enable strict check of hooks (They need to exit with 0)")
 
+	addTLSVerifyFlag(cmd)
 	addSystemFlag(cmd)
 	addCosignFlags(cmd)
 	addPowerFlags(cmd)
@@ -76,6 +77,11 @@ func addRecoverySystemFlag(cmd *cobra.Command) {
 // addLocalImageFlag add local image flag shared between install, pull-image, upgrade
 func addLocalImageFlag(cmd *cobra.Command) {
 	cmd.Flags().Bool("local", false, "Use an image from local cache")
+}
+
+// addVerifyRegistryFlag add local image flag shared between install, pull-image, upgrade
+func addTLSVerifyFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool("tls-verify", false, "Require HTTPS and verify certificates of registries (default: true)")
 }
 
 func adaptDockerImageAndDirectoryFlagsToSystem(flags *pflag.FlagSet) {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -59,7 +59,11 @@ func InitCmd(root *cobra.Command) *cobra.Command {
 			}
 
 			cfg.Logger.Infof("Initializing system...")
-			return action.RunInit(cfg, spec)
+			err = action.RunInit(cfg, spec)
+			if err != nil {
+				cfg.Logger.Errorf("init command failed: %v", err)
+			}
+			return err
 		},
 	}
 	root.AddCommand(c)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -90,7 +90,11 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				cfg.Logger.Errorf("failed to initialize install action: %v", err)
 				return err
 			}
-			return install.Run()
+			err = install.Run()
+			if err != nil {
+				cfg.Logger.Errorf("install command failed: %v", err)
+			}
+			return err
 		},
 	}
 	firmType := newEnumFlag([]string{types.EFI}, types.EFI)

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -53,7 +53,12 @@ func NewMountCmd(root *cobra.Command) *cobra.Command {
 			}
 
 			cfg.Logger.Info("Mounting system...")
-			return action.RunMount(cfg, spec)
+			err = action.RunMount(cfg, spec)
+			if err != nil {
+				cfg.Logger.Errorf("mount command failed: %v", err)
+			}
+
+			return err
 		},
 	}
 	root.AddCommand(c)

--- a/cmd/pull-image.go
+++ b/cmd/pull-image.go
@@ -58,6 +58,12 @@ func NewPullImageCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				return elementalError.NewFromError(err, elementalError.ReadingBuildConfig)
 			}
 
+			verify, err := cmd.Flags().GetBool("tls-verify")
+			if err != nil {
+				cfg.Logger.Errorf("Invalid tls-verify-flag %s", err.Error())
+				return elementalError.NewFromError(err, elementalError.ReadingBuildConfig)
+			}
+
 			// Set this after parsing of the flags, so it fails on parsing and prints usage properly
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true // Do not propagate errors down the line, we control them
@@ -66,7 +72,7 @@ func NewPullImageCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 
 			var digest string
 			e := types.OCIImageExtractor{}
-			if digest, err = e.ExtractImage(image, destination, cfg.Platform.String(), local); err != nil {
+			if digest, err = e.ExtractImage(image, destination, cfg.Platform.String(), local, verify); err != nil {
 				cfg.Logger.Error(err.Error())
 				return elementalError.NewFromError(err, elementalError.UnpackImage)
 			}
@@ -79,6 +85,7 @@ func NewPullImageCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	root.AddCommand(c)
 	addPlatformFlags(c)
 	addLocalImageFlag(c)
+	addTLSVerifyFlag(c)
 	return c
 }
 

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -72,7 +72,13 @@ func NewResetCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				cfg.Logger.Errorf("failed to initialize reset action: %v", err)
 				return err
 			}
-			return reset.Run()
+
+			err = reset.Run()
+			if err != nil {
+				cfg.Logger.Errorf("reset command failed: %v", err)
+			}
+
+			return err
 		},
 	}
 	root.AddCommand(c)

--- a/cmd/upgrade-recovery.go
+++ b/cmd/upgrade-recovery.go
@@ -73,7 +73,12 @@ func NewUpgradeRecoveryCmd(root *cobra.Command, addCheckRoot bool) *cobra.Comman
 				return err
 			}
 
-			return upgrade.Run()
+			err = upgrade.Run()
+			if err != nil {
+				cfg.Logger.Errorf("upgrade-recovery command failed: %v", err)
+			}
+
+			return err
 		},
 	}
 	root.AddCommand(c)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -81,7 +81,12 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 				return err
 			}
 
-			return upgrade.Run()
+			err = upgrade.Run()
+			if err != nil {
+				cfg.Logger.Errorf("upgrade command failed: %v", err)
+			}
+
+			return err
 		},
 	}
 	root.AddCommand(c)

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Build Actions", func() {
 			rootSrc, _ := types.NewSrcFromURI("oci:elementalos:latest")
 			iso.RootFS = []*types.ImageSource{rootSrc}
 
-			extractor.SideEffect = func(_, destination, platform string, _ bool) (string, error) {
+			extractor.SideEffect = func(_, destination, platform string, _, _ bool) (string, error) {
 				bootDir := filepath.Join(destination, "boot")
 				logger.Debugf("Creating %s", bootDir)
 				err := utils.MkdirAll(fs, bootDir, constants.DirPerm)

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -279,7 +279,7 @@ func (u *UpgradeAction) Run() (err error) {
 	// Deploy system image
 	err = elemental.MirrorRoot(u.cfg.Config, u.snapshot.WorkDir, u.spec.System)
 	if err != nil {
-		u.cfg.Logger.Errorf("failed deploying source: %s", u.spec.System.String())
+		u.cfg.Logger.Errorf("failed deploying source '%s': %v", u.spec.System.String(), err)
 		return elementalError.NewFromError(err, elementalError.DumpSource)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -127,6 +127,7 @@ func NewConfig(opts ...GenericOptions) *types.Config {
 		Client:                    http.NewClient(),
 		Platform:                  defaultPlatform,
 		SquashFsCompressionConfig: constants.GetDefaultSquashfsCompressionOptions(),
+		TLSVerify:                 true,
 	}
 	for _, o := range opts {
 		err := o(c)

--- a/pkg/elemental/elemental.go
+++ b/pkg/elemental/elemental.go
@@ -579,7 +579,7 @@ func DumpSource(
 			}
 		}
 
-		digest, err = c.ImageExtractor.ExtractImage(imgSrc.Value(), target, c.Platform.String(), c.LocalImage)
+		digest, err = c.ImageExtractor.ExtractImage(imgSrc.Value(), target, c.Platform.String(), c.LocalImage, c.Verify)
 		if err != nil {
 			return err
 		}

--- a/pkg/elemental/elemental_test.go
+++ b/pkg/elemental/elemental_test.go
@@ -609,7 +609,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 		})
 		It("Fails to unpack a docker image to target", Label("docker"), func() {
 			unpackErr := errors.New("failed to unpack")
-			extractor.SideEffect = func(_, _, _ string, _ bool) (string, error) { return "", unpackErr }
+			extractor.SideEffect = func(_, _, _ string, _, _ bool) (string, error) { return "", unpackErr }
 			err := elemental.DumpSource(*config, destDir, types.NewDockerSrc("docker/image:latest"), nil)
 			Expect(err).To(Equal(unpackErr))
 		})
@@ -936,7 +936,7 @@ var _ = Describe("Elemental", Label("elemental"), func() {
 	})
 	Describe("DeployRecoverySystem", Label("recovery"), func() {
 		BeforeEach(func() {
-			extractor.SideEffect = func(_, destination, platform string, _ bool) (string, error) {
+			extractor.SideEffect = func(_, destination, platform string, _, _ bool) (string, error) {
 				bootDir := filepath.Join(destination, "boot")
 				logger.Debugf("Creating %s", bootDir)
 				err := utils.MkdirAll(fs, bootDir, constants.DirPerm)

--- a/pkg/mocks/extractor_mock.go
+++ b/pkg/mocks/extractor_mock.go
@@ -33,7 +33,7 @@ func NewFakeImageExtractor(logger types.Logger) *FakeImageExtractor {
 	}
 }
 
-func (f FakeImageExtractor) ExtractImage(imageRef, destination, platformRef string, local bool) (string, error) {
+func (f FakeImageExtractor) ExtractImage(imageRef, destination, platformRef string, local bool, verify bool) (string, error) {
 	f.Logger.Debugf("extracting %s to %s in platform %s", imageRef, destination, platformRef)
 	if f.SideEffect != nil {
 		f.Logger.Debugf("running sideeffect")

--- a/pkg/mocks/extractor_mock.go
+++ b/pkg/mocks/extractor_mock.go
@@ -22,7 +22,7 @@ const FakeDigest = "fakeDigest"
 
 type FakeImageExtractor struct {
 	Logger     types.Logger
-	SideEffect func(imageRef, destination, platformRef string, local bool) (string, error)
+	SideEffect func(imageRef, destination, platformRef string, local bool, verify bool) (string, error)
 }
 
 var _ types.ImageExtractor = FakeImageExtractor{}
@@ -37,7 +37,7 @@ func (f FakeImageExtractor) ExtractImage(imageRef, destination, platformRef stri
 	f.Logger.Debugf("extracting %s to %s in platform %s", imageRef, destination, platformRef)
 	if f.SideEffect != nil {
 		f.Logger.Debugf("running sideeffect")
-		return f.SideEffect(imageRef, destination, platformRef, local)
+		return f.SideEffect(imageRef, destination, platformRef, local, verify)
 	}
 
 	return FakeDigest, nil

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	Platform                  *Platform `yaml:"platform,omitempty" mapstructure:"platform"`
 	Cosign                    bool      `yaml:"cosign,omitempty" mapstructure:"cosign"`
 	Verify                    bool      `yaml:"verify,omitempty" mapstructure:"verify"`
+	TLSVerify                 bool      `yaml:"tls-verify,omitempty" mapstructure:"tls-verify"`
 	CosignPubKey              string    `yaml:"cosign-key,omitempty" mapstructure:"cosign-key"`
 	LocalImage                bool      `yaml:"local,omitempty" mapstructure:"local"`
 	Arch                      string    `yaml:"arch,omitempty" mapstructure:"arch"`

--- a/pkg/types/image.go
+++ b/pkg/types/image.go
@@ -32,20 +32,25 @@ import (
 )
 
 type ImageExtractor interface {
-	ExtractImage(imageRef, destination, platformRef string, local bool) (string, error)
+	ExtractImage(imageRef, destination, platformRef string, local bool, verify bool) (string, error)
 }
 
 type OCIImageExtractor struct{}
 
 var _ ImageExtractor = OCIImageExtractor{}
 
-func (e OCIImageExtractor) ExtractImage(imageRef, destination, platformRef string, local bool) (string, error) {
+func (e OCIImageExtractor) ExtractImage(imageRef, destination, platformRef string, local bool, verify bool) (string, error) {
 	platform, err := containerregistry.ParsePlatform(platformRef)
 	if err != nil {
 		return "", err
 	}
 
-	ref, err := name.ParseReference(imageRef)
+	opts := []name.Option{}
+	if !verify {
+		opts = append(opts, name.Insecure)
+	}
+
+	ref, err := name.ParseReference(imageRef, opts...)
 	if err != nil {
 		return "", err
 	}

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -49,10 +49,9 @@ var _ = Describe("Elemental Feature tests", func() {
 
 			By(fmt.Sprintf("and upgrading to %s", comm.UpgradeImage()))
 
-			upgradeCmd := s.ElementalCmd("upgrade", "--tls-verify=false", "--bootloader", "--system", comm.UpgradeImage())
+			upgradeCmd := s.ElementalCmd("upgrade", "--bootloader", "--system", comm.UpgradeImage())
 			out, err := s.NewPodmanRunCommand(comm.ToolkitImage(), fmt.Sprintf("-c \"mount --rbind /host/run /run && %s\"", upgradeCmd)).
 				Privileged().
-				NoTLSVerify().
 				WithMount("/", "/host").
 				Run()
 

--- a/tests/upgrade/upgrade_test.go
+++ b/tests/upgrade/upgrade_test.go
@@ -49,9 +49,10 @@ var _ = Describe("Elemental Feature tests", func() {
 
 			By(fmt.Sprintf("and upgrading to %s", comm.UpgradeImage()))
 
-			upgradeCmd := s.ElementalCmd("upgrade", "--bootloader", "--system", comm.UpgradeImage())
+			upgradeCmd := s.ElementalCmd("upgrade", "--tls-verify=false", "--bootloader", "--system", comm.UpgradeImage())
 			out, err := s.NewPodmanRunCommand(comm.ToolkitImage(), fmt.Sprintf("-c \"mount --rbind /host/run /run && %s\"", upgradeCmd)).
 				Privileged().
+				NoTLSVerify().
 				WithMount("/", "/host").
 				Run()
 

--- a/tests/vm/podman.go
+++ b/tests/vm/podman.go
@@ -26,6 +26,7 @@ import (
 type PodmanRunCommand struct {
 	sut        *SUT
 	privileged bool
+	tlsVerify  bool
 	image      string
 	mounts     []VolumeMount
 	entrypoint string
@@ -42,6 +43,11 @@ func (p *PodmanRunCommand) Privileged() *PodmanRunCommand {
 	return p
 }
 
+func (p *PodmanRunCommand) NoTLSVerify() *PodmanRunCommand {
+	p.tlsVerify = false
+	return p
+}
+
 func (p *PodmanRunCommand) WithMount(from, to string) *PodmanRunCommand {
 	p.mounts = append(p.mounts, VolumeMount{from: from, to: to})
 	return p
@@ -51,6 +57,11 @@ func (p *PodmanRunCommand) Run() (string, error) {
 	priv := ""
 	if p.privileged {
 		priv = "--privileged"
+	}
+
+	tlsVerify := ""
+	if !p.tlsVerify {
+		tlsVerify = "--tls-verify=false"
 	}
 
 	mounts := []string{}
@@ -63,7 +74,7 @@ func (p *PodmanRunCommand) Run() (string, error) {
 		entrypoint = fmt.Sprintf("--entrypoint=%s", p.entrypoint)
 	}
 
-	cmd := fmt.Sprintf("podman run %s %s %s %s %s", priv, strings.Join(mounts, " "), entrypoint, p.image, p.command)
+	cmd := fmt.Sprintf("podman run %s %s %s %s %s %s", tlsVerify, priv, strings.Join(mounts, " "), entrypoint, p.image, p.command)
 	By(fmt.Sprintf("Running podman command: '%s'", cmd))
 	return p.sut.Command(cmd)
 }

--- a/tests/vm/sut.go
+++ b/tests/vm/sut.go
@@ -309,6 +309,7 @@ func (s *SUT) IsVMRunning() bool {
 
 func (s *SUT) NewPodmanRunCommand(image, command string) *PodmanRunCommand {
 	return &PodmanRunCommand{
+		tlsVerify:  true,
 		sut:        s,
 		image:      image,
 		entrypoint: "/bin/bash",


### PR DESCRIPTION
This PR allows to pull images from insecure registries with the flag `--tls-verify`. 

Part of #2132