### PR TITLE
Add correlation_id grub env to upgraded system

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -93,6 +93,7 @@ func NewUpgradeCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().Bool("recovery", false, "Upgrade recovery image too")
 	c.Flags().Bool("bootloader", false, "Reinstall bootloader during the upgrade")
 	c.Flags().StringSlice("cloud-init-paths", []string{}, "Cloud-init config files to run during upgrade")
+	c.Flags().String("correlation-id", "", "A correlation ID that will be applied to the upgraded system")
 	addSharedInstallUpgradeFlags(c)
 	addLocalImageFlag(c)
 	return c

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -293,6 +293,7 @@ func (u *UpgradeAction) Run() (err error) {
 
 	// Closing snapshotter transaction
 	u.cfg.Logger.Info("Closing snapshotter transaction")
+	u.snapshot.CorrelationID = u.spec.CorrelationID
 	err = u.snapshotter.CloseTransaction(u.snapshot)
 	if err != nil {
 		u.cfg.Logger.Errorf("failed closing snapshot transaction: %v", err)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -89,6 +89,7 @@ const (
 	GrubDefEntry           = "Elemental"
 	GrubFallback           = "default_fallback"
 	GrubPassiveSnapshots   = "passive_snaps"
+	CorrelationID          = "correlation_id"
 	ElementalBootloaderBin = "/usr/lib/elemental/bootloader"
 
 	// Mountpoints of images and partitions
@@ -341,6 +342,7 @@ func GetUpgradeKeyEnvMap() map[string]string {
 		"recovery":            "RECOVERY",
 		"system":              "SYSTEM",
 		"recovery-system.uri": "RECOVERY_SYSTEM",
+		"correlation-id":      "CORRELATION_ID",
 	}
 }
 

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -373,6 +373,7 @@ type UpgradeSpec struct {
 	RecoverySystem    Image        `yaml:"recovery-system,omitempty" mapstructure:"recovery-system"`
 	GrubDefEntry      string       `yaml:"grub-entry-name,omitempty" mapstructure:"grub-entry-name"`
 	BootloaderUpgrade bool         `yaml:"bootloader,omitempty" mapstructure:"bootloader"`
+	CorrelationID     string       `yaml:"correlation-id,omitempty" mapstructure:"correlation-id"`
 	Partitions        ElementalPartitions
 	State             *InstallState
 }

--- a/pkg/types/snapshotter.go
+++ b/pkg/types/snapshotter.go
@@ -41,12 +41,13 @@ type SnapshotterConfig struct {
 }
 
 type Snapshot struct {
-	ID         int
-	MountPoint string
-	Path       string
-	WorkDir    string
-	Label      string
-	InProgress bool
+	ID            int
+	MountPoint    string
+	Path          string
+	WorkDir       string
+	Label         string
+	InProgress    bool
+	CorrelationID string
 }
 
 type LoopDeviceConfig struct {


### PR DESCRIPTION
This is an enabler for https://github.com/rancher/elemental/issues/1103

The idea is that the CAPI elemental plugin will be able to set a correlation id when upgrading the system. 
The correlation id is then used to determine whether the system needs to be upgraded or not by fetching the current `correlation_id`, if any, from `/run/elemental/efi/grub_oem_env`.

Not sure how good this is, so just a draft PR to start a discussion.
Documentation should also be updated eventually.