### PR TITLE
Require grub2 instead of grub2-common

### DIFF
--- a/.obs/specfile/elemental-toolkit/elemental-toolkit.spec
+++ b/.obs/specfile/elemental-toolkit/elemental-toolkit.spec
@@ -43,7 +43,7 @@ Requires:       mtools
 Requires:       util-linux
 Requires:       gptfdisk
 Requires:       dracut
-Requires:       grub2-common
+Requires:       grub2
 Requires:       squashfs
 Requires:       util-linux-systemd
 


### PR DESCRIPTION
The distinction of grub2 vs grub2-common is not present in all SUSE streams, so let's require grub2 which is the generic package requiring other grub2 parts.