### PR TITLE
Btrfs snapshotter without snapper

### DIFF
--- a/examples/green/snapshotter.yaml
+++ b/examples/green/snapshotter.yaml
@@ -2,4 +2,4 @@ snapshotter:
   type: btrfs
   max-snaps: 4
   config:
-    snapper: false
+    snapper: true

--- a/examples/green/snapshotter.yaml
+++ b/examples/green/snapshotter.yaml
@@ -1,3 +1,5 @@
 snapshotter:
   type: btrfs
   max-snaps: 4
+  config:
+    snapper: false

--- a/pkg/snapshotter/btrfs-backend.go
+++ b/pkg/snapshotter/btrfs-backend.go
@@ -87,13 +87,14 @@ func (d *Date) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 }
 
 type btrfsBackend struct {
-	cfg      *types.Config
-	activeID int
-	device   string
+	cfg          *types.Config
+	activeID     int
+	device       string
+	maxSnapshots int
 }
 
-func newBtrfsBackend(cfg *types.Config) *btrfsBackend {
-	return &btrfsBackend{cfg: cfg}
+func newBtrfsBackend(cfg *types.Config, maxSnapshots int) *btrfsBackend {
+	return &btrfsBackend{cfg: cfg, maxSnapshots: maxSnapshots}
 }
 
 func (b *btrfsBackend) InitBackend(device string, activeID int) {

--- a/pkg/snapshotter/btrfs-backend.go
+++ b/pkg/snapshotter/btrfs-backend.go
@@ -1,0 +1,302 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshotter
+
+import (
+	"bufio"
+	"encoding/xml"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
+	"github.com/rancher/elemental-toolkit/v2/pkg/types"
+	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
+)
+
+var _ subvolumeBackend = (*btrfsBackend)(nil)
+
+type SnapperSnapshotXML struct {
+	XMLName     xml.Name   `xml:"snapshot"`
+	Type        string     `xml:"type"`
+	Num         int        `xml:"num"`
+	Date        Date       `xml:"date"`
+	Cleanup     string     `xml:"cleanup"`
+	Description string     `xml:"description"`
+	UserData    []UserData `xml:"userdata"`
+}
+
+type UserData struct {
+	XMLName xml.Name `xml:"userdata"`
+	Key     string   `xml:"key"`
+	Value   string   `xml:"value"`
+}
+
+func newSnapperSnapshotXML(id int, desc string) SnapperSnapshotXML {
+	var usrData UserData
+	if id == 1 {
+		usrData = UserData{Key: installProgress, Value: "yes"}
+	} else {
+		usrData = UserData{Key: updateProgress, Value: "yes"}
+	}
+	return SnapperSnapshotXML{
+		Type:        "single",
+		Num:         id,
+		Date:        Date(time.Now()),
+		Description: desc,
+		Cleanup:     "number",
+		UserData:    []UserData{usrData},
+	}
+}
+
+func (d Date) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	t := time.Time(d)
+	v := t.Format(dateFormat)
+	return e.EncodeElement(v, start)
+}
+
+func (d *Date) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+	var s string
+	err := dec.DecodeElement(&s, &start)
+	if err != nil {
+		return err
+	}
+	t, err := time.Parse(dateFormat, s)
+	if err != nil {
+		return err
+	}
+	*d = Date(t)
+	return nil
+}
+
+type btrfsBackend struct {
+	cfg      *types.Config
+	activeID int
+	device   string
+}
+
+func newBtrfsBackend(cfg *types.Config) *btrfsBackend {
+	return &btrfsBackend{cfg: cfg}
+}
+
+func (b *btrfsBackend) InitBackend(device string, activeID int) {
+	b.activeID = activeID
+	b.device = device
+}
+
+func (b *btrfsBackend) InitBrfsPartition(rootDir string) error {
+	b.cfg.Logger.Debug("Enabling btrfs quota")
+	cmdOut, err := b.cfg.Runner.Run("btrfs", "quota", "enable", rootDir)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed setting quota for btrfs partition at %s: %s", rootDir, string(cmdOut))
+		return err
+	}
+
+	b.cfg.Logger.Debug("Creating essential subvolumes")
+	for _, subvolume := range []string{filepath.Join(rootDir, rootSubvol), filepath.Join(rootDir, rootSubvol, snapshotsPath)} {
+		b.cfg.Logger.Debugf("Creating subvolume: %s", subvolume)
+		cmdOut, err = b.cfg.Runner.Run("btrfs", "subvolume", "create", subvolume)
+		if err != nil {
+			b.cfg.Logger.Errorf("failed creating subvolume %s: %s", subvolume, string(cmdOut))
+			return err
+		}
+	}
+
+	b.cfg.Logger.Debug("Create btrfs quota group")
+	cmdOut, err = b.cfg.Runner.Run("btrfs", "qgroup", "create", "1/0", rootDir)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed creating quota group for %s: %s", rootDir, string(cmdOut))
+		return err
+	}
+
+	return nil
+}
+
+func (b btrfsBackend) CreateNewSnapshot(rootDir string, baseID int) (*types.Snapshot, error) {
+	if baseID == 0 {
+		b.cfg.Logger.Info("Creating first root filesystem as a snapshot")
+		newID := 1
+		err := utils.MkdirAll(b.cfg.Fs, filepath.Join(rootDir, snapshotsPath, strconv.Itoa(newID)), constants.DirPerm)
+		if err != nil {
+			return nil, err
+		}
+		cmdOut, err := b.cfg.Runner.Run(
+			"btrfs", "subvolume", "create",
+			filepath.Join(rootDir, fmt.Sprintf(snapshotPathTmpl, newID)),
+		)
+		if err != nil {
+			b.cfg.Logger.Errorf("failed creating first snapshot volume: %s", string(cmdOut))
+			return nil, err
+		}
+		snapperXML := filepath.Join(rootDir, fmt.Sprintf(snapshotInfoPath, newID))
+		err = b.writeSnapperSnapshotXML(snapperXML, newSnapperSnapshotXML(newID, "first root filesystem"))
+		if err != nil {
+			b.cfg.Logger.Errorf("failed creating snapper info XML")
+			return nil, err
+		}
+		workingDir := filepath.Join(rootDir, fmt.Sprintf(snapshotPathTmpl, newID))
+		return &types.Snapshot{
+			ID:      newID,
+			WorkDir: workingDir,
+			Path:    workingDir,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("not implemented yet")
+}
+
+func (b btrfsBackend) CommitSnapshot(rootDir string, snapshot *types.Snapshot) error {
+	err := b.clearInProgressMetadata(rootDir, snapshot.ID)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed updating snapshot %d metadata: %v", snapshot.ID, err)
+		return err
+	}
+
+	cmdOut, err := b.cfg.Runner.Run("btrfs", "property", "set", snapshot.Path, "ro", "true")
+	if err != nil {
+		b.cfg.Logger.Errorf("failed setting read only property to snapshot %d: %s", snapshot.ID, string(cmdOut))
+		return err
+	}
+
+	subvolID, err := b.findSubvolumeByPath(rootDir, fmt.Sprintf(snapshotPathTmpl, snapshot.ID))
+	if err != nil {
+		b.cfg.Logger.Error("failed finding subvolume")
+		return err
+	}
+
+	cmdOut, err = b.cfg.Runner.Run("btrfs", "subvolume", "set-default", strconv.Itoa(subvolID), snapshot.Path)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed setting read only property to snapshot %d: %s", snapshot.ID, string(cmdOut))
+		return err
+	}
+	return nil
+}
+
+func (b btrfsBackend) ListSnapshots(_ string) (snapshotsList, error) {
+	var snaps snapshotsList
+	return snaps, fmt.Errorf("not implemented yet")
+}
+
+func (b btrfsBackend) DeleteSnapshot(_ string, _ int) error {
+	return fmt.Errorf("not implemented yet")
+}
+
+func (b btrfsBackend) SnapshotsCleanup(_ string) error {
+	return fmt.Errorf("not implemented yet")
+}
+
+func (b btrfsBackend) writeSnapperSnapshotXML(filepath string, snapshot SnapperSnapshotXML) error {
+	data, err := xml.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		b.cfg.Logger.Errorf("failed marhsalling snapper's snapshot XML: %v", err)
+		return err
+	}
+	err = b.cfg.Fs.WriteFile(filepath, data, constants.FilePerm)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed writing snapper's snapshot XML: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (b btrfsBackend) loadSnapperSnapshotXML(filepath string) (SnapperSnapshotXML, error) {
+	var data SnapperSnapshotXML
+
+	bData, err := b.cfg.Fs.ReadFile(filepath)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed reading '%s' file: %v", filepath, err)
+		return data, err
+	}
+
+	err = xml.Unmarshal(bData, &data)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed decoding '%s' file contents: %v", filepath, err)
+		return data, err
+	}
+
+	return data, nil
+}
+
+func (b btrfsBackend) findSubvolumeByPath(rootDir, path string) (int, error) {
+	subvolumes, err := b.getSubvolumes(rootDir)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed loading subvolumes: %v", err)
+		return 0, err
+	}
+
+	for _, subvol := range subvolumes {
+		if strings.Contains(subvol.path, path) {
+			return subvol.id, nil
+		}
+	}
+
+	b.cfg.Logger.Errorf("could not find subvolume with path '%s' in subvolumes list '%v'", path, subvolumes)
+	return 0, fmt.Errorf("can't find subvolume '%s'", path)
+}
+
+func (b btrfsBackend) getSubvolumes(rootDir string) (btrfsSubvolList, error) {
+	out, err := b.cfg.Runner.Run("btrfs", "subvolume", "list", "--sort=path", rootDir)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed listing btrfs subvolumes: %s", err.Error())
+		return nil, err
+	}
+	return b.parseVolumes(strings.TrimSpace(string(out))), nil
+}
+
+func (b btrfsBackend) parseVolumes(rawBtrfsList string) btrfsSubvolList {
+	re := regexp.MustCompile(`^ID (\d+) gen \d+ top level \d+ path (.*)$`)
+	list := btrfsSubvolList{}
+
+	scanner := bufio.NewScanner(strings.NewReader(rawBtrfsList))
+	for scanner.Scan() {
+		match := re.FindStringSubmatch(strings.TrimSpace(scanner.Text()))
+		if match != nil {
+			id, _ := strconv.Atoi(match[1])
+			path := match[2]
+			list = append(list, btrfsSubvol{id: id, path: path})
+		}
+	}
+	return list
+}
+
+func (b btrfsBackend) clearInProgressMetadata(rootDir string, id int) error {
+	snapperXML := filepath.Join(rootDir, fmt.Sprintf(snapshotInfoPath, id))
+	snapshotData, err := b.loadSnapperSnapshotXML(snapperXML)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed reading snapshot %d metadata: %v", id, err)
+		return err
+	}
+
+	var usrData []UserData
+	for _, ud := range snapshotData.UserData {
+		if ud.Key == updateProgress || ud.Key == installProgress {
+			continue
+		}
+		usrData = append(usrData, ud)
+	}
+	snapshotData.UserData = usrData
+
+	err = b.writeSnapperSnapshotXML(snapperXML, snapshotData)
+	if err != nil {
+		b.cfg.Logger.Errorf("failed writing snapshot %d metadata: %v", id, err)
+		return err
+	}
+	return nil
+}

