### PR TITLE
golangci-lint: use new formats config property

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,9 @@ run:
   timeout: 5m
   tests: false
 output:
-  format: github-actions
+  formats:
+    - format: github-actions
+    - format: colored-line-number
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
output.format was deprecated and does not build on version 1.64 and up.

replace with the new output.formats which take a map of formats to
output [1]

[1] https://golangci-lint.run/usage/configuration/#output-configuration

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
