### PR TITLE
Add persistent disk encryption

### DIFF
--- a/.github/workflows/build_and_test_x86.yaml
+++ b/.github/workflows/build_and_test_x86.yaml
@@ -164,6 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps.detect.outputs.tests }}
+      installertests: ${{ steps.detect.outputs.installertests }}
     steps:
       - id: detect
         env:
@@ -171,8 +172,10 @@ jobs:
         run: |
           if [ "${FLAVOR}" == green ]; then
             echo "tests=['test-upgrade', 'test-downgrade', 'test-recovery', 'test-fallback', 'test-fsck', 'test-grubfallback']" >> $GITHUB_OUTPUT
+            echo "installertests=['test-installer', 'test-encryption']" >> $GITHUB_OUTPUT
           else
             echo "tests=['test-active']" >> $GITHUB_OUTPUT
+            echo "installertests=['test-installer']" >> $GITHUB_OUTPUT
           fi
 
   tests-matrix:
@@ -255,6 +258,10 @@ jobs:
       - build-iso
       - detect
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test: ${{ fromJson(needs.detect.outputs.installertests) }}
+      fail-fast: false
     env:
       FLAVOR: ${{ inputs.flavor }}
       ARCH: x86_64
@@ -288,12 +295,12 @@ jobs:
           sudo udevadm trigger --name-match=kvm
       - name: Run installer test
         run: |
-          make ISO=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.iso ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=/usr/share/OVMF/OVMF_CODE.fd test-installer
+          make ISO=/tmp/elemental-${{ env.FLAVOR }}.${{ env.ARCH}}.iso ELMNTL_TARGETARCH=${{ env.ARCH }} ELMNTL_FIRMWARE=/usr/share/OVMF/OVMF_CODE.fd ${{ matrix.test }}
       - name: Upload serial console for installer tests
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: serial-${{ env.ARCH }}-${{ env.FLAVOR }}-installer.log
+          name: serial-${{ env.ARCH }}-${{ env.FLAVOR }}-${{ matrix.test }}.log
           path: tests/serial.log
           if-no-files-found: error
           overwrite: true
@@ -301,7 +308,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: vmstdout-${{ env.ARCH }}-${{ env.FLAVOR }}-installer.log
+          name: vmstdout-${{ env.ARCH }}-${{ env.FLAVOR }}-${{ matrix.test }}.log
           path: tests/vmstdout
           if-no-files-found: error
           overwrite: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,8 @@ RUN ARCH=$(uname -m); \
         gptfdisk \
         patterns-microos-selinux \
         btrfsprogs \
-	snapper \
+	    snapper \
+        cryptsetup \
         lvm2 && \
     zypper cc -a
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN ARCH=$(uname -m); \
         gptfdisk \
         patterns-microos-selinux \
         btrfsprogs \
-	    snapper \
+        snapper \
         cryptsetup \
         lvm2 && \
     zypper cc -a

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -351,6 +351,19 @@ func applyKernelCmdline(r *types.RunConfig, mount *types.MountSpec) error {
 					Options:    []string{"rw", "defaults"},
 				})
 			}
+		case "elemental.encrypted_volumes":
+			vols := strings.Split(split[1], ",")
+
+			for _, vol := range vols {
+				switch vol {
+				case "persistent":
+					mount.Persistent.Encrypted = true
+					mount.Persistent.Volume.Device = constants.PersistentDeviceMapperPath
+				default:
+					r.Logger.Warnf("Unknown encrypted volume '%s', skipping", vol)
+				}
+			}
+
 		}
 	}
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -158,6 +158,13 @@ func addPlatformFlags(cmd *cobra.Command) {
 	cmd.Flags().String("platform", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH), "Platform to build the image for")
 }
 
