### PR TITLE
Bump go to v1.23.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_OS_IMAGE=registry.opensuse.org/opensuse/tumbleweed
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.23
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS elemental-bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/rancher/elemental-toolkit/v2
 
-go 1.22.0
-
-toolchain go1.22.4
+go 1.23.4
 
 require (
 	github.com/bramvdbogaerde/go-scp v1.5.0


### PR DESCRIPTION
Needed for latest version of k8s.io/mount-utils: https://github.com/rancher/elemental-toolkit/actions/runs/12667300751/job/35300394149?pr=2245