### PR TITLE
Fix nested permissions definition

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,12 +19,10 @@ on:
       - go.sum
       - examples/**
 
-permissions:
-  content: read
-  pull-requests: read
-
 jobs:
   detect:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       flavor: ${{ steps.set-matrix.outputs.flavor }}
@@ -42,10 +40,11 @@ jobs:
         fi
 
   build-toolkit:
-    needs:
-      - detect
     permissions:
       packages: write
+      contents: read
+    needs:
+      - detect
     runs-on: ubuntu-latest
     env:
       PLATFORM: ${{ needs.detect.outputs.platform }}

--- a/.github/workflows/build_and_test_arm.yaml
+++ b/.github/workflows/build_and_test_arm.yaml
@@ -15,8 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  content: read
-  pull-requests: read
+  contents: read
 
 jobs:
   build-iso:

--- a/.github/workflows/build_and_test_x86.yaml
+++ b/.github/workflows/build_and_test_x86.yaml
@@ -11,14 +11,11 @@ concurrency:
   group: ci-${{ inputs.flavor }}-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 
-permissions:
-  content: read
-  pull-requests: read
-
 jobs:
   build-os:
     permissions:
       packages: write
+      contents: read
     runs-on: ubuntu-latest
     env:
       FLAVOR: ${{ inputs.flavor }}
@@ -44,6 +41,8 @@ jobs:
           make ARCH=${{ env.ARCH }} DOCKER_ARGS=--push build-os
 
   build-iso:
+    permissions:
+      contents: read
     needs: 
       - build-os
     runs-on: ubuntu-latest
@@ -86,6 +85,8 @@ jobs:
           enableCrossOsArchive: true
 
   build-disk:
+    permissions:
+      contents: read
     needs:
       - build-os
     runs-on: ubuntu-latest
@@ -135,6 +136,8 @@ jobs:
           enableCrossOsArchive: true
 
   detect:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps.detect.outputs.tests }}
@@ -165,6 +168,8 @@ jobs:
           echo "toolkit=ghcr.io/rancher/elemental-toolkit/elemental-cli:${VERSION}" >> $GITHUB_OUTPUT
 
   tests-matrix:
+    permissions:
+      contents: read
     needs:
       - build-disk
       - detect
@@ -238,6 +243,8 @@ jobs:
           make test-clean
 
   test-installer:
+    permissions:
+      contents: read
     needs:
       - build-iso
       - detect

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -16,8 +16,7 @@ on:
       - main
 
 permissions:
-  content: read
-  pull-requests: read
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -10,8 +10,7 @@ on:
    - cron: 0 20 * * *
 
 permissions:
-  content: read
-  pull-requests: read
+  contents: read
 
 jobs:
   build-deploy:


### PR DESCRIPTION
Top level permissions can't be increased for specific jobs, hence setting the permission on each specific job on workflows that require more fine grain approach.

In addition it removes the pull-request permission as this is mostly required for PR decorators, read/write labels, etc.