+// addEncryptionFlags adds the disk encryption flag for install command
+func addEncryptionFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("encrypt-persistent", false, "Encrypt the persistent data partition on install")
+	cmd.Flags().StringArray("enroll-passphrase", nil, "Clear text password to enroll as key for disk encryption")
+	cmd.Flags().StringArray("enroll-key-file", nil, "Key-files to enroll as keys for disk encryption")
+}
+
 type enum struct {
 	Allowed []string
 	Value   string

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -123,6 +123,7 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	addSharedInstallUpgradeFlags(c)
 	addLocalImageFlag(c)
 	addPlatformFlags(c)
+	addEncryptionFlags(c)
 	return c
 }
 

--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -65,6 +65,7 @@ RUN ARCH=$(uname -m); \
       btrfsmaintenance \
       snapper \
       xterm-resize \
+      cryptsetup \
       ${ADD_PKGS} && \
     zypper clean --all
 

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -52,6 +52,10 @@ test-installer: prepare-installer-test
 	VM_PID=$$(scripts/run_vm.sh vmpid) go run $(GINKGO) $(GINKGO_ARGS) ./tests/installer
 	VM_PID=$$(scripts/run_vm.sh vmpid) go run $(GINKGO) $(GINKGO_ARGS) ./tests/smoke
 
+.PHONY: test-encryption
+test-encryption: prepare-installer-test
+	VM_PID=$$(scripts/run_vm.sh vmpid) go run $(GINKGO) $(GINKGO_ARGS) ./tests/encryption
+
 .PHONY: test-smoke
 test-smoke: test-active
 	VM_PID=$$(scripts/run_vm.sh vmpid) go run $(GINKGO) $(GINKGO_ARGS) ./tests/smoke

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -108,6 +108,10 @@ const (
 	PersistentStateDir    = ".state"
 	RunningStateDir       = "/run/initramfs/elemental-state" // TODO: converge this constant with StateDir/RecoveryDir when moving to elemental-rootfs as default rootfs feature.
 
+	// Disk encryption constants
+	PersistentDeviceMapperName = "cr_persistent"
+	PersistentDeviceMapperPath = "/dev/mapper/" + PersistentDeviceMapperName
+
 	// Running mode sentinel files
 	ActiveMode   = "/run/elemental/active_mode"
 	PassiveMode  = "/run/elemental/passive_mode"

--- a/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
+++ b/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
@@ -1,9 +1,12 @@
 # bootargs.cfg inherits from grub.cfg several context variables:
 #   'img' => defines the image path to boot from. Active img is statically defined, does not require a value
+#   'mode' => active/passive/recovery, mode to boot
 #   'state_label' => label of the state partition filesystem
 #   'oem_label' => label of the oem partition filesystem
 #   'recovery_label' => label of the recovery partition filesystem
 #   'snapshotter' => snapshotter type, assumes loopdevice type if undefined
+#   'snap_arg' => kernel args for snapshotter
+#   'encrypted_volumes' => comma-separated list of encrypted volume names
 #
 # In addition bootargs.cfg is responsible of setting the following variables:
 #   'kernelcmd' => essential kernel command line parameters (all elemental specific and non elemental specific)
@@ -20,7 +23,7 @@ else
   if [ "${snapshotter}" == "btrfs" ]; then
     set snap_arg="elemental.snapshotter=btrfs"
   fi
-  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} panic=5 security=selinux fsck.mode=force fsck.repair=yes"
+  set kernelcmd="console=tty1 console=ttyS0 root=LABEL=${state_label} ${img_arg} ${snap_arg} elemental.mode=${mode} elemental.oemlabel=${oem_label} panic=5 security=selinux fsck.mode=force fsck.repair=yes elemental.encrypted_volumes=${encrypted_volumes}"
 fi
 
 set kernel=/${root_subpath}boot/vmlinuz

--- a/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
+++ b/pkg/features/embedded/grub-default-bootargs/etc/elemental/bootargs.cfg
@@ -5,7 +5,6 @@
 #   'oem_label' => label of the oem partition filesystem
 #   'recovery_label' => label of the recovery partition filesystem
 #   'snapshotter' => snapshotter type, assumes loopdevice type if undefined
