### PR TITLE
Temporarly disable audit package in example Dockerfile

### DIFF
--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -75,6 +75,8 @@ COPY --from=toolkit /usr/bin/elemental /usr/bin/elemental
 RUN systemctl enable NetworkManager.service && \
     systemctl enable sshd.service
 
+RUN useradd --system systemd-timesync
+
 # This is for automatic testing purposes, do not do this in production.
 RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
 

--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -59,7 +59,7 @@ RUN ARCH=$(uname -m); \
       sed \
       iproute2 \
       podman \
-      audit \
+      # audit \ comment out 'audit' package, installation fails in containers boo#1231236
       patterns-microos-selinux \
       btrfsprogs \
       btrfsmaintenance \


### PR DESCRIPTION
Audit package fails to install since last TW update, this is a temporary workaround.