--- a/pkg/snapshotter/btrfs-backend.go
+++ b/pkg/snapshotter/btrfs-backend.go
@@ -33,6 +33,8 @@ import (
 	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
 )
 
+const dateFormat = "2006-01-02 15:04:05"
+
 var _ subvolumeBackend = (*btrfsBackend)(nil)
 
 type SnapperSnapshotXML struct {

--- a/pkg/snapshotter/btrfs-backend_test.go
+++ b/pkg/snapshotter/btrfs-backend_test.go
@@ -1,0 +1,573 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshotter_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	conf "github.com/rancher/elemental-toolkit/v2/pkg/config"
+	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
+	"github.com/rancher/elemental-toolkit/v2/pkg/mocks"
+	"github.com/rancher/elemental-toolkit/v2/pkg/snapshotter"
+	"github.com/rancher/elemental-toolkit/v2/pkg/types"
+	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
+	"github.com/twpayne/go-vfs/v4"
+	"github.com/twpayne/go-vfs/v4/vfst"
+)
+
+var _ = Describe("btrfsBackend", Label("snapshotter", " btrfs"), func() {
+	var cfg *types.Config
+	var runner *mocks.FakeRunner
+	var fs vfs.FS
+	var logger types.Logger
+	var mounter *mocks.FakeMounter
+	var cleanup func()
+
+	var memLog *bytes.Buffer
+	var btrfsCfg types.BtrfsConfig
+	var rootDir string
+	var statePart *types.Partition
+	var syscall *mocks.FakeSyscall
+
+	type sideEffect struct {
+		cmd      string
+		cmdOut   string
+		errorMsg string
+	}
+	var sEffects []*sideEffect
+
+	BeforeEach(func() {
+		sEffects = []*sideEffect{}
+		rootDir = "/some/root"
+		statePart = &types.Partition{
+			Name:       constants.StatePartName,
+			Path:       "/dev/state-device",
+			MountPoint: rootDir,
+		}
+		runner = mocks.NewFakeRunner()
+		mounter = mocks.NewFakeMounter()
+		syscall = &mocks.FakeSyscall{}
+		memLog = bytes.NewBuffer(nil)
+		logger = types.NewBufferLogger(memLog)
+		logger.SetLevel(types.DebugLevel())
+
+		var err error
+		fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{})
+		Expect(err).Should(BeNil())
+
+		cfg = conf.NewConfig(
+			conf.WithFs(fs),
+			conf.WithRunner(runner),
+			conf.WithLogger(logger),
+			conf.WithMounter(mounter),
+			conf.WithSyscall(syscall),
+			conf.WithPlatform("linux/amd64"),
+		)
+		btrfsCfg = types.BtrfsConfig{Snapper: false}
+		Expect(utils.MkdirAll(fs, rootDir, constants.DirPerm)).To(Succeed())
+
+		runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
+			fullCmd := strings.Join(append([]string{cmd}, args...), " ")
+			for _, effect := range sEffects {
+				if strings.HasPrefix(fullCmd, effect.cmd) {
+					if effect.errorMsg != "" {
+						return []byte(effect.cmdOut), fmt.Errorf(effect.errorMsg)
+					}
+					return []byte(effect.cmdOut), nil
+				}
+			}
+			return []byte{}, nil
+		}
+	})
+
+	AfterEach(func() {
+		cleanup()
+	})
+
+	Describe("in a not initiated environment", func() {
+		It("probes a non initiated environment, missing subvolumes", func() {
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			stat, err := backend.Probe(statePart.Path, statePart.MountPoint)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stat.ActiveID).To(Equal(0))
+			Expect(runner.MatchMilestones([][]string{{"btrfs", "subvolume", "list"}})).To(Succeed())
+			runner.ClearCmds()
+		})
+
+		It("fails to probe partition, can't read btrfs subvolumes", func() {
+			errMsg := "btrfs failed"
+			sEffects = append(sEffects, &sideEffect{cmd: "btrfs subvolume list", errorMsg: errMsg})
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			_, err := backend.Probe(statePart.Path, statePart.MountPoint)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(errMsg))
+		})
+
+		It("initalizes the btrfs partition", func() {
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			Expect(backend.InitBrfsPartition(rootDir)).To(Succeed())
+			Expect(runner.MatchMilestones([][]string{
+				{"btrfs", "quota", "enable"},
+				{"btrfs", "subvolume", "create"},
+				{"btrfs", "subvolume", "create"},
+				{"btrfs", "qgroup", "create"},
+			})).To(Succeed())
+		})
+
+		It("partition initialization fails enabling quota", func() {
+			errMsg := "btrfs quota failed"
+			sEffects = append(sEffects, &sideEffect{cmd: "btrfs quota enable", errorMsg: errMsg})
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			Expect(backend.InitBrfsPartition(rootDir)).NotTo(Succeed())
+			Expect(runner.MatchMilestones([][]string{
+				{"btrfs", "quota", "enable"},
+			})).To(Succeed())
+		})
+
+		It("partition initialization fails creating subvolume", func() {
+			errMsg := "subvolume create failed"
+			sEffects = append(sEffects, &sideEffect{cmd: "btrfs subvolume create", errorMsg: errMsg})
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			Expect(backend.InitBrfsPartition(rootDir)).NotTo(Succeed())
+			Expect(runner.MatchMilestones([][]string{
+				{"btrfs", "quota", "enable"},
+				{"btrfs", "subvolume", "create"},
+			})).To(Succeed())
+		})
+
+		It("partition initialization fails setting quota group", func() {
+			errMsg := "qgroup create failed"
+			sEffects = append(sEffects, &sideEffect{cmd: "btrfs qgroup create", errorMsg: errMsg})
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			Expect(backend.InitBrfsPartition(rootDir)).NotTo(Succeed())
+			Expect(runner.MatchMilestones([][]string{
+				{"btrfs", "quota", "enable"},
+				{"btrfs", "subvolume", "create"},
+				{"btrfs", "subvolume", "create"},
+				{"btrfs", "qgroup", "create"},
+			})).To(Succeed())
+		})
+
+		It("creates the very first snapshot", func() {
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			snap, err := backend.CreateNewSnapshot(rootDir, 0)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snap.ID).To(Equal(1))
+			Expect(runner.MatchMilestones([][]string{
+				{"btrfs", "subvolume", "create"},
+			})).To(Succeed())
+		})
+
+		It("fails to create the first snapshot folder", func() {
+			cfg.Fs = vfs.NewReadOnlyFS(fs)
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			_, err := backend.CreateNewSnapshot(rootDir, 0)
+			Expect(err).To(HaveOccurred())
+			Expect(runner.MatchMilestones([][]string{
+				{"btrfs", "subvolume", "create"},
+			})).NotTo(Succeed())
+		})
+
+		It("fails to create the first snapshot", func() {
+			errMsg := "subvolume create failed"
+			sEffects = append(sEffects, &sideEffect{cmd: "btrfs subvolume create", errorMsg: errMsg})
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			_, err := backend.CreateNewSnapshot(rootDir, 0)
+			Expect(err).To(HaveOccurred())
+			Expect(runner.MatchMilestones([][]string{
+				{"btrfs", "subvolume", "create"},
+			})).To(Succeed())
+		})
+
+		It("lists no snapshots", func() {
+			listCmd := "btrfs subvolume list"
+			defVolCmd := "btrfs subvolume get-default"
+
+			sEffects = append(sEffects, &sideEffect{cmd: listCmd, cmdOut: "there are no subvolumes"})
+			sEffects = append(sEffects, &sideEffect{cmd: defVolCmd, cmdOut: "there is no default subvolume"})
+
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			lst, err := backend.ListSnapshots(rootDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lst.ActiveID).To(Equal(0))
+			Expect(len(lst.IDs)).To(Equal(0))
+			Expect(runner.MatchMilestones([][]string{
+				strings.Fields(listCmd),
+				strings.Fields(defVolCmd),
+			})).To(Succeed())
+		})
+
+		It("fails to list snapshots, can't read subvolumes", func() {
+			listCmd := "btrfs subvolume list"
+			defVolCmd := "btrfs subvolume get-default"
+
+			sEffects = append(sEffects, &sideEffect{cmd: listCmd, errorMsg: "can't read subvolumes"})
+
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			_, err := backend.ListSnapshots(rootDir)
+			Expect(err).To(HaveOccurred())
+			Expect(runner.MatchMilestones([][]string{
+				strings.Fields(listCmd),
+			})).To(Succeed())
+			Expect(runner.MatchMilestones([][]string{
+				strings.Fields(defVolCmd),
+			})).NotTo(Succeed())
+		})
+
+		It("fails to list snapshots, can't find the default subvolume", func() {
+			listCmd := "btrfs subvolume list"
+			defVolCmd := "btrfs subvolume get-default"
+
+			sEffects = append(sEffects, &sideEffect{cmd: listCmd, cmdOut: "there are no subvolumes"})
+			sEffects = append(sEffects, &sideEffect{cmd: defVolCmd, errorMsg: "can't find the default subvolume"})
+
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			_, err := backend.ListSnapshots(rootDir)
+			Expect(err).To(HaveOccurred())
+			Expect(runner.MatchMilestones([][]string{
+				strings.Fields(listCmd),
+				strings.Fields(defVolCmd),
+			})).To(Succeed())
+		})
+	})
+
+	Describe("initiated environment while not being in active nor passive", func() {
+		var defaultVol, volumesList, listCmd, getDefCmd string
+		var volSideEffect *sideEffect
+		BeforeEach(func() {
+			defaultVol = "ID 259 gen 13453 top level 258 path @/.snapshots/1/snapshot\n"
+			volumesList = "ID 257 gen 13451 top level 3 path @\n"
+			volumesList += "ID 258 gen 13452 top level 257 path @/.snapshots\n"
+			volumesList += defaultVol
+
+			listCmd = "btrfs subvolume list"
+			getDefCmd = "btrfs subvolume get-default"
+
+			volSideEffect = &sideEffect{cmd: listCmd, cmdOut: volumesList}
+			sEffects = append(sEffects, volSideEffect)
+		})
+
+		Describe("initated backend", func() {
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			var defVolSideEffect *sideEffect
+			BeforeEach(func() {
+				defVolSideEffect = &sideEffect{cmd: getDefCmd, cmdOut: defaultVol}
+				sEffects = append(sEffects, defVolSideEffect)
+				By("probes an initiatied environment", func() {
+					backend = snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+					stat, err := backend.Probe(statePart.Path, statePart.MountPoint)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(stat.ActiveID).To(Equal(1))
+					Expect(stat.CurrentID).To(Equal(0))
+					Expect(stat.RootDir).To(Equal(statePart.MountPoint))
+					Expect(stat.StateMount).To(Equal(statePart.MountPoint))
+					Expect(runner.MatchMilestones([][]string{
+						strings.Fields(listCmd),
+						strings.Fields(getDefCmd),
+					})).To(Succeed())
+				})
+				// Clear commands history
+				runner.ClearCmds()
+			})
+
+			Describe("snapshot created", func() {
+				var snap *types.Snapshot
+				var err error
+				BeforeEach(func() {
+					By("creates a new snapshot", func() {
+						snap, err = backend.CreateNewSnapshot(rootDir, 1)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(snap.ID).To(Equal(2))
+						Expect(runner.MatchMilestones([][]string{
+							{"btrfs", "subvolume", "list"},
+							{"btrfs", "subvolume", "get-default"},
+							{"btrfs", "subvolume", "snapshot"},
+						})).To(Succeed())
+					})
+					runner.ClearCmds()
+				})
+
+				It("commits a snapshot", func() {
+					// Include the new snapshot int he subvolumes list
+					volSideEffect.cmdOut += "ID 260 gen 13454 top level 259 path @/.snapshots/2/snapshot\n"
+
+					err = backend.CommitSnapshot(rootDir, snap)
+					Expect(err).To(Succeed())
+					Expect(runner.MatchMilestones([][]string{
+						{"btrfs", "property", "set"},
+						{"btrfs", "subvolume", "list"},
+						{"btrfs", "subvolume", "set-default", "260"},
+					})).To(Succeed())
+				})
+
+				It("fails to set the snapshot as read-only", func() {
+					propCmd := "btrfs property set"
+					errMsg := "failed setting read only property"
+					sEffects = append(sEffects, &sideEffect{cmd: propCmd, errorMsg: errMsg})
+
+					err = backend.CommitSnapshot(rootDir, snap)
+					Expect(err).NotTo(Succeed())
+					Expect(runner.MatchMilestones([][]string{
+						{"btrfs", "property", "set"},
+					})).To(Succeed())
+					Expect(runner.MatchMilestones([][]string{
+						{"btrfs", "subvolume", "list"},
+					})).NotTo(Succeed())
+				})
+
+				It("fails to fine the volume ID of the snapshot", func() {
+					propCmd := "btrfs property set"
+					errMsg := "failed setting read only property"
+					sEffects = append(sEffects, &sideEffect{cmd: propCmd, errorMsg: errMsg})
+
+					err = backend.CommitSnapshot(rootDir, snap)
+					Expect(err).NotTo(Succeed())
+					Expect(runner.MatchMilestones([][]string{
+						{"btrfs", "property", "set"},
+					})).To(Succeed())
+					Expect(runner.MatchMilestones([][]string{
+						{"btrfs", "subvolume", "list"},
+					})).NotTo(Succeed())
+				})
+
+				It("fails to set new snapshot as default", func() {
+					// Include the new snapshot int he subvolumes list
+					volSideEffect.cmdOut += "ID 260 gen 13454 top level 259 path @/.snapshots/2/snapshot\n"
+
+					setDefCmd := "btrfs subvolume set-default 260"
+					errMsg := "subvolume set-default failed"
+					sEffects = append(sEffects, &sideEffect{cmd: setDefCmd, errorMsg: errMsg})
+
+					err = backend.CommitSnapshot(rootDir, snap)
+					Expect(err).NotTo(Succeed())
+					Expect(runner.MatchMilestones([][]string{
+						{"btrfs", "property", "set"},
+						{"btrfs", "subvolume", "list"},
+						{"btrfs", "subvolume", "set-default", "260"},
+					})).To(Succeed())
+				})
+
+				It("lists expected snapshots", func() {
+					lst, err := backend.ListSnapshots(rootDir)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(lst.ActiveID).To(Equal(1))
+					Expect(len(lst.IDs)).To(Equal(1))
+					Expect(lst.IDs[0]).To(Equal(1))
+					Expect(runner.MatchMilestones([][]string{
+						strings.Fields(listCmd),
+						strings.Fields(getDefCmd),
+					})).To(Succeed())
+				})
+			})
+
+			It("fails to determine a new ID while creating a new snapshot", func() {
+				errMsg := "failed listing subvolumes"
+				listCmd := "btrfs subvolume list"
+
+				// It does not detect any subvolume
+				sEffects = []*sideEffect{}
+				_, err := backend.CreateNewSnapshot(rootDir, 1)
+				Expect(err).To(HaveOccurred())
+				Expect(runner.MatchMilestones([][]string{
+					strings.Fields(listCmd),
+				})).To(Succeed())
+
+				// Fails to list subvolumes
+				runner.ClearCmds()
+				sEffects = []*sideEffect{{cmd: listCmd, errorMsg: errMsg}}
+				_, err = backend.CreateNewSnapshot(rootDir, 1)
+				Expect(err).To(HaveOccurred())
+				Expect(runner.MatchMilestones([][]string{
+					strings.Fields(listCmd),
+				})).To(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "subvolume", "get-default"},
+				})).NotTo(Succeed())
+			})
+
+			It("fails to create a new snapshot", func() {
+				errMsg := "failed create snapshot"
+				cSnapCmd := "btrfs subvolume snapshot"
+				sEffects = append(sEffects, &sideEffect{cmd: cSnapCmd, errorMsg: errMsg})
+				_, err := backend.CreateNewSnapshot(rootDir, 1)
+				Expect(err).To(HaveOccurred())
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "subvolume", "list"},
+					{"btrfs", "subvolume", "get-default"},
+					strings.Fields(cSnapCmd),
+				})).To(Succeed())
+			})
+		})
+
+		It("fails to detect active snapshot", func() {
+			errMsg := "failed get-default"
+			sEffects = append(sEffects, &sideEffect{cmd: getDefCmd, errorMsg: errMsg})
+
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			_, err := backend.Probe(statePart.Path, statePart.MountPoint)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(errMsg))
+		})
+	})
+
+	Describe("initiated environment while being in active or passive", func() {
+		var defaultVol, volumesList, listCmd, getDefCmd, fMntCmd string
+		var listSideEffect *sideEffect
+		BeforeEach(func() {
+			defaultVol = "ID 261 gen 13455 top level 260 path @/.snapshots/3/snapshot\n"
+			volumesList = "ID 257 gen 13451 top level 3 path @\n"
+			volumesList += "ID 258 gen 13452 top level 257 path @/.snapshots\n"
+			volumesList += "ID 259 gen 13453 top level 258 path @/.snapshots/1/snapshot\n"
+			volumesList += "ID 260 gen 13454 top level 259 path @/.snapshots/2/snapshot\n"
+			volumesList += defaultVol
+
+			listCmd = "btrfs subvolume list"
+			getDefCmd = "btrfs subvolume get-default"
+			fMntCmd = "findmnt"
+
+			listSideEffect = &sideEffect{cmd: listCmd, cmdOut: volumesList}
+
+			sEffects = append(sEffects, listSideEffect)
+			sEffects = append(sEffects, &sideEffect{cmd: getDefCmd, cmdOut: defaultVol})
+
+			// Set active mode
+			Expect(utils.MkdirAll(fs, constants.RunElementalDir, constants.DirPerm)).To(Succeed())
+			Expect(fs.WriteFile(constants.ActiveMode, []byte("1"), constants.FilePerm)).To(Succeed())
+		})
+
+		Describe("initated backend", func() {
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			BeforeEach(func() {
+				mntLines := "/dev/sda[/@/.snapshots/2/snapshot] /some/root\n"
+				mntLines += "/dev/sda[/@] /some/root/run/initramfs/elemental-state\n"
+
+				sEffects = append(sEffects, &sideEffect{cmd: fMntCmd, cmdOut: mntLines})
+				By("probes an initiatied environment, in active mode", func() {
+					backend = snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 2)
+					stat, err := backend.Probe(statePart.Path, statePart.MountPoint)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(stat.ActiveID).To(Equal(3))
+					Expect(stat.CurrentID).To(Equal(2))
+					Expect(stat.RootDir).To(Equal("/some/root"))
+					Expect(stat.StateMount).To(Equal("/some/root/run/initramfs/elemental-state"))
+					Expect(runner.MatchMilestones([][]string{
+						strings.Fields(listCmd),
+						strings.Fields(getDefCmd),
+						strings.Fields(fMntCmd),
+					})).To(Succeed())
+					runner.ClearCmds()
+				})
+			})
+
+			It("deletes the given snapshot", func() {
+				Expect(backend.DeleteSnapshot(rootDir, 1)).To(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "subvolume", "delete"},
+				})).To(Succeed())
+			})
+
+			It("fails to delete the current snapshot", func() {
+				Expect(backend.DeleteSnapshot(rootDir, 2)).NotTo(Succeed())
+			})
+
+			It("fails to delete the given snapshot", func() {
+				deleteCmd := "btrfs subvolume delete"
+				sEffects = append(sEffects, &sideEffect{cmd: deleteCmd, errorMsg: "failed deleting snapshot"})
+				Expect(backend.DeleteSnapshot(rootDir, 1)).NotTo(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					strings.Fields(deleteCmd),
+				})).To(Succeed())
+			})
+
+			It("fails to delete snapshot 0", func() {
+				Expect(backend.DeleteSnapshot(rootDir, 0)).NotTo(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "subvolume", "delete"},
+				})).NotTo(Succeed())
+			})
+
+			It("fails to delete snapshot folder", func() {
+				cfg.Fs = vfs.NewReadOnlyFS(fs)
+				Expect(backend.DeleteSnapshot(rootDir, 1)).NotTo(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "subvolume", "delete"},
+				})).To(Succeed())
+			})
+
+			It("cleans up the expected snapshot", func() {
+				Expect(backend.SnapshotsCleanup(rootDir)).To(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "subvolume", "delete", "/some/root/.snapshots/1/snapshot"},
+				})).To(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "subvolume", "delete", "/some/root/.snapshots/2/snapshot"},
+				})).NotTo(Succeed())
+				Expect(memLog.Bytes()).NotTo(ContainSubstring("current snapshot '2' can't be cleaned up"))
+			})
+
+			It("cleans up the expected snapshot, stops on current snapshot", func() {
+				listSideEffect.cmdOut += "ID 262 gen 13456 top level 261 path @/.snapshots/4/snapshot\n"
+				Expect(backend.SnapshotsCleanup(rootDir)).To(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "subvolume", "delete", "/some/root/.snapshots/1/snapshot"},
+				})).To(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "subvolume", "delete", "/some/root/.snapshots/2/snapshot"},
+				})).NotTo(Succeed())
+				Expect(memLog.String()).To(ContainSubstring("current snapshot '2' can't be cleaned up"))
+			})
+
+			//TODO missing a test to check it stops on current
+
+			It("fails to clean up the expected snapshot, can´t delete the snapshot", func() {
+				deleteCmd := "btrfs subvolume delete"
+				sEffects = append(sEffects, &sideEffect{cmd: deleteCmd, errorMsg: "failed deleting snapshot"})
+				Expect(backend.SnapshotsCleanup(rootDir)).NotTo(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "subvolume", "delete", "/some/root/.snapshots/1/snapshot"},
+				})).To(Succeed())
+			})
+
+			It("fails to clean up the expected snapshot, can't list subvolumes", func() {
+				listCmd := "btrfs subvolume list"
+				sEffects = []*sideEffect{{cmd: listCmd, errorMsg: "failed deleting snapshot"}}
+				Expect(backend.SnapshotsCleanup(rootDir)).NotTo(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					strings.Fields(listCmd),
+				})).To(Succeed())
+			})
+		})
+
+		It("fails to find active or passive mounts", func() {
+			errMsg := "findmnt failed"
+			sEffects = append(sEffects, &sideEffect{cmd: fMntCmd, errorMsg: errMsg})
+
+			// Set active mode
+			Expect(utils.MkdirAll(fs, constants.RunElementalDir, constants.DirPerm)).To(Succeed())
+			Expect(fs.WriteFile(constants.ActiveMode, []byte("1"), constants.FilePerm)).To(Succeed())
+
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			_, err := backend.Probe(statePart.Path, statePart.MountPoint)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(errMsg))
+		})
+	})
+})

