### PR TITLE
Minor change to lookup devices using blkid

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -472,7 +472,7 @@ func ReadUpgradeSpec(r *types.RunConfig, flags *pflag.FlagSet, recoveryOnly bool
 		return nil, fmt.Errorf("failed sanitizing upgrade spec: %v", err)
 	}
 
-	err = config.ReconcileUpgradeSpec(upgrade)
+	err = config.ReconcileUpgradeSpec(r, upgrade)
 	r.Logger.Debugf("Loaded upgrade UpgradeSpec: %s", litter.Sdump(upgrade))
 	return upgrade, err
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -468,6 +468,11 @@ func ReadUpgradeSpec(r *types.RunConfig, flags *pflag.FlagSet, recoveryOnly bool
 	} else {
 		err = upgrade.Sanitize()
 	}
+	if err != nil {
+		return nil, fmt.Errorf("failed sanitizing upgrade spec: %v", err)
+	}
+
+	err = config.ReconcileUpgradeSpec(upgrade)
 	r.Logger.Debugf("Loaded upgrade UpgradeSpec: %s", litter.Sdump(upgrade))
 	return upgrade, err
 }

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -67,8 +67,7 @@ var _ = Describe("Config", Label("config"), func() {
 
 				up, err := ReadUpgradeSpec(cfg, nil, false)
 				Expect(err).Should(HaveOccurred(), litter.Sdump(cfg))
-
-				Expect(up.GrubDefEntry).To(Equal("so"))
+				Expect(up).To(BeNil())
 
 				inst, err := ReadInstallSpec(cfg, nil)
 				Expect(err).Should(HaveOccurred(), litter.Sdump(cfg))
@@ -493,7 +492,7 @@ var _ = Describe("Config", Label("config"), func() {
 				ghwTest.CreateDevices()
 				defer ghwTest.Clean()
 
-				err := os.Setenv("ELEMENTAL_UPGRADE_RECOVERY", "true")
+				Expect(os.Setenv("ELEMENTAL_UPGRADE_RECOVERY", "true")).To(Succeed())
 				spec, err := ReadUpgradeSpec(cfg, nil, false)
 				Expect(err).ShouldNot(HaveOccurred())
 				// Overwrites recovery-system image, flags have priority over files and env vars

--- a/examples/green/Dockerfile
+++ b/examples/green/Dockerfile
@@ -74,8 +74,8 @@ RUN systemd-sysusers
 # This is for automatic testing purposes, do not do this in production.
 RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
 
-# SELinux in enforce mode
-#RUN sed -i "s|SELINUX=.*|SELINUX=enforcing|g" /etc/selinux/config
+# SELinux in permissive mode
+RUN sed -i "s|SELINUX=.*|SELINUX=permissive|g" /etc/selinux/config
 
 # Add default snapshotter setup
 ADD snapshotter.yaml /etc/elemental/config.d/snapshotter.yaml

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -584,4 +585,55 @@ func NewBuildConfig(opts ...GenericOptions) *types.BuildConfig {
 		Snapshotter: types.NewLoopDevice(),
 	}
 	return b
+}
+
+// ReconcileUpgradeSpec will check current mounts which may differ from elemental disovery from /sys/block tree
+// as this skips multipathed devices which may be in use.
+func ReconcileUpgradeSpec(spec *v1.UpgradeSpec) error {
+	if spec.Partitions.State != nil {
+		if err := reconcilePartition(spec.Partitions.State); err != nil {
+			return err
+		}
+	}
+	if spec.Partitions.Recovery != nil {
+		if err := reconcilePartition(spec.Partitions.Recovery); err != nil {
+			return err
+		}
+	}
+
+	if spec.Partitions.Persistent != nil {
+		if err := reconcilePartition(spec.Partitions.Persistent); err != nil {
+			return err
+		}
+	}
+
+	if spec.Partitions.OEM != nil {
+		if err := reconcilePartition(spec.Partitions.OEM); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func reconcilePartition(part *v1.Partition) error {
+	discoveredMountDiskBytes, err := execBlkid(part.FilesystemLabel)
+	if err != nil {
+		return fmt.Errorf("error discovering current partition using label %s: %w", part.FilesystemLabel, err)
+	}
+
+	// trim space since `blkid` output has a newline in result
+	discoveredMount := strings.TrimSpace(string(discoveredMountDiskBytes))
+	if part.Path != discoveredMount {
+		part.Path = discoveredMount
+	}
+	return nil
+}
+func execBlkid(name string) ([]byte, error) {
+	path, err := exec.LookPath("blkid")
+	if err != nil {
+		return nil, err
+	}
+
+	blkidCmd := exec.Command(path, "-L", name)
+	return blkidCmd.Output()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -589,34 +588,34 @@ func NewBuildConfig(opts ...GenericOptions) *types.BuildConfig {
 
 // ReconcileUpgradeSpec will check current mounts which may differ from elemental disovery from /sys/block tree
 // as this skips multipathed devices which may be in use.
-func ReconcileUpgradeSpec(spec *v1.UpgradeSpec) error {
+func ReconcileUpgradeSpec(r *types.RunConfig, spec *types.UpgradeSpec) error {
 	if spec.Partitions.State != nil {
-		if err := reconcilePartition(spec.Partitions.State); err != nil {
+		if err := reconcilePartition(r, spec.Partitions.State); err != nil {
 			return err
 		}
 	}
 	if spec.Partitions.Recovery != nil {
-		if err := reconcilePartition(spec.Partitions.Recovery); err != nil {
+		if err := reconcilePartition(r, spec.Partitions.Recovery); err != nil {
 			return err
 		}
 	}
 
 	if spec.Partitions.Persistent != nil {
-		if err := reconcilePartition(spec.Partitions.Persistent); err != nil {
+		if err := reconcilePartition(r, spec.Partitions.Persistent); err != nil {
 			return err
 		}
 	}
 
 	if spec.Partitions.OEM != nil {
-		if err := reconcilePartition(spec.Partitions.OEM); err != nil {
+		if err := reconcilePartition(r, spec.Partitions.OEM); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func reconcilePartition(part *v1.Partition) error {
-	discoveredMountDiskBytes, err := execBlkid(part.FilesystemLabel)
+func reconcilePartition(r *types.RunConfig, part *types.Partition) error {
+	discoveredMountDiskBytes, err := execBlkid(r, part.FilesystemLabel)
 	if err != nil {
 		return fmt.Errorf("error discovering current partition using label %s: %w", part.FilesystemLabel, err)
 	}
@@ -628,12 +627,10 @@ func reconcilePartition(part *v1.Partition) error {
 	}
 	return nil
 }
-func execBlkid(name string) ([]byte, error) {
-	path, err := exec.LookPath("blkid")
-	if err != nil {
-		return nil, err
+func execBlkid(r *types.RunConfig, name string) ([]byte, error) {
+	if ok := r.Config.Runner.CommandExists("blkid"); ok {
+		return r.Config.Runner.Run("blkid", "-L", name)
 	}
 
-	blkidCmd := exec.Command(path, "-L", name)
-	return blkidCmd.Output()
+	return []byte{}, fmt.Errorf("blkid not found")
 }


### PR DESCRIPTION
Minor change to lookup devices using blkid and updating the upgradeSpec
if needed. This may be needed when running elemental upgrade in
multipathd systems

Signed-off-by: Gaurav Mehta <gaurav.mehta@suse.com>
