### PR TITLE
rename cos -> elemental in tests

### DIFF
--- a/tests/wait-active/wait_test.go
+++ b/tests/wait-active/wait_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Elemental booting an expandable disk image", func() {
 	Context("Wait until system is expanded", func() {
 		It("eventually is active", func() {
 			Eventually(func() string {
-				out, _ := s.Command("cat /run/cos/active_mode")
+				out, _ := s.Command("cat /run/elemental/active_mode")
 				return out
 			}, 15*time.Minute, 10*time.Second).Should(ContainSubstring("1"))
 


### PR DESCRIPTION
/run/cos has been renamed to /run/elemental in a previous version.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
