### PR TITLE
Fix workflows, permissions at top level

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,10 @@ on:
       - go.sum
       - examples/**
 
+permissions:
+  content: read
+  pull-requests: read
+
 jobs:
   permissions:
     content: read

--- a/.github/workflows/build_and_test_arm.yaml
+++ b/.github/workflows/build_and_test_arm.yaml
@@ -14,10 +14,11 @@ concurrency:
   group: ci-${{ inputs.flavor }}-aarch64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
-jobs:
+permissions:
+  content: read
+  pull-requests: read
 
-  permissions:
-    content: read
+jobs:
   build-iso:
     needs: detect
     runs-on: [self-hosted, arm64]

--- a/.github/workflows/build_and_test_x86.yaml
+++ b/.github/workflows/build_and_test_x86.yaml
@@ -11,9 +11,11 @@ concurrency:
   group: ci-${{ inputs.flavor }}-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
+permissions:
+  content: read
+  pull-requests: read
+
 jobs:
-  permissions:
-      content: read
   build-os:
     permissions:
       packages: write

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -14,9 +14,12 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  content: read
+  pull-requests: read
+
 jobs:
-  permissions:
-    content: read
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -8,9 +8,12 @@ on:
       - main
   schedule:
    - cron: 0 20 * * *
+
+permissions:
+  content: read
+  pull-requests: read
+
 jobs:
-  permissions:
-    content: read
   build-deploy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is fixing https://github.com/rancher/elemental-toolkit/pull/2129 which introduced a syntax error, permissions should be at the very top level. See [error](https://github.com/rancher/elemental-toolkit/actions/runs/9843930952)

In addition it is also adding permissions to read PRs, to my understanding this is required to allow GHA runs on PRs from forks.