### PR TITLE
Make tar creation deterministic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS elemental-bin
 ENV CGO_ENABLED=0
 WORKDIR /src/
 
+# install GNU tar instead of busybox one to support --sort
+RUN apk add --no-cache tar
+
 # Add specific dirs to the image so cache is not invalidated when modifying non go files
 ADD go.mod .
 ADD go.sum .

--- a/pkg/features/generate-tarballs.go
+++ b/pkg/features/generate-tarballs.go
@@ -62,7 +62,7 @@ func main() {
 
 		fmt.Printf("Generate %s from %s\n", output, input)
 
-		cmd := exec.Command("tar", "-C", inputDir, "-czvf", output, input)
+		cmd := exec.Command("tar", "--sort=name", "--mtime=@1", "--owner=0", "--group=0", "--numeric-owner", "--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime", "-C", inputDir, "-czvf", output, input)
 
 		out, err := cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
for this, we sort entries, override owner+group+mtime and omit ctime+atime

based on https://reproducible-builds.org/docs/archives/#full-example