### PR TITLE
Fix dracut modules dependencies

### DIFF
--- a/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/module-setup.sh
+++ b/pkg/features/embedded/elemental-rootfs/usr/lib/dracut/modules.d/30elemental-rootfs/module-setup.sh
@@ -24,7 +24,7 @@ install() {
     declare systemdsystemunitdir=${systemdsystemunitdir}
 
     inst_multiple \
-        mount cut basename lsblk elemental
+        mount cut basename elemental rsync findmnt
 
     inst_simple "/etc/elemental/config.yaml"
 

--- a/pkg/features/embedded/elemental-sysroot/usr/lib/dracut/modules.d/20elemental-sysroot/module-setup.sh
+++ b/pkg/features/embedded/elemental-sysroot/usr/lib/dracut/modules.d/20elemental-sysroot/module-setup.sh
@@ -18,8 +18,8 @@ install() {
     declare systemdutildir=${systemdutildir}
     declare systemdsystemunitdir=${systemdsystemunitdir}
 
-    inst_multiple -o \
-        "$systemdutildir"/systemd-fsck ln mkdir mount umount systemd-escape e2fsck
+    inst_multiple \
+        "$systemdutildir"/systemd-fsck ln mkdir mount umount systemd-escape e2fsck lsblk basename
 
     inst_hook cmdline 30 "${moddir}/elemental-cmdline.sh"
 


### PR DESCRIPTION
This fixes a regression introduced in eb77a4ca928a48521610498e4f5826c961a19b53 leading to a missing `rsync` in initrd