### PR TITLE
[BACKPORT v2.3.x] Add snapshotter.type flag to build-disk command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ DOCKER?=docker
 BASE_OS_IMAGE?=registry.opensuse.org/opensuse/tumbleweed
 DOCKER_SOCK?=/var/run/docker.sock
 
+SNAPSHOTTER_TYPE?=loopdevice
+ifeq ("$(FLAVOR)","green")
+	SNAPSHOTTER_TYPE=btrfs
+endif
+
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 GIT_COMMIT_SHORT?=$(shell git rev-parse --short HEAD)
 GIT_TAG?=$(shell git describe --candidates=50 --abbrev=0 --tags 2>/dev/null || echo "v0.0.1" )
@@ -94,7 +99,8 @@ build-disk:
 	mkdir -p $(ROOT_DIR)/build
 	$(DOCKER) run --rm -v $(DOCKER_SOCK):$(DOCKER_SOCK) -v $(ROOT_DIR)/build:/build -v $(ROOT_DIR)/tests/assets:/assets \
 		--entrypoint /usr/bin/elemental $(TOOLKIT_REPO):$(VERSION) --debug build-disk --platform $(PLATFORM) \
-		--expandable -n elemental-$(FLAVOR).$(ARCH) --local --cloud-init /assets/remote_login.yaml -o /build --system $(REPO):$(VERSION)
+		--expandable -n elemental-$(FLAVOR).$(ARCH) --local --cloud-init /assets/remote_login.yaml -o /build --system $(REPO):$(VERSION) \
+		--snapshotter.type $(SNAPSHOTTER_TYPE)
 	qemu-img convert -O qcow2 $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).raw $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).qcow2
 	qemu-img resize $(ROOT_DIR)/build/elemental-$(FLAVOR).$(ARCH).qcow2 $(DISKSIZE) 
 

--- a/cmd/build-disk.go
+++ b/cmd/build-disk.go
@@ -110,6 +110,7 @@ func NewBuildDisk(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	addLocalImageFlag(c)
 	addSquashFsCompressionFlags(c)
 	addCosignFlags(c)
+	addSnapshotterFlags(c)
 	return c
 }
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/rancher/elemental-toolkit/v2/pkg/constants"
 	"github.com/rancher/elemental-toolkit/v2/pkg/types"
 )
 
@@ -83,6 +84,15 @@ func addSnapshotLabelsFlag(cmd *cobra.Command) {
 // addLocalImageFlag add local image flag shared between install, pull-image, upgrade
 func addLocalImageFlag(cmd *cobra.Command) {
 	cmd.Flags().Bool("local", false, "Use an image from local cache")
+}
+
+func addSnapshotterFlags(cmd *cobra.Command) {
+	snapshotterType := newEnumFlag(
+		[]string{constants.LoopDeviceSnapshotterType, constants.BtrfsSnapshotterType},
+		constants.LoopDeviceSnapshotterType,
+	)
+
+	cmd.Flags().Var(snapshotterType, "snapshotter.type", "Sets the snapshotter type to install")
 }
 
 // addVerifyRegistryFlag add local image flag shared between install, pull-image, upgrade

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -99,10 +99,6 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	}
 	firmType := newEnumFlag([]string{types.EFI}, types.EFI)
 	pTableType := newEnumFlag([]string{types.GPT}, types.GPT)
-	snapshotterType := newEnumFlag(
-		[]string{constants.LoopDeviceSnapshotterType, constants.BtrfsSnapshotterType},
-		constants.LoopDeviceSnapshotterType,
-	)
 
 	root.AddCommand(c)
 	c.Flags().StringSliceP("cloud-init", "c", []string{}, "Cloud-init config files")
@@ -118,11 +114,11 @@ func NewInstallCmd(root *cobra.Command, addCheckRoot bool) *cobra.Command {
 	c.Flags().Bool("force", false, "Force install")
 	c.Flags().Bool("eject-cd", false, "Try to eject the cd on reboot, only valid if booting from iso")
 	c.Flags().Bool("disable-boot-entry", false, "Dont create an EFI entry for the system install.")
-	c.Flags().Var(snapshotterType, "snapshotter.type", "Sets the snapshotter type to install")
 	c.Flags().StringSlice("cloud-init-paths", []string{}, "Cloud-init config files to run during install")
 	addSharedInstallUpgradeFlags(c)
 	addLocalImageFlag(c)
 	addPlatformFlags(c)
+	addSnapshotterFlags(c)
 	return c
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -555,8 +555,14 @@ func NewDisk(cfg *types.BuildConfig) *types.DiskSpec {
 		)+mountSuffix,
 	)
 
+	partitions := NewDiskElementalPartitions(workdir)
+
+	if cfg.Snapshotter.Type == constants.BtrfsSnapshotterType {
+		partitions.State.FS = constants.Btrfs
+	}
+
 	return &types.DiskSpec{
-		Partitions:     NewDiskElementalPartitions(workdir),
+		Partitions:     partitions,
 		GrubConf:       filepath.Join(constants.GrubCfgPath, constants.GrubCfg),
 		System:         types.NewEmptySrc(),
 		RecoverySystem: recoveryImg,


### PR DESCRIPTION
When building a disk image we do not specify the snapshotter, which configures the expansion mechanism to set COS_STATE partition filesystem to ext4.

The green flavor uses the btrfs snapshotter, which means when it boots and tries to mount the COS_STATE partition it expects a btrfs filesystem, but finds an ext4 one, which errors.

In this commit we add the --snapshotter.type flag to the build-disk command and set the snapshotter in the Makefile accordingly.