--- a/pkg/snapshotter/btrfs.go
+++ b/pkg/snapshotter/btrfs.go
@@ -39,9 +39,6 @@ const (
 	snapshotPathRegex = `.snapshots/(\d+)/snapshot`
 	snapshotInfoPath  = ".snapshots/%d/info.xml"
 	snapshotWorkDir   = "snapshot.workDir"
-	dateFormat        = "2006-01-02 15:04:05"
-	snapperRootConfig = "/etc/snapper/configs/root"
-	snapperSysconfig  = "/etc/sysconfig/snapper"
 	installProgress   = "install-in-progress"
 	updateProgress    = "update-in-progress"
 )
@@ -111,12 +108,18 @@ func newBtrfsSnapshotter(cfg types.Config, snapCfg types.SnapshotterConfig, boot
 			return nil, fmt.Errorf("%s", msg)
 		}
 	}
+	var backend subvolumeBackend
+	if btrfsCfg.Snapper {
+		backend = newSnapperBackend(&cfg, snapCfg.MaxSnaps)
+	} else {
+		backend = newBtrfsBackend(&cfg, snapCfg.MaxSnaps)
+	}
 	return &Btrfs{
 		cfg: cfg, snapshotterCfg: snapCfg,
 		btrfsCfg: *btrfsCfg, bootloader: bootloader,
 		snapshotsUmount: func() error { return nil },
 		snapshotsMount:  func() error { return nil },
-		backend:         newSnapperBackend(&cfg, snapCfg.MaxSnaps),
+		backend:         backend,
 	}, nil
 }
 

