### PR TITLE
Add orange flavor btrfs support

### DIFF
--- a/examples/orange/Dockerfile
+++ b/examples/orange/Dockerfile
@@ -51,7 +51,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   locales \
   kbd \
   podman \
-  xz-utils
+  btrfs-progs \
+  btrfsmaintenance \
+  xz-utils && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Hack to prevent systemd-firstboot failures while setting keymap, this is known
 # Debian issue (T_T) https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=790955
@@ -74,6 +77,9 @@ RUN cp /usr/share/systemd/tmp.mount /etc/systemd/system
 # Generate en_US.UTF-8 locale, this the locale set at boot by
 # the default cloud-init
 RUN locale-gen --lang en_US.UTF-8
+
+# Add default snapshotter setup
+ADD snapshotter.yaml /etc/elemental/config.d/snapshotter.yaml
 
 # Generate initrd with required elemental services
 RUN elemental --debug init -f

--- a/examples/orange/snapshotter.yaml
+++ b/examples/orange/snapshotter.yaml
@@ -1,0 +1,5 @@
+snapshotter:
+  type: btrfs
+  max-snaps: 4
+  config:
+    snapper: false

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -89,6 +89,7 @@ const (
 	GrubDefEntry           = "Elemental"
 	GrubFallback           = "default_fallback"
 	GrubPassiveSnapshots   = "passive_snaps"
+	GrubActiveSnapshot     = "active_snap"
 	ElementalBootloaderBin = "/usr/lib/elemental/bootloader"
 
 	// Mountpoints or links to images and partitions

--- a/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
+++ b/pkg/features/embedded/grub-config/etc/elemental/grub.cfg
@@ -65,22 +65,37 @@ function set_loopdevice {
 
 ## Sources bootargs from the current volume
 function source_bootargs {
-  source (${volume})/etc/cos/bootargs.cfg
-  source (${volume})/etc/elemental/bootargs.cfg
+  source (${volume})/${root_subpath}etc/cos/bootargs.cfg
+  source (${volume})/${root_subpath}etc/elemental/bootargs.cfg
 }
 
 ## Defines the volume and image to boot from for active or passive boots
 function set_volume {
   if [ "${snapshotter}" == "btrfs" ]; then
+    # apply btrfs default subvolume if applicable
     set btrfs_relative_path="y"
     set volume="${root}"
-    if [ -n "${1}" ]; then
-      set img="@/.snapshots/${1}/snapshot"
-      btrfs-mount-subvol ($root) / ${img}
+    # check if active snap is defined with default top level volume
+    if [ -d "@/.snapshots/${active_snap}/snapshot" ]; then
+      if [ -n "${1}" ]; then
+        set img="@/.snapshots/${1}/snapshot"
+      else
+        set img="@/.snapshots/${active_snap}/snapshot"
+      fi
+      set root_subpath="${img}/"
+    else
+      # if not in top level use subvolume based mounts 
+      set root_subpath=""
+      if [ -n "${1}" ]; then
+        set img="@/.snapshots/${1}/snapshot"
+        btrfs-mount-subvol ($root) / ${img}
+      fi
     fi
   elif [ -z "${1}" ]; then
+    set root_subpath=""
     set_loopdevice /.snapshots/active
   else
+    set root_subpath=""
     set img="/.snapshots/${1}/snapshot.img"
     set_loopdevice ${img}
   fi
@@ -88,7 +103,7 @@ function set_volume {
 
 menuentry "${display_name}" --id active {
   set mode=active
-  search --no-floppy --label --set=root ${state_label}
+  search --no-floppy --set root --label ${state_label}
   set_volume
   source_bootargs
   linux (${volume})${kernel} ${kernelcmd} ${extra_cmdline} ${extra_active_cmdline}
@@ -98,7 +113,7 @@ menuentry "${display_name}" --id active {
 for passive_snap in ${passive_snaps}; do
   menuentry "${display_name} (snapshot ${passive_snap})" --id passive${passive_snap} ${passive_snap} {
     set mode=passive
-    search --no-floppy --label --set=root ${state_label}
+    search --no-floppy --set root --label ${state_label}
     set_volume ${2}
     source_bootargs
     linux (${volume})${kernel} ${kernelcmd} ${extra_cmdline} ${extra_passive_cmdline}
@@ -108,7 +123,7 @@ done
 
 menuentry "${display_name} recovery" --id recovery {
   set mode=recovery
-  search --no-floppy --label --set=root ${recovery_label}
+  search --no-floppy --set root --label ${recovery_label}
 
   # Check the presence of the image and fallback to legacy path if not present
   set img=/boot/recovery.img

--- a/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
+++ b/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
@@ -23,5 +23,5 @@ else
   set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} panic=5 security=selinux fsck.mode=force fsck.repair=yes"
 fi
 
-set kernel=/boot/vmlinuz
-set initramfs=/boot/initrd
+set kernel=/${root_subpath}boot/vmlinuz
+set initramfs=/${root_subpath}boot/initrd

--- a/pkg/snapshotter/btrfs.go
+++ b/pkg/snapshotter/btrfs.go
@@ -31,8 +31,6 @@ import (
 
 const (
 	rootSubvol        = "@"
-	rootSubvolID      = 257
-	snapshotsSubvolID = 258
 	snapshotsPath     = ".snapshots"
 	snapshotPathTmpl  = ".snapshots/%d/snapshot"
 	snapshotPathRegex = `.snapshots/(\d+)/snapshot`

--- a/pkg/snapshotter/snapper-backend.go
+++ b/pkg/snapshotter/snapper-backend.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	snapperRootConfig = "/etc/snapper/configs/root"
-	snapperSysconfig  = "/etc/sysconfig/snapper"
+	snapperRootConfig    = "/etc/snapper/configs/root"
+	snapperSysconfig     = "/etc/sysconfig/snapper"
+	snapperDefaultconfig = "/etc/default/snapper"
 )
 
 var _ subvolumeBackend = (*snapperBackend)(nil)
@@ -220,7 +221,11 @@ func (s snapperBackend) configureSnapper(snapshotPath string) error {
 	}
 
 	sysconfigData := map[string]string{}
-	sysconfig := filepath.Join(snapshotPath, snapperSysconfig)
+	sysconfig := filepath.Join(snapshotPath, snapperDefaultconfig)
+	if ok, _ := utils.Exists(s.cfg.Fs, sysconfig); !ok {
+		sysconfig = filepath.Join(snapshotPath, snapperSysconfig)
+	}
+
 	if ok, _ := utils.Exists(s.cfg.Fs, sysconfig); ok {
 		sysconfigData, err = utils.LoadEnvFile(s.cfg.Fs, sysconfig)
 		if err != nil {


### PR DESCRIPTION
- remove btrfs default subvolume,
- save btrfs device in Btrfs structure,
- rework brtfs state mountpoint detection (uses btrfs device, got rid of rootSubvolID and snapshotsSubvolID constants),
- add 'active' relative symlink to active snapshot (updated in CloseTransaction() and read in getActiveSnapshot()),
- add grub 'active_snap' variable (could it be replaced by dracut resolving the 'active' link ?),
- add grub 'root_subpath' variable which allows to prefix kernel and initrd image with a subpath,
- handle grub modules packaging under /usr/lib/elemental/bootloader
- add RelativizeLink() to recursively make symbolic links relative,
- ensure kernel and initrd are relative links (allow grub to process without mounting subvolume)
- update orange Dockerfile