### PR TITLE
pkg/error: fix 'occured' -> 'occurred' in exit code comments

### DIFF
--- a/pkg/error/exit-codes.go
+++ b/pkg/error/exit-codes.go
@@ -232,25 +232,25 @@ const CopyFileImg = 77
 // Error setting persistent GRUB variables
 const SetGrubVariables = 78
 
-// Error occured on before-disk hook
+// Error occurred on before-disk hook
 const HookBeforeDisk = 79
 
-// Error occured on after-disk hook
+// Error occurred on after-disk hook
 const HookAfterDisk = 80
 
-// Error occured on after-disk-chroot hook
+// Error occurred on after-disk-chroot hook
 const HookAfterDiskChroot = 81
 
-// Error occured on after-disk hook
+// Error occurred on after-disk hook
 const HookPostDisk = 82
 
-// Error occured checking configured size is bigger than minimum required size
+// Error occurred checking configured size is bigger than minimum required size
 const InvalidSize = 83
 
-// Error occured initializing snapshotter
+// Error occurred initializing snapshotter
 const SnapshotterInit = 84
 
-// Error occured starting an snapshotter transaction
+// Error occurred starting an snapshotter transaction
 const SnapshotterStart = 85
 
 // Error mounting EFI partition


### PR DESCRIPTION
Five comments in `pkg/error/exit-codes.go` (lines 235-247) read `Error occured on`. Fixed to `occurred`. Comment-only change.