### PR TITLE
 Add cloud-init paths of the new root in 'after-*' hooks

### DIFF
--- a/examples/green-rpi/01_rpi-firmware.yaml
+++ b/examples/green-rpi/01_rpi-firmware.yaml
@@ -1,7 +1,0 @@
-name: "Raspberry Pi post disk hook"
-stages:
-    after-disk:
-    - &copyfirmware
-      name: "Copy firmware to EFI partition"
-      commands:
-      - cp -r /build/build/recovery.img.root/boot/vc/* /build/build/efi/

--- a/examples/green-rpi/Dockerfile
+++ b/examples/green-rpi/Dockerfile
@@ -55,7 +55,17 @@ COPY --from=TOOLKIT /usr/bin/elemental /usr/bin/elemental
 RUN systemctl enable NetworkManager.service
 
 # Generate initrd with required elemental services
-RUN elemental --debug init --force
+RUN elemental --debug init --force \
+      elemental-rootfs \
+      elemental-sysroot \
+      grub-config \
+      grub-default-bootargs \
+      elemental-setup \
+      dracut-config \
+      cloud-config-defaults \
+      cloud-config-essentials \
+      boot-assessment \
+      arm-firmware
 
 # Update os-release file with some metadata
 RUN echo IMAGE_REPO=\"${REPO}\"         >> /etc/os-release && \

--- a/examples/green-rpi/Dockerfile
+++ b/examples/green-rpi/Dockerfile
@@ -55,12 +55,7 @@ COPY --from=TOOLKIT /usr/bin/elemental /usr/bin/elemental
 RUN systemctl enable NetworkManager.service
 
 # Generate initrd with required elemental services
-RUN elemental init -f && \
-    kernel=$(ls /boot/Image-* | head -n1) && \
-    if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi && \
-    rm -rf /var/log/update* && \
-    >/var/log/lastlog && \
-    rm -rf /boot/vmlinux*
+RUN elemental --debug init --force
 
 # Update os-release file with some metadata
 RUN echo IMAGE_REPO=\"${REPO}\"         >> /etc/os-release && \

--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -76,6 +76,8 @@ var _ = Describe("Build Actions", func() {
 			config.WithImageExtractor(extractor),
 			config.WithPlatform("linux/amd64"),
 		)
+		// build-disk will create `/run/elemental-build` and assumes /run to exist
+		Expect(utils.MkdirAll(fs, "/run", constants.DirPerm)).To(Succeed())
 
 	})
 	AfterEach(func() {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -81,8 +81,15 @@ func NewInstallAction(cfg *types.RunConfig, spec *types.InstallSpec, opts ...Ins
 	return i, err
 }
 
+// installHook runs the given hook without chroot. Moreover if the hook is 'after-install'
+// it appends defiled cloud init paths rooted to the deployed root. This way any
+// 'after-install' hook provided by the deployed system image is also taken into account.
 func (i *InstallAction) installHook(hook string) error {
-	return Hook(&i.cfg.Config, hook, i.cfg.Strict, i.cfg.CloudInitPaths...)
+	cIPaths := i.cfg.CloudInitPaths
+	if hook == cnst.AfterInstallHook {
+		cIPaths = append(cIPaths, utils.PreAppendRoot(cnst.WorkingImgDir, i.cfg.CloudInitPaths...)...)
+	}
+	return Hook(&i.cfg.Config, hook, i.cfg.Strict, cIPaths...)
 }
 
 func (i *InstallAction) installChrootHook(hook string, root string) error {

--- a/pkg/action/upgrade-recovery.go
+++ b/pkg/action/upgrade-recovery.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
-	cnst "github.com/rancher/elemental-toolkit/v2/pkg/constants"
 	"github.com/rancher/elemental-toolkit/v2/pkg/elemental"
 	elementalError "github.com/rancher/elemental-toolkit/v2/pkg/error"
 	"github.com/rancher/elemental-toolkit/v2/pkg/types"
@@ -125,14 +124,14 @@ func (u *UpgradeRecoveryAction) upgradeInstallStateYaml() error {
 				Digest:     u.spec.RecoverySystem.Source.GetDigest(),
 				Labels:     u.spec.SnapshotLabels,
 				Date:       u.spec.State.Date,
-				FromAction: cnst.ActionUpgradeRecovery,
+				FromAction: constants.ActionUpgradeRecovery,
 			},
 		}
 		u.spec.State.Partitions[constants.RecoveryPartName] = recoveryPart
 	} else if recoveryPart.RecoveryImage != nil {
 		recoveryPart.RecoveryImage.Date = u.spec.State.Date
 		recoveryPart.RecoveryImage.Labels = u.spec.SnapshotLabels
-		recoveryPart.RecoveryImage.FromAction = cnst.ActionUpgradeRecovery
+		recoveryPart.RecoveryImage.FromAction = constants.ActionUpgradeRecovery
 	}
 
 	// State partition is mounted in three different locations.

--- a/pkg/action/upgrade-recovery_test.go
+++ b/pkg/action/upgrade-recovery_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/rancher/elemental-toolkit/v2/pkg/action"
 	conf "github.com/rancher/elemental-toolkit/v2/pkg/config"
 	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
-	cnst "github.com/rancher/elemental-toolkit/v2/pkg/constants"
 	"github.com/rancher/elemental-toolkit/v2/pkg/mocks"
 	"github.com/rancher/elemental-toolkit/v2/pkg/types"
 	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
@@ -212,7 +211,7 @@ var _ = Describe("Upgrade Recovery Actions", func() {
 				// Just a small test to ensure we touched the state file
 				Expect(spec.State.Date).ToNot(BeEmpty(), "post-upgrade state should contain a date")
 				Expect(spec.State.Date).To(Equal(spec.State.Partitions["recovery"].RecoveryImage.Date))
-				Expect(spec.State.Partitions["recovery"].RecoveryImage.FromAction).To(Equal(cnst.ActionUpgradeRecovery))
+				Expect(spec.State.Partitions["recovery"].RecoveryImage.FromAction).To(Equal(constants.ActionUpgradeRecovery))
 				Expect(spec.State.Partitions["recovery"].RecoveryImage.Labels["foo"]).To(Equal("bar"))
 			})
 			It("Successfully skips updateInstallState", Label("docker"), func() {

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/rancher/elemental-toolkit/v2/pkg/action"
 	conf "github.com/rancher/elemental-toolkit/v2/pkg/config"
 	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
-	cnst "github.com/rancher/elemental-toolkit/v2/pkg/constants"
 	"github.com/rancher/elemental-toolkit/v2/pkg/mocks"
 	"github.com/rancher/elemental-toolkit/v2/pkg/types"
 	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
@@ -246,7 +245,7 @@ var _ = Describe("Runtime Actions", func() {
 				Expect(state.Partitions[constants.StatePartName].Snapshots[3].Active).
 					To(BeTrue())
 				Expect(state.Partitions[constants.StatePartName].Snapshots[3].FromAction).
-					To(Equal(cnst.ActionUpgrade))
+					To(Equal(constants.ActionUpgrade))
 				Expect(state.Partitions[constants.StatePartName].Snapshots[3].Date).
 					To(Equal(state.Date))
 				Expect(state.Partitions[constants.StatePartName].Snapshots[3].Labels["foo"]).

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -91,19 +91,21 @@ const (
 	GrubPassiveSnapshots   = "passive_snaps"
 	ElementalBootloaderBin = "/usr/lib/elemental/bootloader"
 
-	// Mountpoints of images and partitions
-	RunElementalDir    = "/run/elemental"
-	RecoveryDir        = "/run/elemental/recovery"
-	StateDir           = "/run/elemental/state"
-	OEMDir             = "/run/elemental/oem"
-	PersistentDir      = "/run/elemental/persistent"
-	TransitionDir      = "/run/elemental/transition"
-	BootDir            = "/run/elemental/efi"
-	ImgSrcDir          = "/run/elemental/imgsrc"
-	WorkingImgDir      = "/run/elemental/workingtree"
-	OverlayDir         = "/run/elemental/overlay"
-	PersistentStateDir = ".state"
-	RunningStateDir    = "/run/initramfs/elemental-state" // TODO: converge this constant with StateDir/RecoveryDir when moving to elemental-rootfs as default rootfs feature.
+	// Mountpoints or links to images and partitions
+	RunElementalBuildLink = "/run/elemental-build"
+	RunElementalDir       = "/run/elemental"
+	RecoveryDir           = "/run/elemental/recovery"
+	StateDir              = "/run/elemental/state"
+	OEMDir                = "/run/elemental/oem"
+	PersistentDir         = "/run/elemental/persistent"
+	TransitionDir         = "/run/elemental/transition"
+	BootDir               = "/run/elemental/efi"
+	ImgSrcDir             = "/run/elemental/imgsrc"
+	WorkingImgDir         = "/run/elemental/workingtree"
+	WorkingImgBuildLink   = RunElementalBuildLink + "/workingtree"
+	OverlayDir            = "/run/elemental/overlay"
+	PersistentStateDir    = ".state"
+	RunningStateDir       = "/run/initramfs/elemental-state" // TODO: converge this constant with StateDir/RecoveryDir when moving to elemental-rootfs as default rootfs feature.
 
 	// Running mode sentinel files
 	ActiveMode   = "/run/elemental/active_mode"

--- a/pkg/features/embedded/arm-firmware/system/oem/00_armfirmware.yaml
+++ b/pkg/features/embedded/arm-firmware/system/oem/00_armfirmware.yaml
@@ -1,0 +1,20 @@
+name: "Set ARM Firmware"
+stages:
+    after-install-chroot:
+    - &pifirmware
+      name: Raspberry PI post hook
+      if: '[ -d "/boot/vc" ]'
+      commands:
+      - cp -rf /boot/vc/* /run/elemental/efi/
+
+    after-upgrade-chroot:
+    - <<: *pifirmware
+
+    after-reset-chroot:
+    - <<: *pifirmware
+
+    after-disk:
+    - name: Raspberry PI post hook
+      if: '[ -d "/run/elemental-build/workingtree/boot/vc" ]'
+      commands:
+      - cp -rf /run/elemental-build/workingtree/boot/vc/* /run/elemental-build/efi/

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -54,6 +54,7 @@ const (
 	FeatureCloudConfigEssentials = "cloud-config-essentials"
 	FeatureBootAssessment        = "boot-assessment"
 	FeatureAutologin             = "autologin"
+	FeatureArmFirmware           = "arm-firmware"
 )
 
 var (
@@ -67,6 +68,7 @@ var (
 		FeatureCloudConfigDefaults,
 		FeatureCloudConfigEssentials,
 		FeatureBootAssessment,
+		FeatureArmFirmware,
 	}
 
 	Default = []string{
@@ -79,6 +81,7 @@ var (
 		FeatureCloudConfigDefaults,
 		FeatureCloudConfigEssentials,
 		FeatureBootAssessment,
+		FeatureArmFirmware,
 	}
 )
 
@@ -170,6 +173,8 @@ func Get(names []string) ([]*Feature, error) {
 			}
 			features = append(features, New(name, units))
 		case FeatureAutologin:
+			features = append(features, New(name, nil))
+		case FeatureArmFirmware:
 			features = append(features, New(name, nil))
 		default:
 			notFound = append(notFound, name)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -81,7 +81,6 @@ var (
 		FeatureCloudConfigDefaults,
 		FeatureCloudConfigEssentials,
 		FeatureBootAssessment,
-		FeatureArmFirmware,
 	}
 )
 

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -646,3 +646,12 @@ func CreateRAWFile(fs types.FS, filename string, size uint) error {
 	}
 	return nil
 }
+
+// PreAppendRoot simply adds the given root as a prefix to the given paths
+func PreAppendRoot(root string, paths ...string) []string {
+	var newPaths []string
+	for _, path := range paths {
+		newPaths = append(newPaths, filepath.Join(root, path))
+	}
+	return newPaths
+}


### PR DESCRIPTION
This commit enables to run the non chrooted 'after-*' hooks included in the newly deployed image root. This specially applies to the install, reset, upgrade and build-disk commands.

Moreover, 'after-disk' command now includes static reference paths to the new root and working directory, so that those can be used within the hooks regardless of the chosen output directory.

Part of rancher/elemental#1516