### PR TITLE
Drop cleanup worker step

### DIFF
--- a/.github/workflows/build_and_test_x86.yaml
+++ b/.github/workflows/build_and_test_x86.yaml
@@ -131,12 +131,6 @@ jobs:
           key: ${{ env.cache-name }}-${{ inputs.version }}
           lookup-only: true
       - if: ${{ steps.cache-disk.outputs.cache-hit != 'true' }}
-        name: Cleanup worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-          sudo df -h
-      - if: ${{ steps.cache-disk.outputs.cache-hit != 'true' }}
         name: Pull images
         uses: ./.github/actions/fetchimages
         with:


### PR DESCRIPTION
Cleanup worker step can take up to 4m and it is not really needed building a disk is not that much heavier in disk than building an OS image or similar.