-#   'snap_arg' => kernel args for snapshotter
 #   'encrypted_volumes' => comma-separated list of encrypted volume names
 #
 # In addition bootargs.cfg is responsible of setting the following variables:

--- a/pkg/partitioner/cryptsetup.go
+++ b/pkg/partitioner/cryptsetup.go
@@ -1,0 +1,76 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package partitioner
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/rancher/elemental-toolkit/v2/pkg/types"
+)
+
+func EncryptDevice(runner types.Runner, device, mappedName string, slots []types.KeySlot) error {
+	logger := runner.GetLogger()
+
+	if len(slots) == 0 {
+		return fmt.Errorf("Needs at least 1 key-slot to encrypt %s", device)
+	}
+
+	firstSlot := slots[0]
+
+	cmd := runner.InitCmd("cryptsetup", "luksFormat", "--key-slot", fmt.Sprintf("%d", firstSlot.Slot), device, "-")
+	err := unlockCmd(cmd, firstSlot)
+	if err != nil {
+		logger.Errorf("Error generating unlock command for device '%s': %s", device, err.Error())
+		return err
+	}
+
+	stdout, err := runner.RunCmd(cmd)
+	if err != nil {
+		logger.Errorf("Error formatting device %s: %s", device, stdout)
+		return err
+	}
+
+	cmd = runner.InitCmd("cryptsetup", "open", device, mappedName)
+
+	if err = unlockCmd(cmd, firstSlot); err != nil {
+		return err
+	}
+
+	stdout, err = runner.RunCmd(cmd)
+	if err != nil {
+		logger.Errorf("Error opening device %s: %s", device, stdout)
+	}
+
+	return err
+}
+
+func unlockCmd(cmd *exec.Cmd, slot types.KeySlot) error {
+	if slot.Passphrase != "" {
+		cmd.Stdin = strings.NewReader(string(slot.Passphrase))
+		return nil
+	}
+
+	if slot.KeyFile != "" {
+		cmd.Args = append(cmd.Args, "--key-file", slot.KeyFile)
+		return nil
+	}
+
+	return errors.New("Unknown key slot authorization")
+}

--- a/pkg/types/grub.go
+++ b/pkg/types/grub.go
@@ -29,6 +29,10 @@ func (i InstallSpec) GetGrubLabels() map[string]string {
 
 	if i.Partitions.Persistent != nil {
 		grubEnv["persistent_label"] = i.Partitions.Persistent.FilesystemLabel
+
+		if i.Partitions.Persistent.Encryption != nil {
+			grubEnv["encrypted_volumes"] = "persistent"
+		}
 	}
 
 	return grubEnv

--- a/pkg/types/sensitive.go
+++ b/pkg/types/sensitive.go
@@ -1,0 +1,50 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	_ fmt.Formatter          = (*SensitiveString)(nil)
+	_ json.Marshaler         = (*SensitiveString)(nil)
+	_ yaml.Marshaler         = (*SensitiveString)(nil)
+	_ encoding.TextMarshaler = (*SensitiveString)(nil)
+)
+
+type SensitiveString string
+
+func (s SensitiveString) Format(f fmt.State, _ rune) {
+	_, _ = f.Write([]byte("***"))
+}
+
+func (s SensitiveString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string("***"))
+}
+
+func (s SensitiveString) MarshalYAML() (any, error) {
+	return json.Marshal(string("***"))
+}
+
+func (s SensitiveString) MarshalText() (text []byte, err error) {
+	return []byte("***"), nil
+}

--- a/tests/assets/encrypted_extra_partition.yaml
+++ b/tests/assets/encrypted_extra_partition.yaml
@@ -1,0 +1,11 @@
+install:
+  extra-partitions:
+    - Name: extra
+      size: 100
+      fs: ext4
+      label: extra
+      encryption:
+        name: cr_extra
+        key_slots:
+        - slot: 1
+          passphrase: "extrapass"

