### PR TITLE
Minor change to patch upgradeSpec with in-use devices in case they differ from discovered ones

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/mount-utils"
 
 	"github.com/rancher/elemental-toolkit/internal/version"
+
 	"github.com/rancher/elemental-toolkit/pkg/config"
 	"github.com/rancher/elemental-toolkit/pkg/constants"
 	v1 "github.com/rancher/elemental-toolkit/pkg/types/v1"
@@ -295,6 +296,11 @@ func ReadUpgradeSpec(r *v1.RunConfig, flags *pflag.FlagSet) (*v1.UpgradeSpec, er
 		r.Logger.Warnf("error unmarshalling UpgradeSpec: %s", err)
 	}
 	err = upgrade.Sanitize()
+	if err != nil {
+		return nil, fmt.Errorf("failed sanitizing upgrade spec: %v", err)
+	}
+
+	err = config.ReconcileUpgradeSpec(upgrade)
 	r.Logger.Debugf("Loaded upgrade UpgradeSpec: %s", litter.Sdump(upgrade))
 	return upgrade, err
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -592,4 +593,55 @@ func NewBuildConfig(opts ...GenericOptions) *v1.BuildConfig {
 		Name:   constants.BuildImgName,
 	}
 	return b
+}
+
+// ReconcileUpgradeSpec will check current mounts which may differ from elemental disovery from /sys/block tree
+// as this skips multipathed devices which may be in use.
+func ReconcileUpgradeSpec(spec *v1.UpgradeSpec) error {
+	if spec.Partitions.State != nil {
+		if err := reconcilePartition(spec.Partitions.State); err != nil {
+			return err
+		}
+	}
+	if spec.Partitions.Recovery != nil {
+		if err := reconcilePartition(spec.Partitions.Recovery); err != nil {
+			return err
+		}
+	}
+
+	if spec.Partitions.Persistent != nil {
+		if err := reconcilePartition(spec.Partitions.Persistent); err != nil {
+			return err
+		}
+	}
+
+	if spec.Partitions.OEM != nil {
+		if err := reconcilePartition(spec.Partitions.OEM); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func reconcilePartition(part *v1.Partition) error {
+	discoveredMountDiskBytes, err := execBlkid(part.FilesystemLabel)
+	if err != nil {
+		return fmt.Errorf("error discovering current partition using label %s: %w", part.FilesystemLabel, err)
+	}
+
+	// trim space since `blkid` output has a newline in result
+	discoveredMount := strings.TrimSpace(string(discoveredMountDiskBytes))
+	if part.Path != discoveredMount {
+		part.Path = discoveredMount
+	}
+	return nil
+}
+func execBlkid(name string) ([]byte, error) {
+	path, err := exec.LookPath("blkid")
+	if err != nil {
+		return nil, err
+	}
+
+	blkidCmd := exec.Command(path, "-L", name)
+	return blkidCmd.Output()
 }


### PR DESCRIPTION
When multipathing is enabled, the OS boots off the multipath /dev/mapper device

During upgrade elemental uses `jaypipes/ghw` to find block devices from `/sys/block` tree.

This misses the multipath partitions, which can cause issue https://github.com/rancher/elemental-toolkit/issues/2299

The PR introduces a minor change where once the UpgradeSpec is generated from parsing of `/sys/block` tree we lookup the result of `blkid -L $LABEL` to identify partition with label.

This will result in the multipath partition being returned

For example from a sample multipath'd host

```
node-1-dhcp:~ # blkid -L COS_STATE
/dev/mapper/0QEMU_QEMU_HARDDISK_ABCDE-part4

node-1-dhcp:~ # blkid -t LABEL=COS_STATE
/dev/sdb4: LABEL="COS_STATE" UUID="ffacd836-c2bf-4c97-b816-ae54ef9ea56c" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="state" PARTUUID="88fdf8e1-fba0-4b88-b537-49f59c5e881c"
/dev/mapper/0QEMU_QEMU_HARDDISK_ABCDE-part4: LABEL="COS_STATE" UUID="ffacd836-c2bf-4c97-b816-ae54ef9ea56c" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="state" PARTUUID="88fdf8e1-fba0-4b88-b537-49f59c5e881c"
/dev/sda4: LABEL="COS_STATE" UUID="ffacd836-c2bf-4c97-b816-ae54ef9ea56c" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="state" PARTUUID="88fdf8e1-fba0-4b88-b537-49f59c5e881c"
```

If the partition does not match the one generated from parsing `/sys/block` then we update the upgrade spec to use the newly found partition.