### PR TITLE
Fix docs

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Install npm dependencies
@@ -42,7 +42,7 @@ jobs:
         run: |
           make BASE_URL=https://rancher.github.io/elemental-toolkit build-docs
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./public
 
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -12,10 +12,13 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       HUGO_VERSION: 0.111.0
+      HUGO_CHECKSUM: 0fffb81022166d5c3a9df2c0d1873ca33ac411a028af9c8e66a89f0146734068
     steps:
       - name: Install Hugo CLI
         run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends hugo
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
+          echo "${HUGO_CHECKSUM} ${{ runner.temp }}/hugo.deb" | sha256sum -c - || exit 1
+          sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Install Dart Sass
         run: sudo snap install dart-sass
       - name: Checkout


### PR DESCRIPTION
This commit fixes a regression on docs publishing caused by commit https://github.com/rancher/elemental-toolkit/commit/732cd6cc9aaac2f4c27bdd6819fe9d4349f13f7b. This commit keeps the hugo version as it was but adds checksum validation to ensure the downloaded binary is not corrupted or tampered.