--- a/pkg/snapshotter/btrfs_test.go
+++ b/pkg/snapshotter/btrfs_test.go
@@ -308,15 +308,15 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 						{"snapper", "--no-dbus", "--root", "/some/root/.snapshots/1/snapshot", "create"},
 					})).To(Succeed())
 
-					defaultTmpl := filepath.Join(snap.WorkDir, "/etc/snapper/config-templates/default")
+					defaultTmpl := filepath.Join(snap.Path, "/etc/snapper/config-templates/default")
 					Expect(utils.MkdirAll(fs, filepath.Dir(defaultTmpl), constants.DirPerm)).To(Succeed())
 					Expect(fs.WriteFile(defaultTmpl, []byte{}, constants.FilePerm)).To(Succeed())
 
-					snapperSysconfig := filepath.Join(snap.WorkDir, "/etc/sysconfig/snapper")
+					snapperSysconfig := filepath.Join(snap.Path, "/etc/sysconfig/snapper")
 					Expect(utils.MkdirAll(fs, filepath.Dir(snapperSysconfig), constants.DirPerm)).To(Succeed())
 					Expect(fs.WriteFile(snapperSysconfig, []byte{}, constants.FilePerm)).To(Succeed())
 
-					snapperCfg := filepath.Join(snap.WorkDir, "/etc/snapper/configs")
+					snapperCfg := filepath.Join(snap.Path, "/etc/snapper/configs")
 					Expect(utils.MkdirAll(fs, snapperCfg, constants.DirPerm)).To(Succeed())
 				})
 
