### PR TITLE
Avoid panic when MaxSnaps is set to 0

### DIFF
--- a/pkg/snapshotter/loopdevice.go
+++ b/pkg/snapshotter/loopdevice.go
@@ -464,7 +464,7 @@ func (l *LoopDevice) cleanOldSnapshots() error {
 	}
 
 	sort.Ints(ids)
-	for len(ids) > l.snapshotterCfg.MaxSnaps-1 {
+	for len(ids) > l.snapshotterCfg.MaxSnaps-1 && len(ids) > 0 {
 		err = l.DeleteSnapshot(ids[0])
 		if err != nil {
 			l.cfg.Logger.Warnf("could not delete snapshot %d", ids[0])

--- a/pkg/snapshotter/loopdevice_test.go
+++ b/pkg/snapshotter/loopdevice_test.go
@@ -22,14 +22,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/twpayne/go-vfs/v4"
+	"github.com/twpayne/go-vfs/v4/vfst"
+
 	conf "github.com/rancher/elemental-toolkit/v2/pkg/config"
 	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
 	"github.com/rancher/elemental-toolkit/v2/pkg/mocks"
 	"github.com/rancher/elemental-toolkit/v2/pkg/snapshotter"
 	"github.com/rancher/elemental-toolkit/v2/pkg/types"
 	"github.com/rancher/elemental-toolkit/v2/pkg/utils"
-	"github.com/twpayne/go-vfs/v4"
-	"github.com/twpayne/go-vfs/v4/vfst"
 )
 
 var _ = Describe("LoopDevice", Label("snapshotter", "loopdevice"), func() {
@@ -190,6 +191,17 @@ var _ = Describe("LoopDevice", Label("snapshotter", "loopdevice"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(lp.GetSnapshots()).Error().To(HaveOccurred())
+	})
+
+	It("closes a transaction with 0 MaxSnaps", func() {
+		snapCfg.MaxSnaps = 0
+		lp, err := snapshotter.NewSnapshotter(cfg, snapCfg, bootloader)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(lp.InitSnapshotter(statePart, efiDir)).To(Succeed())
+
+		snap, err := lp.StartTransaction()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(lp.CloseTransaction(snap)).Error().ToNot(HaveOccurred())
 	})
 
 	Describe("using loopdevice on sixth snapshot", func() {


### PR DESCRIPTION
When the MaxSnaps configuration option is set to 0 the following panic
occurs during installation:

```
[PANICKED] Test Panicked
  In [It] at: /usr/lib64/go/1.24/src/runtime/panic.go:115 @ 07/01/25 10:04:57.47

  runtime error: index out of range [0] with length 0

  Full Stack Trace
    github.com/rancher/elemental-toolkit/v2/pkg/snapshotter.(*LoopDevice).cleanOldSnapshots(0xc00025a300)
        /home/frelon/src/elemental-toolkit/pkg/snapshotter/loopdevice.go:468 +0x3e7
    github.com/rancher/elemental-toolkit/v2/pkg/snapshotter.(*LoopDevice).CloseTransaction(0xc00025a300, 0xc000234a00)
        /home/frelon/src/elemental-toolkit/pkg/snapshotter/loopdevice.go:271 +0x11d5
    github.com/rancher/elemental-toolkit/v2/pkg/snapshotter_test.init.func3.12()
        /home/frelon/src/elemental-toolkit/pkg/snapshotter/loopdevice_test.go:204 +0x38e
```

This commit checks that we don't try to delete old snapshots in case
there are none.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
