### PR TITLE
Expose ELEMENTAL_CLOUD_INIT_PATHS option

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -119,6 +119,7 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().Bool("eject-cd", false, "Try to eject the cd on reboot, only valid if booting from iso")
 	c.Flags().Bool("disable-boot-entry", false, "Dont create an EFI entry for the system install.")
 	c.Flags().Var(snapshotterType, "snapshotter.type", "Sets the snapshotter type to install")
+	c.Flags().StringSlice("cloud-init-paths", []string{}, "Cloud-init config files to run during install")
 	addSharedInstallUpgradeFlags(c)
 	addLocalImageFlag(c)
 	addPlatformFlags(c)

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -86,7 +86,7 @@ func NewResetCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().BoolP("reset-persistent", "", false, "Clear persistent partitions")
 	c.Flags().BoolP("reset-oem", "", false, "Clear OEM partitions")
 	c.Flags().Bool("disable-boot-entry", false, "Dont create an EFI entry for the system install.")
-
+	c.Flags().StringSlice("cloud-init-paths", []string{}, "Cloud-init config files to run during reset")
 	addResetFlags(c)
 	return c
 }

--- a/cmd/run-stage.go
+++ b/cmd/run-stage.go
@@ -44,6 +44,7 @@ func NewRunStage(root *cobra.Command) *cobra.Command {
 	}
 	root.AddCommand(c)
 	c.Flags().Bool("strict", false, "Set strict checking for errors, i.e. fail if errors were found")
+	c.Flags().StringSlice("cloud-init-paths", []string{}, "Cloud-init config files to run")
 	return c
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -92,6 +92,7 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	root.AddCommand(c)
 	c.Flags().Bool("recovery", false, "Upgrade recovery image too")
 	c.Flags().Bool("bootloader", false, "Reinstall bootloader during the upgrade")
+	c.Flags().StringSlice("cloud-init-paths", []string{}, "Cloud-init config files to run during upgrade")
 	addSharedInstallUpgradeFlags(c)
 	addLocalImageFlag(c)
 	return c

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -287,6 +287,7 @@ func GetRunKeyEnvMap() map[string]string {
 		"strict":           "STRICT",
 		"eject-cd":         "EJECT_CD",
 		"snapshotter.type": "SNAPSHOTTER_TYPE",
+		"cloud-init-paths": "CLOUD_INIT_PATHS",
 	}
 }
 

--- a/pkg/snapshotter/btrfs.go
+++ b/pkg/snapshotter/btrfs.go
@@ -125,7 +125,7 @@ func newBtrfsSnapshotter(cfg types.Config, snapCfg types.SnapshotterConfig, boot
 		if !ok {
 			msg := "failed casting BtrfsConfig type"
 			cfg.Logger.Errorf(msg)
-			return nil, fmt.Errorf(msg)
+			return nil, fmt.Errorf("%s", msg)
 		}
 	}
 	return &Btrfs{
@@ -458,7 +458,7 @@ func (b *Btrfs) SnapshotToImageSource(snap *types.Snapshot) (*types.ImageSource,
 		msg := fmt.Sprintf("snapshot path does not exist: %s.", snap.Path)
 		b.cfg.Logger.Errorf(msg)
 		if err == nil {
-			err = fmt.Errorf(msg)
+			err = fmt.Errorf("%s", msg)
 		}
 		return nil, err
 	}

--- a/pkg/snapshotter/loopdevice.go
+++ b/pkg/snapshotter/loopdevice.go
@@ -71,7 +71,7 @@ func newLoopDeviceSnapshotter(cfg types.Config, snapCfg types.SnapshotterConfig,
 		if !ok {
 			msg := "failed casting LoopDeviceConfig type"
 			cfg.Logger.Errorf(msg)
-			return nil, fmt.Errorf(msg)
+			return nil, fmt.Errorf("%s", msg)
 		}
 	}
 	return &LoopDevice{cfg: cfg, snapshotterCfg: snapCfg, loopDevCfg: *loopDevCfg, bootloader: bootloader}, nil
@@ -363,7 +363,7 @@ func (l *LoopDevice) SnapshotToImageSource(snap *types.Snapshot) (*types.ImageSo
 		msg := fmt.Sprintf("snapshot path does not exist: %s.", snap.Path)
 		l.cfg.Logger.Errorf(msg)
 		if err == nil {
-			err = fmt.Errorf(msg)
+			err = fmt.Errorf("%s", msg)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
This adds the `--cloud-init-paths` argument for all `elemental` cli subcommands. This was previously added only for `build-disk`, but I find it useful in all other cases.

The `ELEMENTAL_CLOUD_INIT_PATHS` env variable is also added to achieve the same effect.

The reason to introduce this feature is to address corner cases when using `after-install` and `after-reset`, especially the latter since in the default Elemental images, `/system/oem` and `/usr/local/cloud-config` are read only, and `/oem` is going to be formatted before being evaluated.

Having a dynamic path to be evaluated at run time allows for more freedom.

This is also an enabler for https://github.com/rancher/elemental-operator/issues/806