### PR TITLE
Disable network in initrd and disable selinux

### DIFF
--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -78,7 +78,7 @@ RUN systemctl enable NetworkManager.service && \
 RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
 
 # SELinux in enforce mode
-RUN sed -i "s|SELINUX=.*|SELINUX=enforcing|g" /etc/selinux/config
+#RUN sed -i "s|SELINUX=.*|SELINUX=enforcing|g" /etc/selinux/config
 
 # Add default snapshotter setup
 ADD snapshotter.yaml /etc/elemental/config.d/snapshotter.yaml

--- a/pkg/features/embedded/cloud-config-defaults/system/oem/00_layout.yaml
+++ b/pkg/features/embedded/cloud-config-defaults/system/oem/00_layout.yaml
@@ -8,8 +8,8 @@
 name: "Rootfs Layout Settings"
 stages:
   rootfs:
-    - if: '[ ! -f "/run/elemental/recovery_mode" ]'
-      name: "Layout configuration"
+    - if: '[ -f "/run/elemental/recovery_mode" ]'
+      name: "Layout configuration for recovery"
       files:
         - path: /run/elemental/config.d/layout.yaml
           content: |
@@ -17,3 +17,4 @@ stages:
               ephemeral:
                 type: tmpfs
                 size: 25%
+                paths: ['/srv', '/etc', '/var', '/root']

--- a/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
+++ b/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
@@ -15,12 +15,12 @@ if [ -n "${img}" ]; then
 fi
 
 if [ "${mode}" == "recovery" ]; then
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} security=selinux enforcing=0 rd.neednet=1"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${recovery_label} ${img_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} security=selinux enforcing=0"
 else
   if [ "${snapshotter}" == "btrfs" ]; then
     set snap_arg="elemental.snapshotter=btrfs"
   fi
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} panic=5 security=selinux rd.neednet=1 fsck.mode=force fsck.repair=yes"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} panic=5 security=selinux fsck.mode=force fsck.repair=yes"
 fi
 
 set kernel=/boot/vmlinuz

--- a/tests/common/common.go
+++ b/tests/common/common.go
@@ -20,8 +20,8 @@ import (
 	"flag"
 )
 
-const DefaultUpgradeImage = "ghcr.io/rancher/elemental-toolkit/elemental-green:v2.0.0"
-const DefaultToolkitImage = "ghcr.io/rancher/elemental-toolkit/elemental-cli:v2.0.0"
+const DefaultUpgradeImage = "ghcr.io/rancher/elemental-toolkit/elemental-green:v2.1.1"
+const DefaultToolkitImage = "ghcr.io/rancher/elemental-toolkit/elemental-cli:v2.1.1"
 
 var upgradeImage string
 var toolkitImage string

--- a/tests/recovery/recovery_test.go
+++ b/tests/recovery/recovery_test.go
@@ -70,14 +70,17 @@ var _ = Describe("Elemental Recovery upgrade tests", func() {
 
 			upgradedVersion := s.GetOSRelease("TIMESTAMP")
 			Expect(upgradedVersion).ToNot(Equal(currentVersion))
+			s.Reset()
+			s.EventuallyBootedFrom(sut.Active)
 		})
 	})
 
 	// After this test, the VM is no longer in its initial state!!
 	Context("upgrading recovery", func() {
 		When("using specific images", func() {
-			It("upgrades to a specific image and reset back to the installed version", Label("third-test"), func() {
-				By(fmt.Sprintf("upgrading to %s", comm.UpgradeImage()))
+			It("upgrades to a specific image", func() {
+				Expect(s.BootFrom()).To(Equal(sut.Active))
+				By(fmt.Sprintf("upgrading recovery to %s", comm.UpgradeImage()))
 				cmd := s.ElementalCmd("upgrade-recovery", "--recovery-system.uri", comm.UpgradeImage())
 				By(fmt.Sprintf("running %s", cmd))
 				out, err := s.Command(cmd)


### PR DESCRIPTION
This PR includes three independent changes (and a commit for each):

1. Disables enforce mode for SELINUX. Dbus service in green example started to fail due to some SELINUX denials. Until this is fixed and further analyzed we switch to permissive mode.
2. Fixes the recovery tests, we realized they were not testing the right system, upgrading recovery was performed from a downgraded system as a result of the previous test.
3. Disables network setup in initrd. This turned to be buggy lately, despite not causing an explicit failure it causes the system to be stuck for around 90s at boot (probably related to this issue: https://github.com/dracutdevs/dracut/issues/2378 ), this can be seen on CI tests timing, as suddenly tests started to last way longer, compare the timing in this [run](https://github.com/rancher/elemental-toolkit/actions/runs/10704464931) and this other [one](https://github.com/rancher/elemental-toolkit/actions/runs/10705828157) without NM in initrd.

All of them are currenltye required to turn the CI back to green with the expected performance.