### PR TITLE
Expose max snapshots environment variable

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -272,6 +272,25 @@ var _ = Describe("Config", Label("config"), func() {
 
 			Expect(cfg.Snapshotter.Type).To(Equal(constants.BtrfsSnapshotterType))
 			Expect(cfg.Snapshotter.MaxSnaps).To(Equal(constants.BtrfsMaxSnaps))
+
+			// Test MAX_SNAPS string conversion from env
+			Expect(os.Setenv("ELEMENTAL_SNAPSHOTTER_TYPE", "btrfs")).Should(Succeed())
+			Expect(os.Setenv("ELEMENTAL_SNAPSHOTTER_MAX_SNAPS", "42")).Should(Succeed())
+
+			cfg, err = ReadConfigRun("fixtures/config/", nil, mounter)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(cfg.Snapshotter.Type).To(Equal(constants.BtrfsSnapshotterType))
+			Expect(cfg.Snapshotter.MaxSnaps).To(Equal(42))
+
+			Expect(os.Setenv("ELEMENTAL_SNAPSHOTTER_TYPE", "loopdevice")).Should(Succeed())
+			Expect(os.Setenv("ELEMENTAL_SNAPSHOTTER_MAX_SNAPS", "42")).Should(Succeed())
+
+			cfg, err = ReadConfigRun("fixtures/config/", nil, mounter)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(cfg.Snapshotter.Type).To(Equal(constants.LoopDeviceSnapshotterType))
+			Expect(cfg.Snapshotter.MaxSnaps).To(Equal(42))
 		})
 	})
 	Describe("Read runtime specs", Label("spec"), func() {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -289,12 +289,13 @@ func GetDefaultSquashfsCompressionOptions() []string {
 // GetRunKeyEnvMap returns environment variable bindings to RunConfig data
 func GetRunKeyEnvMap() map[string]string {
 	return map[string]string{
-		"poweroff":         "POWEROFF",
-		"reboot":           "REBOOT",
-		"strict":           "STRICT",
-		"eject-cd":         "EJECT_CD",
-		"snapshotter.type": "SNAPSHOTTER_TYPE",
-		"cloud-init-paths": "CLOUD_INIT_PATHS",
+		"poweroff":              "POWEROFF",
+		"reboot":                "REBOOT",
+		"strict":                "STRICT",
+		"eject-cd":              "EJECT_CD",
+		"snapshotter.type":      "SNAPSHOTTER_TYPE",
+		"snapshotter.max-snaps": "SNAPSHOTTER_MAX_SNAPS",
+		"cloud-init-paths":      "CLOUD_INIT_PATHS",
 	}
 }
 

--- a/pkg/types/snapshotter.go
+++ b/pkg/types/snapshotter.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"fmt"
+	"strconv"
 
 	mapstructure "github.com/mitchellh/mapstructure"
 	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
@@ -142,7 +143,17 @@ func (c *SnapshotterConfig) CustomUnmarshal(data interface{}) (bool, error) {
 		if mData["max-snaps"] != nil {
 			maxSnaps, ok := mData["max-snaps"].(int)
 			if !ok {
-				return false, fmt.Errorf("'max-snap' must be of integer type")
+				// If not integer value, try to convert from string.
+				// This will be the case when passed as env variable ELEMENTAL_SNAPSHOTTER_MAX_SNAPS
+				maxSnapsFromEnv, ok := mData["max-snaps"].(string)
+				if !ok {
+					return false, fmt.Errorf("'max-snap' must be of integer type")
+				}
+				maxSnapsConverted, err := strconv.Atoi(maxSnapsFromEnv)
+				if err != nil {
+					return false, fmt.Errorf("could not convert 'max-snap' from string input to integer type")
+				}
+				maxSnaps = maxSnapsConverted
 			}
 			c.MaxSnaps = maxSnaps
 		} else if c.Type == constants.BtrfsSnapshotterType {

--- a/pkg/types/snapshotter.go
+++ b/pkg/types/snapshotter.go
@@ -151,7 +151,7 @@ func (c *SnapshotterConfig) CustomUnmarshal(data interface{}) (bool, error) {
 				}
 				maxSnapsConverted, err := strconv.Atoi(maxSnapsFromEnv)
 				if err != nil {
-					return false, fmt.Errorf("could not convert 'max-snap' from string input to integer type")
+					return false, fmt.Errorf("converting 'max-snap' from string input to integer type: %w", err)
 				}
 				maxSnaps = maxSnapsConverted
 			}


### PR DESCRIPTION
Little change to expose the MAX_SNAPS as environment variable. 
This will be exploited by the `elemental-register` during install.