### PR TITLE
Try to remove old workflows from github

### DIFF
--- a/.github/workflows/build-main-blue-x86_64.yaml
+++ b/.github/workflows/build-main-blue-x86_64.yaml
@@ -1,0 +1,8 @@
+name: main-blue-x86_64
+on: push
+jobs:
+  my-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: my-step
+        run: echo "Hello World!"

--- a/.github/workflows/build-main-green-x86_64.yaml
+++ b/.github/workflows/build-main-green-x86_64.yaml
@@ -1,0 +1,8 @@
+name: main-green-x86_64
+on: push
+jobs:
+  my-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: my-step
+        run: echo "Hello World!"

--- a/.github/workflows/build-main-orange-x86_64.yaml
+++ b/.github/workflows/build-main-orange-x86_64.yaml
@@ -1,0 +1,8 @@
+name: main-orange-x86_64
+on: push
+jobs:
+  my-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: my-step
+        run: echo "Hello World!"

--- a/.github/workflows/build-main-teal-x86_64.yaml
+++ b/.github/workflows/build-main-teal-x86_64.yaml
@@ -1,0 +1,8 @@
+name: main-teal-x86_64
+on: push
+jobs:
+  my-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: my-step
+        run: echo "Hello World!"


### PR DESCRIPTION
Github finds security issues in old workflows that are no longer used
and do not exist in main branch.

This commit adds back the build-* workflows to try and overwrite the
workflow runs and remove the security issues.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