@@ -502,15 +502,15 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 						{"snapper", "create", "--from"},
 					})).To(Succeed())
 
-					defaultTmpl := filepath.Join(snap.WorkDir, "/etc/snapper/config-templates/default")
+					defaultTmpl := filepath.Join(snap.Path, "/etc/snapper/config-templates/default")
 					Expect(utils.MkdirAll(fs, filepath.Dir(defaultTmpl), constants.DirPerm)).To(Succeed())
 					Expect(fs.WriteFile(defaultTmpl, []byte{}, constants.FilePerm)).To(Succeed())
 
-					snapperSysconfig := filepath.Join(snap.WorkDir, "/etc/sysconfig/snapper")
+					snapperSysconfig := filepath.Join(snap.Path, "/etc/sysconfig/snapper")
 					Expect(utils.MkdirAll(fs, filepath.Dir(snapperSysconfig), constants.DirPerm)).To(Succeed())
 					Expect(fs.WriteFile(snapperSysconfig, []byte{}, constants.FilePerm)).To(Succeed())
 
-					snapperCfg := filepath.Join(snap.WorkDir, "/etc/snapper/configs")
+					snapperCfg := filepath.Join(snap.Path, "/etc/snapper/configs")
 					Expect(utils.MkdirAll(fs, snapperCfg, constants.DirPerm)).To(Succeed())
 				})
 