--- a/tests/encryption/installer_encryption_test.go
+++ b/tests/encryption/installer_encryption_test.go
@@ -1,0 +1,85 @@
+package cos_test
+
+import (
+	"fmt"
+	"math/rand"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	sut "github.com/rancher/elemental-toolkit/v2/tests/vm"
+)
+
+func generatePassphrase(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	b := make([]byte, length)
+
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+
+	return string(b)
+}
+
+var _ = Describe("Elemental Installer encryption tests", func() {
+	var s *sut.SUT
+
+	BeforeEach(func() {
+		s = sut.NewSUT()
+		s.EventuallyConnects()
+	})
+
+	Context("Using efi", func() {
+		// EFI variant tests is not able to set the boot order and there is no plan to let the user do so according to virtualbox
+		// So we need to manually eject/insert the cd to force the boot order. CD inserted -> boot from cd, CD empty -> boot from disk
+		BeforeEach(func() {
+			// Assert we are booting from CD before running the tests
+			By("Making sure we booted from CD")
+			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.LiveCD))
+		})
+		AfterEach(func() {
+			if CurrentSpecReport().Failed() {
+				s.GatherAllLogs()
+			}
+		})
+
+		Context("partition layout tests", func() {
+			Context("with partition layout", func() {
+				It("performs a standard install", func() {
+					err := s.SendFile("../assets/encrypted_extra_partition.yaml", "/etc/elemental/config.d/encrypted_extra_partition.yaml", "0770")
+					Expect(err).ToNot(HaveOccurred())
+
+					passphrase := generatePassphrase(10)
+					By(fmt.Sprintf("Running the elemental install with passphrase '%s'", passphrase))
+					out, err := s.Command(s.ElementalCmd("install", "--squash-no-compression", "/dev/vda", "--encrypt-persistent", "--enroll-passphrase", passphrase))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(out).To(ContainSubstring("Mounting disk partitions"))
+					Expect(out).To(ContainSubstring("Partitioning device..."))
+					Expect(out).To(ContainSubstring("Running after-install hook"))
+
+					// Mount OEM before changing boot entry
+					_, err = s.Command("mount /dev/disk/by-partlabel/oem /oem")
+					Expect(err).ToNot(HaveOccurred())
+
+					// Trying to mount from the installed system will lock
+					// waiting for the passphrase, so we boot into recovery to
+					// verify we can mount the encrypted partitions using the
+					// expected passphrases.
+					err = s.ChangeBootOnce(sut.Recovery)
+					Expect(err).ToNot(HaveOccurred())
+					s.Reboot()
+					s.AssertBootedFrom(sut.Recovery)
+
+					By("Mounting cr_persistent")
+					_, err = s.Command(fmt.Sprintf("echo %s | cryptsetup open --type luks /dev/disk/by-partlabel/persistent cr_persistent", passphrase))
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Mounting cr_extra from config file")
+					_, err = s.Command("echo extrapass | cryptsetup open --type luks /dev/disk/by-partlabel/extra cr_extra")
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+	})
+})

--- a/tests/encryption/tests_suite_test.go
+++ b/tests/encryption/tests_suite_test.go
@@ -1,0 +1,13 @@
+package cos_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Elemental Installer test Suite")
+}


### PR DESCRIPTION
Add flags to encrypt persistent partition on install:

* encrypt-persistent: flag to enable luks encryption on persistent partition.
* enroll-passphrase: string to enroll as passphrase to unlock partition.
* enroll-key-file: key-file to enroll as key to unlock partition.

During install this will invoke cryptsetup to create the LUKS partition and during mount we use systemd-cryptsetup to attach the partition before mounting the contained filesystem.

This also introduces some changes in the grub configuration, the encrypted_volumes variable can be set in grub_oem_env during install to configure which volumes are actually encrypted.

This change is tested in the new `test-encryption` target that runs an `elemental install` with a random passphrase and tests that the persistent partition and any extra-partitions can be unlocked when booted from the recovery system.

In the future the hope is to extend this to include state and oem partition, but that will need more changes to the bootloader configuration (most notably using the `cryptomount` command)

Part of #1782 