--- a/pkg/snapshotter/btrfs_test.go
+++ b/pkg/snapshotter/btrfs_test.go
@@ -372,7 +372,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 					})
 
 					It("fails setting snapshot read only", func() {
-						failCmd = "btrfs property set"
+						failCmd = "snapper --no-dbus --root /some/root/.snapshots/1/snapshot modify"
 						err = b.CloseTransaction(snap)
 						Expect(err.Error()).To(ContainSubstring(failCmd))
 						Expect(runner.MatchMilestones([][]string{
@@ -381,7 +381,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 					})
 
 					It("fails setting default", func() {
-						failCmd = "btrfs subvolume set-default"
+						failCmd = "snapper --no-dbus --root /some/root/.snapshots/1/snapshot modify"
 						err = b.CloseTransaction(snap)
 						Expect(err.Error()).To(ContainSubstring(failCmd))
 						Expect(runner.MatchMilestones([][]string{
@@ -562,14 +562,14 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 					})
 
 					It("fails setting snapshot read only", func() {
-						failCmd = "btrfs property set"
+						failCmd = "snapper --no-dbus --root /some/root modify"
 						err = b.CloseTransaction(snap)
 						Expect(err.Error()).To(ContainSubstring(failCmd))
 						Expect(runner.MatchMilestones([][]string{{"snapper", "--no-dbus", "--root", "/some/root", "delete"}})).To(Succeed())
 					})
 
 					It("fails setting default", func() {
-						failCmd = "btrfs subvolume set-default"
+						failCmd = "snapper --no-dbus --root /some/root modify"
 						err = b.CloseTransaction(snap)
 						Expect(err.Error()).To(ContainSubstring(failCmd))
 						Expect(runner.MatchMilestones([][]string{{"snapper", "--no-dbus", "--root", "/some/root", "delete"}})).To(Succeed())

--- a/pkg/snapshotter/btrfs_test.go
+++ b/pkg/snapshotter/btrfs_test.go
@@ -469,8 +469,8 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 					case strings.HasPrefix(fullCmd, "btrfs subvolume get-default"):
 						return []byte(defaultVol), nil
 					case cmd == "findmnt":
-						mntLines := "/dev/sda[/@/.snapshots/1/snapshot] /some/root\n"
-						mntLines += "/dev/sda[/@] /some/root/run/initramfs/elemental-state\n"
+						mntLines := "/dev/sda[/@/.snapshots/1/snapshot] /\n"
+						mntLines += "/dev/sda[/@] /run/initramfs/elemental-state\n"
 						return []byte(mntLines), nil
 					default:
 						return []byte{}, nil
@@ -489,7 +489,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 				BeforeEach(func() {
 					runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
 						fullCmd := strings.Join(append([]string{cmd}, args...), " ")
-						if strings.HasPrefix(fullCmd, "snapper --no-dbus --root /some/root create --from") {
+						if strings.HasPrefix(fullCmd, "snapper create --from") {
 							return []byte("2\n"), nil
 						}
 						return []byte{}, nil
@@ -499,7 +499,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(snap.InProgress).To(BeTrue())
 					Expect(runner.MatchMilestones([][]string{
-						{"snapper", "--no-dbus", "--root", "/some/root", "create", "--from"},
+						{"snapper", "create", "--from"},
 					})).To(Succeed())
 
 					defaultTmpl := filepath.Join(snap.WorkDir, "/etc/snapper/config-templates/default")
@@ -517,7 +517,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 				It("successfully closes a transaction on an active system", func() {
 					runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
 						fullCmd := strings.Join(append([]string{cmd}, args...), " ")
-						if strings.HasPrefix(fullCmd, "snapper --no-dbus --root /some/root --csvout list") {
+						if strings.HasPrefix(fullCmd, "snapper --csvout list") {
 							return []byte("1,no,yes\n2,yes,no\n"), nil
 						} else if strings.HasPrefix(fullCmd, "btrfs subvolume list") {
 							return []byte("ID 260 gen 13453 top level 259 path @/.snapshots/2/snapshot\n"), nil
@@ -527,7 +527,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 
 					Expect(b.CloseTransaction(snap)).NotTo(HaveOccurred())
 					Expect(runner.MatchMilestones([][]string{
-						{"snapper", "--no-dbus", "--root", "/some/root", "cleanup"},
+						{"snapper", "cleanup"},
 					})).To(Succeed())
 				})
 
@@ -538,7 +538,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 							fullCmd := strings.Join(append([]string{cmd}, args...), " ")
 							if strings.HasPrefix(fullCmd, failCmd) {
 								return []byte{}, fmt.Errorf("command '%s' failed", failCmd)
-							} else if strings.HasPrefix(fullCmd, "snapper --no-dbus --root /some/root --csvout list") {
+							} else if strings.HasPrefix(fullCmd, "snapper --csvout list") {
 								return []byte("1,no,yes\n2,yes,no\n"), nil
 							} else if strings.HasPrefix(fullCmd, "btrfs subvolume list") {
 								return []byte("ID 260 gen 13453 top level 259 path @/.snapshots/2/snapshot\n"), nil
@@ -551,28 +551,28 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 						failCmd = "rsync"
 						err = b.CloseTransaction(snap)
 						Expect(err.Error()).To(ContainSubstring(failCmd))
-						Expect(runner.MatchMilestones([][]string{{"snapper", "--no-dbus", "--root", "/some/root", "delete"}})).To(Succeed())
+						Expect(runner.MatchMilestones([][]string{{"snapper", "delete"}})).To(Succeed())
 					})
 
 					It("fails on snapper modify", func() {
-						failCmd = "snapper --no-dbus --root /some/root modify"
+						failCmd = "snapper modify"
 						err = b.CloseTransaction(snap)
 						Expect(err.Error()).To(ContainSubstring(failCmd))
-						Expect(runner.MatchMilestones([][]string{{"snapper", "--no-dbus", "--root", "/some/root", "delete"}})).To(Succeed())
+						Expect(runner.MatchMilestones([][]string{{"snapper", "delete"}})).To(Succeed())
 					})
 
 					It("fails setting snapshot read only", func() {
-						failCmd = "snapper --no-dbus --root /some/root modify"
+						failCmd = "snapper modify"
 						err = b.CloseTransaction(snap)
 						Expect(err.Error()).To(ContainSubstring(failCmd))
-						Expect(runner.MatchMilestones([][]string{{"snapper", "--no-dbus", "--root", "/some/root", "delete"}})).To(Succeed())
+						Expect(runner.MatchMilestones([][]string{{"snapper", "delete"}})).To(Succeed())
 					})
 
 					It("fails setting default", func() {
-						failCmd = "snapper --no-dbus --root /some/root modify"
+						failCmd = "snapper modify"
 						err = b.CloseTransaction(snap)
 						Expect(err.Error()).To(ContainSubstring(failCmd))
-						Expect(runner.MatchMilestones([][]string{{"snapper", "--no-dbus", "--root", "/some/root", "delete"}})).To(Succeed())
+						Expect(runner.MatchMilestones([][]string{{"snapper", "delete"}})).To(Succeed())
 					})
 				})
 			})
@@ -580,7 +580,7 @@ var _ = Describe("Btrfs", Label("snapshotter", " btrfs"), func() {
 			It("fails to start a transaction on an active system", func() {
 				runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
 					fullCmd := strings.Join(append([]string{cmd}, args...), " ")
-					if strings.HasPrefix(fullCmd, "snapper --no-dbus --root /some/root create --from") {
+					if strings.HasPrefix(fullCmd, "snapper create --from") {
 						return []byte{}, fmt.Errorf("failed creating snapshot")
 					}
 					return []byte{}, nil

--- a/pkg/snapshotter/snapper-backend.go
+++ b/pkg/snapshotter/snapper-backend.go
@@ -1,0 +1,186 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshotter
+
+import (
+	"bufio"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
+	"github.com/rancher/elemental-toolkit/v2/pkg/types"
+	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
+)
+
+var _ subvolumeBackend = (*snapperBackend)(nil)
+
+type snapperBackend struct {
+	cfg      *types.Config
+	activeID int
+	device   string
+	btrfs    *btrfsBackend
+}
+
+func newSnapperBackend(cfg *types.Config) *snapperBackend {
+	return &snapperBackend{cfg: cfg, btrfs: newBtrfsBackend(cfg)}
+}
+
+func (s *snapperBackend) InitBackend(device string, activeID int) {
+	s.activeID = activeID
+	s.device = device
+	// Also include init data to the underlaying btrfsBackend for consistentcy
+	s.btrfs.InitBackend(device, activeID)
+}
+
+func (s *snapperBackend) InitBrfsPartition(rootDir string) error {
+	// Snapper does not support initiating a just formated btrfs partition
+	return s.btrfs.InitBrfsPartition(rootDir)
+}
+
+func (s snapperBackend) CreateNewSnapshot(rootDir string, baseID int) (*types.Snapshot, error) {
+	if baseID == 0 {
+		// Snapper does not support creating the very first empty snapshot yet
+		return s.btrfs.CreateNewSnapshot(rootDir, baseID)
+	}
+
+	s.cfg.Logger.Infof("Creating a new snapshot from %d", baseID)
+	args := []string{
+		"create", "--from", strconv.Itoa(baseID),
+		"--read-write", "--print-number", "--description",
+		fmt.Sprintf("Update for snapshot %d", baseID),
+		"-c", "number", "--userdata", fmt.Sprintf("%s=yes", updateProgress),
+	}
+	args = append(s.rootArgs(rootDir), args...)
+	cmdOut, err := s.cfg.Runner.Run("snapper", args...)
+	if err != nil {
+		s.cfg.Logger.Errorf("snapper failed to create a new snapshot: %v", err)
+		return nil, err
+	}
+	newID, err := strconv.Atoi(strings.TrimSpace(string(cmdOut)))
+	if err != nil {
+		s.cfg.Logger.Errorf("failed parsing new snapshot ID")
+		return nil, err
+	}
+
+	workingDir := filepath.Join(rootDir, snapshotsPath, strconv.Itoa(newID), snapshotWorkDir)
+	err = utils.MkdirAll(s.cfg.Fs, workingDir, constants.DirPerm)
+	if err != nil {
+		s.cfg.Logger.Errorf("failed creating the snapshot working directory: %v", err)
+		_ = s.DeleteSnapshot(rootDir, newID)
+		return nil, err
+	}
+	path := filepath.Join(rootDir, fmt.Sprintf(snapshotPathTmpl, newID))
+	return &types.Snapshot{
+		ID:      newID,
+		WorkDir: workingDir,
+		Path:    path,
+	}, nil
+}
+
+func (s snapperBackend) CommitSnapshot(rootDir string, snapshot *types.Snapshot) error {
+	if s.activeID == 0 {
+		// Snapper does not support modifying a snapshot from a host not having a configured snapper
+		// and this is the case for the installation media
+		return s.btrfs.CommitSnapshot(rootDir, snapshot)
+	}
+	args := []string{
+		"modify", "--read-only", "--default", "--userdata",
+		fmt.Sprintf("%s=,%s=", installProgress, updateProgress), strconv.Itoa(snapshot.ID),
+	}
+	args = append(s.rootArgs(rootDir), args...)
+	cmdOut, err := s.cfg.Runner.Run("snapper", args...)
+	if err != nil {
+		s.cfg.Logger.Errorf("failed clearing userdata for snapshot %d: %s", snapshot.ID, string(cmdOut))
+		return err
+	}
+	return nil
+}
+
+func (s snapperBackend) ListSnapshots(rootDir string) (snapshotsList, error) {
+	var sl snapshotsList
+	ids := []int{}
+	re := regexp.MustCompile(`^(\d+),(yes|no),(yes|no)$`)
+
+	args := []string{"--csvout", "list", "--columns", "number,default,active"}
+	args = append(s.rootArgs(rootDir), args...)
+	cmdOut, err := s.cfg.Runner.Run("snapper", args...)
+	if err != nil {
+		// snapper tries to relabel even when listing subvolumes, skip this error.
+		if !strings.HasPrefix(string(cmdOut), "fsetfilecon on") {
+			s.cfg.Logger.Errorf("failed collecting current snapshots: %s", string(cmdOut))
+			return sl, err
+		}
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(strings.TrimSpace(string(cmdOut))))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		match := re.FindStringSubmatch(line)
+		if match != nil {
+			id, _ := strconv.Atoi(match[1])
+			if id == 0 {
+				continue
+			}
+			ids = append(ids, id)
+			if match[2] == "yes" {
+				sl.activeID = id
+			}
+			if match[3] == "yes" {
+				sl.currentID = id
+			}
+		}
+	}
+	sl.IDs = ids
+
+	return sl, nil
+}
+
+func (s snapperBackend) DeleteSnapshot(rootDir string, id int) error {
+	if s.activeID == 0 {
+		// With snapper is not possible to delete any snapshot without an active one
+		return s.btrfs.DeleteSnapshot(rootDir, id)
+	}
+	args := []string{"delete", "--sync", strconv.Itoa(id)}
+	args = append(s.rootArgs(rootDir), args...)
+	cmdOut, err := s.cfg.Runner.Run("snapper", args...)
+	if err != nil {
+		s.cfg.Logger.Errorf("snapper failed deleting snapshot %d: %s", id, string(cmdOut))
+		return err
+	}
+	return nil
+}
+
+func (s snapperBackend) SnapshotsCleanup(rootDir string) error {
+	args := []string{"cleanup", "--path", filepath.Join(rootDir, snapshotsPath), "number"}
+	args = append(s.rootArgs(rootDir), args...)
+	cmdOut, err := s.cfg.Runner.Run("snapper", args...)
+	if err != nil {
+		s.cfg.Logger.Warnf("failed snapshots cleanup request: %s", string(cmdOut))
+	}
+	return err
+}
+
+func (s snapperBackend) rootArgs(rootDir string) []string {
+	args := []string{}
+	if rootDir != "/" {
+		args = []string{"--no-dbus", "--root", filepath.Join(rootDir, fmt.Sprintf(snapshotPathTmpl, s.activeID))}
+	}
+	return args
+}

--- a/pkg/snapshotter/snapper-backend.go
+++ b/pkg/snapshotter/snapper-backend.go
@@ -29,6 +29,11 @@ import (
 	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
 )
 
+const (
+	snapperRootConfig = "/etc/snapper/configs/root"
+	snapperSysconfig  = "/etc/sysconfig/snapper"
+)
+
 var _ subvolumeBackend = (*snapperBackend)(nil)
 
 type snapperBackend struct {

--- a/pkg/snapshotter/snapper-backend_test.go
+++ b/pkg/snapshotter/snapper-backend_test.go
@@ -1,0 +1,423 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package snapshotter_test
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	conf "github.com/rancher/elemental-toolkit/v2/pkg/config"
+	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
+	"github.com/rancher/elemental-toolkit/v2/pkg/mocks"
+	"github.com/rancher/elemental-toolkit/v2/pkg/snapshotter"
+	"github.com/rancher/elemental-toolkit/v2/pkg/types"
+	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
+	"github.com/twpayne/go-vfs/v4"
+	"github.com/twpayne/go-vfs/v4/vfst"
+)
+
+var _ = Describe("snapperBackend", Label("snapshotter", " btrfs"), func() {
+	var cfg *types.Config
+	var runner *mocks.FakeRunner
+	var fs vfs.FS
+	var logger types.Logger
+	var mounter *mocks.FakeMounter
+	var cleanup func()
+
+	var memLog *bytes.Buffer
+	var btrfsCfg types.BtrfsConfig
+	var rootDir string
+	var statePart *types.Partition
+	var syscall *mocks.FakeSyscall
+
+	type sideEffect struct {
+		cmd      string
+		cmdOut   string
+		errorMsg string
+	}
+	var sEffects []*sideEffect
+
+	BeforeEach(func() {
+		sEffects = []*sideEffect{}
+		rootDir = "/some/root"
+		statePart = &types.Partition{
+			Name:       constants.StatePartName,
+			Path:       "/dev/state-device",
+			MountPoint: rootDir,
+		}
+		runner = mocks.NewFakeRunner()
+		mounter = mocks.NewFakeMounter()
+		syscall = &mocks.FakeSyscall{}
+		memLog = bytes.NewBuffer(nil)
+		logger = types.NewBufferLogger(memLog)
+		logger.SetLevel(types.DebugLevel())
+
+		var err error
+		fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{})
+		Expect(err).Should(BeNil())
+
+		cfg = conf.NewConfig(
+			conf.WithFs(fs),
+			conf.WithRunner(runner),
+			conf.WithLogger(logger),
+			conf.WithMounter(mounter),
+			conf.WithSyscall(syscall),
+			conf.WithPlatform("linux/amd64"),
+		)
+		btrfsCfg = types.BtrfsConfig{Snapper: true}
+		Expect(utils.MkdirAll(fs, rootDir, constants.DirPerm)).To(Succeed())
+
+		runner.SideEffect = func(cmd string, args ...string) ([]byte, error) {
+			fullCmd := strings.Join(append([]string{cmd}, args...), " ")
+			for _, effect := range sEffects {
+				if strings.HasPrefix(fullCmd, effect.cmd) {
+					if effect.errorMsg != "" {
+						return []byte(effect.cmdOut), fmt.Errorf(effect.errorMsg)
+					}
+					return []byte(effect.cmdOut), nil
+				}
+			}
+			return []byte{}, nil
+		}
+	})
+
+	AfterEach(func() {
+		cleanup()
+	})
+
+	Describe("in a not initiated environment", func() {
+		// Probe and InitBtrfsPartition methods are just borrowed from the btrfs
+		// backend hence those are not nested here as this would be the same exact
+		// test as in btrfs-backend.go
+
+		Describe("snapshot created", func() {
+			var err error
+			var snap *types.Snapshot
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+
+			BeforeEach(func() {
+				By("creates the very first snapshot", func() {
+					backend = snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+					snap, err = backend.CreateNewSnapshot(rootDir, 0)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(snap.ID).To(Equal(1))
+					Expect(runner.MatchMilestones([][]string{
+						{"btrfs", "subvolume", "create"},
+					})).To(Succeed())
+				})
+			})
+			It("commits the first snapshot", func() {
+				defaultTmpl := filepath.Join(snap.Path, "/etc/snapper/config-templates/default")
+				Expect(utils.MkdirAll(fs, filepath.Dir(defaultTmpl), constants.DirPerm)).To(Succeed())
+				Expect(fs.WriteFile(defaultTmpl, []byte{}, constants.FilePerm)).To(Succeed())
+
+				Expect(utils.MkdirAll(fs, filepath.Join(snap.Path, "/etc/sysconfig"), constants.DirPerm)).To(Succeed())
+
+				snapperCfg := filepath.Join(snap.Path, "/etc/snapper/configs")
+				Expect(utils.MkdirAll(fs, snapperCfg, constants.DirPerm)).To(Succeed())
+
+				cmdOut := "ID 259 gen 13454 top level 258 path @/.snapshots/1/snapshot\n"
+				listCmd := "btrfs subvolume list"
+
+				sEffects = append(sEffects, &sideEffect{cmd: listCmd, cmdOut: cmdOut})
+
+				err = backend.CommitSnapshot(rootDir, snap)
+				fmt.Println(runner.GetCmds())
+				Expect(err).To(Succeed())
+
+				Expect(runner.MatchMilestones([][]string{
+					{"btrfs", "property", "set"},
+					{"btrfs", "subvolume", "list"},
+					{"btrfs", "subvolume", "set-default", "259"},
+				})).To(Succeed())
+			})
+		})
+
+		It("lists no snapshots", func() {
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			lst, err := backend.ListSnapshots(rootDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lst.ActiveID).To(Equal(0))
+			Expect(len(lst.IDs)).To(Equal(0))
+			fmt.Println(runner.GetCmds())
+			Expect(runner.MatchMilestones([][]string{
+				{"snapper", "--no-dbus", "--root", "/some/root", "--csvout", "list"},
+			})).To(Succeed())
+		})
+
+		It("fails to list snapshots, snapper errors out", func() {
+			listCmd := "snapper --no-dbus --root /some/root --csvout list"
+			sEffects = append(sEffects, &sideEffect{cmd: listCmd, errorMsg: "can't read subvolumes"})
+
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			_, err := backend.ListSnapshots(rootDir)
+			Expect(err).To(HaveOccurred())
+			fmt.Println(runner.GetCmds())
+			Expect(runner.MatchMilestones([][]string{
+				strings.Fields(listCmd),
+			})).To(Succeed())
+		})
+	})
+
+	Describe("initiated environment while not being in active nor passive", func() {
+		var defaultVol, volumesList, listCmd, getDefCmd string
+		var volSideEffect *sideEffect
+		BeforeEach(func() {
+			defaultVol = "ID 259 gen 13453 top level 258 path @/.snapshots/1/snapshot\n"
+			volumesList = "ID 257 gen 13451 top level 3 path @\n"
+			volumesList += "ID 258 gen 13452 top level 257 path @/.snapshots\n"
+			volumesList += defaultVol
+
+			listCmd = "btrfs subvolume list"
+			getDefCmd = "btrfs subvolume get-default"
+
+			volSideEffect = &sideEffect{cmd: listCmd, cmdOut: volumesList}
+			sEffects = append(sEffects, volSideEffect)
+		})
+
+		Describe("initated backend", func() {
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			var defVolSideEffect *sideEffect
+			BeforeEach(func() {
+				defVolSideEffect = &sideEffect{cmd: getDefCmd, cmdOut: defaultVol}
+				sEffects = append(sEffects, defVolSideEffect)
+				By("probes an initiatied environment", func() {
+					backend = snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+					stat, err := backend.Probe(statePart.Path, statePart.MountPoint)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(stat.ActiveID).To(Equal(1))
+					Expect(stat.CurrentID).To(Equal(0))
+					Expect(stat.RootDir).To(Equal(statePart.MountPoint))
+					Expect(stat.StateMount).To(Equal(statePart.MountPoint))
+					Expect(runner.MatchMilestones([][]string{
+						strings.Fields(listCmd),
+						strings.Fields(getDefCmd),
+					})).To(Succeed())
+				})
+				// Clear commands history
+				runner.ClearCmds()
+			})
+
+			Describe("snapshot created", func() {
+				var snap *types.Snapshot
+				var err error
+				BeforeEach(func() {
+					createCmd := "snapper --no-dbus --root /some/root/.snapshots/1/snapshot create"
+					sEffects = append(sEffects, &sideEffect{cmd: createCmd, cmdOut: "2\n"})
+					By("creates a new snapshot", func() {
+						snap, err = backend.CreateNewSnapshot(rootDir, 1)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(snap.ID).To(Equal(2))
+						Expect(runner.MatchMilestones([][]string{
+							strings.Fields(createCmd),
+						})).To(Succeed())
+					})
+					runner.ClearCmds()
+					defaultTmpl := filepath.Join(snap.Path, "/etc/snapper/config-templates/default")
+					Expect(utils.MkdirAll(fs, filepath.Dir(defaultTmpl), constants.DirPerm)).To(Succeed())
+					Expect(fs.WriteFile(defaultTmpl, []byte{}, constants.FilePerm)).To(Succeed())
+
+					snapperSysconfig := filepath.Join(snap.Path, "/etc/sysconfig/snapper")
+					Expect(utils.MkdirAll(fs, filepath.Dir(snapperSysconfig), constants.DirPerm)).To(Succeed())
+					Expect(fs.WriteFile(snapperSysconfig, []byte{}, constants.FilePerm)).To(Succeed())
+
+					snapperCfg := filepath.Join(snap.Path, "/etc/snapper/configs")
+					Expect(utils.MkdirAll(fs, snapperCfg, constants.DirPerm)).To(Succeed())
+				})
+
+				It("commits a snapshot", func() {
+					modifyCmd := "snapper --no-dbus --root /some/root/.snapshots/1/snapshot modify"
+
+					err = backend.CommitSnapshot(rootDir, snap)
+					Expect(err).To(Succeed())
+					Expect(runner.MatchMilestones([][]string{
+						strings.Fields(modifyCmd),
+					})).To(Succeed())
+				})
+
+				It("fails to find snapper configuration", func() {
+					Expect(utils.RemoveAll(cfg.Fs, filepath.Join(snap.Path, "/etc/snapper/config-templates/default"))).To(Succeed())
+					err = backend.CommitSnapshot(rootDir, snap)
+					Expect(err).NotTo(Succeed())
+					Expect(len(runner.GetCmds())).To(Equal(0))
+				})
+
+				It("fails to write snapper configuration", func() {
+					cfg.Fs = vfs.NewReadOnlyFS(fs)
+					err = backend.CommitSnapshot(rootDir, snap)
+					Expect(err).NotTo(Succeed())
+					Expect(len(runner.GetCmds())).To(Equal(0))
+				})
+
+				It("fails to set the snapshot as read-only", func() {
+					modifyCmd := "snapper --no-dbus --root /some/root/.snapshots/1/snapshot modify"
+					errMsg := "failed setting read only property"
+					sEffects = append(sEffects, &sideEffect{cmd: modifyCmd, errorMsg: errMsg})
+
+					err = backend.CommitSnapshot(rootDir, snap)
+					Expect(err).NotTo(Succeed())
+					Expect(runner.MatchMilestones([][]string{
+						strings.Fields(modifyCmd),
+					})).To(Succeed())
+				})
+
+				It("lists expected snapshots", func() {
+					listCmd := "snapper --no-dbus --root /some/root/.snapshots/1/snapshot --csvout list"
+					cmdOut := "0,no,no\n1,yes,yes\n"
+					sEffects = append(sEffects, &sideEffect{cmd: listCmd, cmdOut: cmdOut})
+
+					lst, err := backend.ListSnapshots(rootDir)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(lst.ActiveID).To(Equal(1))
+					Expect(len(lst.IDs)).To(Equal(1))
+					Expect(lst.IDs[0]).To(Equal(1))
+					Expect(runner.MatchMilestones([][]string{
+						strings.Fields(listCmd),
+					})).To(Succeed())
+				})
+			})
+
+			It("fails to determine a new ID while creating a new snapshot", func() {
+				createCmd := "snapper --no-dbus --root /some/root/.snapshots/1/snapshot create"
+				sEffects = append(sEffects, &sideEffect{cmd: createCmd, cmdOut: "wrong ID\n"})
+
+				_, err := backend.CreateNewSnapshot(rootDir, 1)
+				Expect(err).To(HaveOccurred())
+				Expect(runner.MatchMilestones([][]string{
+					strings.Fields(createCmd),
+				})).To(Succeed())
+			})
+
+			It("fails to create a new snapshot", func() {
+				createCmd := "snapper --no-dbus --root /some/root/.snapshots/1/snapshot create"
+				sEffects = append(sEffects, &sideEffect{cmd: createCmd, errorMsg: "some thing failed"})
+
+				_, err := backend.CreateNewSnapshot(rootDir, 1)
+				Expect(err).To(HaveOccurred())
+				Expect(runner.MatchMilestones([][]string{
+					strings.Fields(createCmd),
+				})).To(Succeed())
+			})
+
+			It("fails to create the working area folder", func() {
+				cfg.Fs = vfs.NewReadOnlyFS(fs)
+				createCmd := "snapper --no-dbus --root /some/root/.snapshots/1/snapshot create"
+				sEffects = append(sEffects, &sideEffect{cmd: createCmd, cmdOut: "2\n"})
+
+				// Snapshot was already created when the error raises, hence it attempts to delete it
+				_, err := backend.CreateNewSnapshot(rootDir, 1)
+				Expect(err).To(HaveOccurred())
+				Expect(runner.MatchMilestones([][]string{
+					strings.Fields(createCmd),
+					{"snapper", "--no-dbus", "--root", "/some/root/.snapshots/1/snapshot", "delete", "--sync", "2"},
+				})).To(Succeed())
+				fmt.Println(runner.GetCmds())
+			})
+		})
+	})
+
+	Describe("initiated environment while being in active or passive", func() {
+		var defaultVol, volumesList, listCmd, getDefCmd, fMntCmd string
+		var listSideEffect *sideEffect
+		BeforeEach(func() {
+			defaultVol = "ID 261 gen 13455 top level 260 path @/.snapshots/3/snapshot\n"
+			volumesList = "ID 257 gen 13451 top level 3 path @\n"
+			volumesList += "ID 258 gen 13452 top level 257 path @/.snapshots\n"
+			volumesList += "ID 259 gen 13453 top level 258 path @/.snapshots/1/snapshot\n"
+			volumesList += "ID 260 gen 13454 top level 259 path @/.snapshots/2/snapshot\n"
+			volumesList += defaultVol
+
+			listCmd = "btrfs subvolume list"
+			getDefCmd = "btrfs subvolume get-default"
+			fMntCmd = "findmnt"
+
+			listSideEffect = &sideEffect{cmd: listCmd, cmdOut: volumesList}
+
+			sEffects = append(sEffects, listSideEffect)
+			sEffects = append(sEffects, &sideEffect{cmd: getDefCmd, cmdOut: defaultVol})
+
+			// Set active mode
+			Expect(utils.MkdirAll(fs, constants.RunElementalDir, constants.DirPerm)).To(Succeed())
+			Expect(fs.WriteFile(constants.ActiveMode, []byte("1"), constants.FilePerm)).To(Succeed())
+		})
+
+		Describe("initated backend", func() {
+			backend := snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 4)
+			BeforeEach(func() {
+				mntLines := "/dev/sda[/@/.snapshots/2/snapshot] /some/root\n"
+				mntLines += "/dev/sda[/@] /some/root/run/initramfs/elemental-state\n"
+
+				sEffects = append(sEffects, &sideEffect{cmd: fMntCmd, cmdOut: mntLines})
+				By("probes an initiatied environment, in active mode", func() {
+					backend = snapshotter.NewSubvolumeBackend(cfg, btrfsCfg, 2)
+					stat, err := backend.Probe(statePart.Path, statePart.MountPoint)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(stat.ActiveID).To(Equal(3))
+					Expect(stat.CurrentID).To(Equal(2))
+					Expect(stat.RootDir).To(Equal("/some/root"))
+					Expect(stat.StateMount).To(Equal("/some/root/run/initramfs/elemental-state"))
+					Expect(runner.MatchMilestones([][]string{
+						strings.Fields(listCmd),
+						strings.Fields(getDefCmd),
+						strings.Fields(fMntCmd),
+					})).To(Succeed())
+					runner.ClearCmds()
+				})
+			})
+
+			It("deletes the given snapshot", func() {
+				Expect(backend.DeleteSnapshot(rootDir, 1)).To(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					{"snapper", "--no-dbus", "--root", "/some/root delete"},
+				})).To(Succeed())
+			})
+
+			It("fails to delete the current snapshot", func() {
+				deleteCmd := "snapper --no-dbus --root /some/root delete"
+				sEffects = append(sEffects, &sideEffect{cmd: deleteCmd, errorMsg: "delete failed"})
+				Expect(backend.DeleteSnapshot(rootDir, 1)).NotTo(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					strings.Fields(deleteCmd),
+				})).To(Succeed())
+			})
+
+			It("cleans up snapshots", func() {
+				cleanupCmd := "snapper --no-dbus --root /some/root cleanup --path /some/root/.snapshots number"
+				Expect(backend.SnapshotsCleanup(rootDir)).To(Succeed())
+				fmt.Println(runner.GetCmds())
+				Expect(runner.MatchMilestones([][]string{
+					strings.Fields(cleanupCmd),
+				})).To(Succeed())
+			})
+
+			It("fails to clean up snapshots", func() {
+				cleanupCmd := "snapper --no-dbus --root /some/root cleanup --path /some/root/.snapshots number"
+
+				sEffects = append(sEffects, &sideEffect{cmd: cleanupCmd, errorMsg: "failed cleaning up"})
+
+				Expect(backend.SnapshotsCleanup(rootDir)).NotTo(Succeed())
+				Expect(runner.MatchMilestones([][]string{
+					strings.Fields(cleanupCmd),
+				})).To(Succeed())
+			})
+		})
+	})
+})

--- a/pkg/types/snapshotter.go
+++ b/pkg/types/snapshotter.go
@@ -55,7 +55,9 @@ type LoopDeviceConfig struct {
 	FS   string `yaml:"fs,omitempty" mapstructure:"fs"`
 }
 
-type BtrfsConfig struct{}
+type BtrfsConfig struct {
+	Snapper bool `yaml:"snapper,omitempty" mapstructure:"snapper"`
+}
 
 func NewLoopDeviceConfig() *LoopDeviceConfig {
 	return &LoopDeviceConfig{
@@ -65,7 +67,9 @@ func NewLoopDeviceConfig() *LoopDeviceConfig {
 }
 
 func NewBtrfsConfig() *BtrfsConfig {
-	return &BtrfsConfig{}
+	return &BtrfsConfig{
+		Snapper: true, // By default use snapper
+	}
 }
 
 func NewLoopDevice() SnapshotterConfig {


### PR DESCRIPTION
This pull requests provides a new `subvolumebackend` interface to handle btrfs subvolumes and snapshots. The motivation is to not make snapper strict requirement of the btrfs snapshotter to better suite distributions where snapper is not that much adopted.

In any case (even if snapper is not in use) the snapshotter is based and built around common snapper conventions, this is easier from a maintenance perspective and allows to eventually consider switching to snapper at a later point in time.

This PR adds a new config parameter `snapper` for the btrfs snapshotter:
```yaml
snapshotter:
  type: btrfs
  max-snaps: 4
  config:
    snapper: true
```

If snapper set to `true` (this is the default value) the snapshotter will attempt to use snapper, otherwise it will relay entirely on `btrfs` utility calls.

Snapper can't perform alone all the uses cases that the Elemental Snapshotter interface requires (specially corner cases related to first snapshot), for those cases the `snapperBackend` implementation makes use of the `btrfsBacked` implementation, hopefully this can be improved in up comming snapper releases (openSUSE/snapper#944).

This PR includes a couple minor behavior changes (on the snapperBackend) that are actually reflected in unit tests:
* The snapper configuration is applied directly over the snapshot (before it was applied over the working directory)
* Snapper is used to define the read only and default snapshot for all snapshots except for the first one